### PR TITLE
fix mp_error_to_string in tommath.h

### DIFF
--- a/tommath.h
+++ b/tommath.h
@@ -190,7 +190,7 @@ typedef int ltm_prime_callback(unsigned char *dst, int len, void *dat);
 #define SIGN(m)    ((m)->sign)
 
 /* error code to char* string */
-char *mp_error_to_string(int code);
+const char *mp_error_to_string(int code);
 
 /* ---> init and deinit bignum functions <--- */
 /* init a bignum */


### PR DESCRIPTION
Without that patch, compilation on gcc fails with

```
bn_error.c:28: error: conflicting types for ‘mp_error_to_string’
./tommath.h:193: note: previous declaration of ‘mp_error_to_string’ was here
```
