### PR TITLE
mp_import / mp_export à la GMP's mpz_import / mpz_export

### DIFF
--- a/bn_mp_export.c
+++ b/bn_mp_export.c
@@ -1,0 +1,87 @@
+#include <tommath.h>
+#ifdef BN_MP_EXPORT_C
+/* LibTomMath, multiple-precision integer library -- Tom St Denis
+ *
+ * LibTomMath is a library that provides multiple-precision
+ * integer arithmetic as well as number theoretic functionality.
+ *
+ * The library was designed directly after the MPI library by
+ * Michael Fromberger but has been written from scratch with
+ * additional optimizations in place.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+
+/* based on gmp's mpz_export.
+ * see http://gmplib.org/manual/Integer-Import-and-Export.html
+ */
+int mp_export(void* rop, size_t* countp, int order, size_t size, 
+                                int endian, size_t nails, mp_int* op) {
+	int result;
+	size_t odd_nails, nail_bytes, i, j, bits, count;
+	unsigned char odd_nail_mask;
+
+	mp_int t;
+
+	if ((result = mp_init_copy(&t, op)) != MP_OKAY) {
+		return result;
+	}
+
+	if (endian == 0) {
+		union {
+			unsigned int i;
+			char c[4];
+		} lint = {0x01020304};
+
+		endian = (lint.c[0] == 4 ? -1 : 1);
+	}
+
+	odd_nails = (nails % 8);
+	odd_nail_mask = 0xff;
+	for (i = 0; i < odd_nails; ++i) {
+		odd_nail_mask ^= (1 << (7 - i));
+	}
+	nail_bytes = nails / 8;
+
+	bits = mp_count_bits(&t);
+	count = bits / (size * 8 - nails) + (bits % (size * 8 - nails) ? 1 : 0);
+
+	for (i = 0; i < count; ++i) {
+		for (j = 0; j < size; ++j) {
+			unsigned char* byte = (
+				(unsigned char*)rop + 
+				(order == -1 ? i : count - 1 - i) * size + 
+				(endian == -1 ? j : size - 1 - j)
+			);
+
+			if (j >= (size - nail_bytes)) {
+				*byte = 0;
+				continue;
+			}
+
+			*byte = (unsigned char)(j == size - nail_bytes - 1 ? (t.dp[0] & odd_nail_mask) : t.dp[0] & 0xFF);
+
+			if ((result = mp_div_2d(&t, (j == size - nail_bytes - 1 ? 8 - odd_nails : 8), &t, NULL)) != MP_OKAY) {
+				mp_clear(&t);
+				return result;
+			}
+		}
+	}
+
+	mp_clear(&t);
+
+	if (countp) {
+		*countp = count;
+	}
+
+	return MP_OKAY;
+}
+
+#endif
+
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/bn_mp_import.c
+++ b/bn_mp_import.c
@@ -1,0 +1,72 @@
+#include <tommath.h>
+#ifdef BN_MP_IMPORT_C
+/* LibTomMath, multiple-precision integer library -- Tom St Denis
+ *
+ * LibTomMath is a library that provides multiple-precision
+ * integer arithmetic as well as number theoretic functionality.
+ *
+ * The library was designed directly after the MPI library by
+ * Michael Fromberger but has been written from scratch with
+ * additional optimizations in place.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+
+/* based on gmp's mpz_import.
+ * see http://gmplib.org/manual/Integer-Import-and-Export.html
+ */
+int mp_import(mp_int* rop, size_t count, int order, size_t size, 
+                            int endian, size_t nails, const void* op) {
+	int result;
+	size_t odd_nails, nail_bytes, i, j;
+	unsigned char odd_nail_mask;
+
+	mp_zero(rop);
+
+	if (endian == 0) {
+		union {
+			unsigned int i;
+			char c[4];
+		} lint = {0x01020304};
+
+		endian = (lint.c[0] == 4 ? -1 : 1);
+	}
+
+	odd_nails = (nails % 8);
+	odd_nail_mask = 0xff;
+	for (i = 0; i < odd_nails; ++i) {
+		odd_nail_mask ^= (1 << (7 - i));
+	}
+	nail_bytes = nails / 8;
+
+	for (i = 0; i < count; ++i) {
+		for (j = 0; j < size - nail_bytes; ++j) {
+			unsigned char byte = *(
+					(unsigned char*)op + 
+					(order == 1 ? i : count - 1 - i) * size + 
+					(endian == 1 ? j + nail_bytes : size - 1 - j - nail_bytes)
+				);
+
+			if (
+				(result = mp_mul_2d(rop, (j == 0 ? 8 - odd_nails : 8), rop)) != MP_OKAY) {
+				return result;
+			}
+
+			rop->dp[0] |= (j == 0 ? (byte & odd_nail_mask) : byte);
+			rop->used  += 1;
+		}
+	}
+
+	mp_clamp(rop);
+
+	return MP_OKAY;
+}
+
+#endif
+
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/callgraph.txt
+++ b/callgraph.txt
@@ -10,8 +10,8 @@ BN_MP_SQRT_C
 |   |   +--->BN_MP_GROW_C
 |   +--->BN_MP_EXPT_D_C
 |   |   +--->BN_MP_INIT_COPY_C
-|   |   +--->BN_MP_SQR_C
-|   |   |   +--->BN_MP_TOOM_SQR_C
+|   |   +--->BN_MP_MUL_C
+|   |   |   +--->BN_MP_TOOM_MUL_C
 |   |   |   |   +--->BN_MP_INIT_MULTI_C
 |   |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   |   +--->BN_MP_MOD_2D_C
@@ -56,37 +56,33 @@ BN_MP_SQRT_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLEAR_MULTI_C
 |   |   |   |   |   +--->BN_MP_CLEAR_C
-|   |   |   +--->BN_MP_KARATSUBA_SQR_C
+|   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_RSHD_C
 |   |   |   |   |   |   +--->BN_MP_ZERO_C
-|   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLEAR_C
-|   |   |   +--->BN_FAST_S_MP_SQR_C
+|   |   |   +--->BN_FAST_S_MP_MUL_DIGS_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_S_MP_SQR_C
+|   |   |   +--->BN_S_MP_MUL_DIGS_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   +--->BN_MP_CLEAR_C
-|   |   +--->BN_MP_MUL_C
-|   |   |   +--->BN_MP_TOOM_MUL_C
+|   |   +--->BN_MP_SQR_C
+|   |   |   +--->BN_MP_TOOM_SQR_C
 |   |   |   |   +--->BN_MP_INIT_MULTI_C
 |   |   |   |   +--->BN_MP_MOD_2D_C
 |   |   |   |   |   +--->BN_MP_ZERO_C
@@ -128,29 +124,23 @@ BN_MP_SQRT_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLEAR_MULTI_C
-|   |   |   +--->BN_MP_KARATSUBA_MUL_C
+|   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_RSHD_C
 |   |   |   |   |   |   +--->BN_MP_ZERO_C
-|   |   |   +--->BN_FAST_S_MP_MUL_DIGS_C
+|   |   |   |   +--->BN_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_CMP_MAG_C
+|   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_S_MP_MUL_DIGS_C
+|   |   |   +--->BN_S_MP_SQR_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   +--->BN_MP_EXCH_C
@@ -203,18 +193,14 @@ BN_MP_SQRT_C
 |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_SUB_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_RSHD_C
@@ -449,6 +435,7 @@ BN_MP_IS_SQUARE_C
 |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_CLEAR_C
 |   +--->BN_MP_CLEAR_C
+|   +--->BN_MP_EXCH_C
 |   +--->BN_MP_ADD_C
 |   |   +--->BN_S_MP_ADD_C
 |   |   |   +--->BN_MP_GROW_C
@@ -457,7 +444,6 @@ BN_MP_IS_SQUARE_C
 |   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   +--->BN_MP_EXCH_C
 +--->BN_MP_GET_INT_C
 +--->BN_MP_SQRT_C
 |   +--->BN_MP_N_ROOT_C
@@ -468,8 +454,8 @@ BN_MP_IS_SQUARE_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_EXPT_D_C
 |   |   |   +--->BN_MP_INIT_COPY_C
-|   |   |   +--->BN_MP_SQR_C
-|   |   |   |   +--->BN_MP_TOOM_SQR_C
+|   |   |   +--->BN_MP_MUL_C
+|   |   |   |   +--->BN_MP_TOOM_MUL_C
 |   |   |   |   |   +--->BN_MP_INIT_MULTI_C
 |   |   |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   |   |   +--->BN_MP_MOD_2D_C
@@ -514,37 +500,33 @@ BN_MP_IS_SQUARE_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLEAR_MULTI_C
 |   |   |   |   |   |   +--->BN_MP_CLEAR_C
-|   |   |   |   +--->BN_MP_KARATSUBA_SQR_C
+|   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_RSHD_C
 |   |   |   |   |   |   |   +--->BN_MP_ZERO_C
-|   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLEAR_C
-|   |   |   |   +--->BN_FAST_S_MP_SQR_C
+|   |   |   |   +--->BN_FAST_S_MP_MUL_DIGS_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_S_MP_SQR_C
+|   |   |   |   +--->BN_S_MP_MUL_DIGS_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   +--->BN_MP_CLEAR_C
-|   |   |   +--->BN_MP_MUL_C
-|   |   |   |   +--->BN_MP_TOOM_MUL_C
+|   |   |   +--->BN_MP_SQR_C
+|   |   |   |   +--->BN_MP_TOOM_SQR_C
 |   |   |   |   |   +--->BN_MP_INIT_MULTI_C
 |   |   |   |   |   +--->BN_MP_MOD_2D_C
 |   |   |   |   |   |   +--->BN_MP_ZERO_C
@@ -586,29 +568,23 @@ BN_MP_IS_SQUARE_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLEAR_MULTI_C
-|   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
+|   |   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_RSHD_C
 |   |   |   |   |   |   |   +--->BN_MP_ZERO_C
-|   |   |   |   +--->BN_FAST_S_MP_MUL_DIGS_C
+|   |   |   |   |   +--->BN_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
+|   |   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_S_MP_MUL_DIGS_C
+|   |   |   |   +--->BN_S_MP_SQR_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   +--->BN_MP_EXCH_C
@@ -661,18 +637,14 @@ BN_MP_IS_SQUARE_C
 |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -864,13 +836,9 @@ BN_MP_IS_SQUARE_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_INIT_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
@@ -878,8 +846,6 @@ BN_MP_IS_SQUARE_C
 |   |   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_ADD_C
 |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_CLEAR_C
 |   +--->BN_FAST_S_MP_SQR_C
 |   |   +--->BN_MP_GROW_C
@@ -956,6 +922,7 @@ BN_MP_EXPTMOD_C
 |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   +--->BN_MP_CLEAR_C
+|   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -964,7 +931,6 @@ BN_MP_EXPTMOD_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_SET_C
 |   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_DIV_2_C
@@ -1046,6 +1012,7 @@ BN_MP_EXPTMOD_C
 |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   +--->BN_MP_CLEAR_C
+|   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -1054,7 +1021,6 @@ BN_MP_EXPTMOD_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_COPY_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_SET_C
@@ -1194,18 +1160,14 @@ BN_MP_EXPTMOD_C
 |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_FAST_S_MP_MUL_DIGS_C
@@ -1329,18 +1291,14 @@ BN_MP_EXPTMOD_C
 |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -1404,6 +1362,7 @@ BN_MP_EXPTMOD_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   +--->BN_MP_CLAMP_C
+|   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_ADD_C
 |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   +--->BN_MP_GROW_C
@@ -1412,7 +1371,6 @@ BN_MP_EXPTMOD_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_EXCH_C
 |   +--->BN_MP_COPY_C
 |   |   +--->BN_MP_GROW_C
 |   +--->BN_MP_SQR_C
@@ -1460,13 +1418,9 @@ BN_MP_EXPTMOD_C
 |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_SUB_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   +--->BN_MP_GROW_C
@@ -1474,8 +1428,6 @@ BN_MP_EXPTMOD_C
 |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
@@ -1528,18 +1480,14 @@ BN_MP_EXPTMOD_C
 |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_SUB_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_RSHD_C
@@ -1690,18 +1638,14 @@ BN_MP_EXPTMOD_C
 |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -1758,6 +1702,7 @@ BN_MP_EXPTMOD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -1766,7 +1711,6 @@ BN_MP_EXPTMOD_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_EXCH_C
 |   +--->BN_MP_SET_C
 |   |   +--->BN_MP_ZERO_C
 |   +--->BN_MP_MOD_C
@@ -1813,6 +1757,7 @@ BN_MP_EXPTMOD_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   +--->BN_MP_CLAMP_C
+|   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_ADD_C
 |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   +--->BN_MP_GROW_C
@@ -1821,7 +1766,6 @@ BN_MP_EXPTMOD_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_EXCH_C
 |   +--->BN_MP_COPY_C
 |   |   +--->BN_MP_GROW_C
 |   +--->BN_MP_SQR_C
@@ -1869,13 +1813,9 @@ BN_MP_EXPTMOD_C
 |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_SUB_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   +--->BN_MP_GROW_C
@@ -1883,8 +1823,6 @@ BN_MP_EXPTMOD_C
 |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
@@ -1937,18 +1875,14 @@ BN_MP_EXPTMOD_C
 |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_SUB_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_RSHD_C
@@ -2040,6 +1974,7 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   |   +--->BN_MP_CLEAR_C
+|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -2048,7 +1983,6 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_SET_C
 |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   +--->BN_MP_DIV_2_C
@@ -2129,6 +2063,7 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   |   +--->BN_MP_CLEAR_C
+|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -2137,7 +2072,6 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_COPY_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_SET_C
@@ -2276,18 +2210,14 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_FAST_S_MP_MUL_DIGS_C
@@ -2410,18 +2340,14 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -2485,6 +2411,7 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -2493,7 +2420,6 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_COPY_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_SQR_C
@@ -2541,13 +2467,9 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -2555,8 +2477,6 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
@@ -2609,18 +2529,14 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -2771,18 +2687,14 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -2839,6 +2751,7 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -2847,7 +2760,6 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_SET_C
 |   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_MOD_C
@@ -2894,6 +2806,7 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -2902,7 +2815,6 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_COPY_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_SQR_C
@@ -2950,13 +2862,9 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -2964,8 +2872,6 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
@@ -3018,18 +2924,14 @@ BN_MP_PRIME_FERMAT_C
 |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -3099,6 +3001,7 @@ BN_MP_SUBMOD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_CLAMP_C
+|   +--->BN_MP_EXCH_C
 |   +--->BN_MP_ADD_C
 |   |   +--->BN_S_MP_ADD_C
 |   |   |   +--->BN_MP_GROW_C
@@ -3107,7 +3010,6 @@ BN_MP_SUBMOD_C
 |   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   +--->BN_MP_EXCH_C
 
 
 BN_MP_MOD_2D_C
@@ -3253,13 +3155,9 @@ BN_MP_SQRMOD_C
 |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
@@ -3267,8 +3165,6 @@ BN_MP_SQRMOD_C
 |   |   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_ADD_C
 |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_CLEAR_C
 |   +--->BN_FAST_S_MP_SQR_C
 |   |   +--->BN_MP_GROW_C
@@ -3327,6 +3223,7 @@ BN_MP_SQRMOD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_CLAMP_C
+|   +--->BN_MP_EXCH_C
 |   +--->BN_MP_ADD_C
 |   |   +--->BN_S_MP_ADD_C
 |   |   |   +--->BN_MP_GROW_C
@@ -3335,7 +3232,6 @@ BN_MP_SQRMOD_C
 |   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   +--->BN_MP_EXCH_C
 
 
 BN_MP_INVMOD_C
@@ -3395,6 +3291,7 @@ BN_MP_INVMOD_C
 |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   +--->BN_MP_CLEAR_C
 |   |   +--->BN_MP_CLEAR_C
+|   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_ADD_C
 |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   +--->BN_MP_GROW_C
@@ -3403,7 +3300,6 @@ BN_MP_INVMOD_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_EXCH_C
 |   +--->BN_MP_SET_C
 |   |   +--->BN_MP_ZERO_C
 |   +--->BN_MP_DIV_2_C
@@ -3487,6 +3383,7 @@ BN_MP_INVMOD_C
 |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   +--->BN_MP_CLEAR_C
 |   |   +--->BN_MP_CLEAR_C
+|   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_ADD_C
 |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   +--->BN_MP_GROW_C
@@ -3495,7 +3392,6 @@ BN_MP_INVMOD_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_EXCH_C
 |   +--->BN_MP_COPY_C
 |   |   +--->BN_MP_GROW_C
 |   +--->BN_MP_SET_C
@@ -3540,6 +3436,24 @@ BN_MP_AND_C
 BN_MP_MUL_D_C
 +--->BN_MP_GROW_C
 +--->BN_MP_CLAMP_C
+
+
+BN_MP_EXPORT_C
++--->BN_MP_INIT_COPY_C
+|   +--->BN_MP_COPY_C
+|   |   +--->BN_MP_GROW_C
++--->BN_MP_COUNT_BITS_C
++--->BN_MP_DIV_2D_C
+|   +--->BN_MP_COPY_C
+|   |   +--->BN_MP_GROW_C
+|   +--->BN_MP_ZERO_C
+|   +--->BN_MP_MOD_2D_C
+|   |   +--->BN_MP_CLAMP_C
+|   +--->BN_MP_CLEAR_C
+|   +--->BN_MP_RSHD_C
+|   +--->BN_MP_CLAMP_C
+|   +--->BN_MP_EXCH_C
++--->BN_MP_CLEAR_C
 
 
 BN_FAST_MP_INVMOD_C
@@ -3598,6 +3512,7 @@ BN_FAST_MP_INVMOD_C
 |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_CLEAR_C
 |   +--->BN_MP_CLEAR_C
+|   +--->BN_MP_EXCH_C
 |   +--->BN_MP_ADD_C
 |   |   +--->BN_S_MP_ADD_C
 |   |   |   +--->BN_MP_GROW_C
@@ -3606,7 +3521,6 @@ BN_FAST_MP_INVMOD_C
 |   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   +--->BN_MP_EXCH_C
 +--->BN_MP_SET_C
 |   +--->BN_MP_ZERO_C
 +--->BN_MP_DIV_2_C
@@ -3706,8 +3620,8 @@ BN_MP_N_ROOT_C
 |   +--->BN_MP_GROW_C
 +--->BN_MP_EXPT_D_C
 |   +--->BN_MP_INIT_COPY_C
-|   +--->BN_MP_SQR_C
-|   |   +--->BN_MP_TOOM_SQR_C
+|   +--->BN_MP_MUL_C
+|   |   +--->BN_MP_TOOM_MUL_C
 |   |   |   +--->BN_MP_INIT_MULTI_C
 |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   +--->BN_MP_MOD_2D_C
@@ -3752,37 +3666,33 @@ BN_MP_N_ROOT_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLEAR_MULTI_C
 |   |   |   |   +--->BN_MP_CLEAR_C
-|   |   +--->BN_MP_KARATSUBA_SQR_C
+|   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_SUB_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_MP_ADD_C
 |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_RSHD_C
 |   |   |   |   |   +--->BN_MP_ZERO_C
-|   |   |   +--->BN_MP_ADD_C
-|   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLEAR_C
-|   |   +--->BN_FAST_S_MP_SQR_C
+|   |   +--->BN_FAST_S_MP_MUL_DIGS_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_S_MP_SQR_C
+|   |   +--->BN_S_MP_MUL_DIGS_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_CLEAR_C
 |   +--->BN_MP_CLEAR_C
-|   +--->BN_MP_MUL_C
-|   |   +--->BN_MP_TOOM_MUL_C
+|   +--->BN_MP_SQR_C
+|   |   +--->BN_MP_TOOM_SQR_C
 |   |   |   +--->BN_MP_INIT_MULTI_C
 |   |   |   +--->BN_MP_MOD_2D_C
 |   |   |   |   +--->BN_MP_ZERO_C
@@ -3824,29 +3734,23 @@ BN_MP_N_ROOT_C
 |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLEAR_MULTI_C
-|   |   +--->BN_MP_KARATSUBA_MUL_C
+|   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_SUB_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_ADD_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_RSHD_C
 |   |   |   |   |   +--->BN_MP_ZERO_C
-|   |   +--->BN_FAST_S_MP_MUL_DIGS_C
+|   |   |   +--->BN_MP_ADD_C
+|   |   |   |   +--->BN_MP_CMP_MAG_C
+|   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_S_MP_MUL_DIGS_C
+|   |   +--->BN_S_MP_SQR_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   +--->BN_MP_EXCH_C
@@ -3899,18 +3803,14 @@ BN_MP_N_ROOT_C
 |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_ADD_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_RSHD_C
@@ -4134,6 +4034,7 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   |   |   |   +--->BN_MP_CLEAR_C
+|   |   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -4142,7 +4043,6 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   |   +--->BN_MP_DIV_2_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
@@ -4212,6 +4112,7 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   |   |   |   +--->BN_MP_CLEAR_C
+|   |   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -4220,7 +4121,6 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   |   +--->BN_MP_COPY_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_DIV_2_C
@@ -4346,18 +4246,14 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_FAST_S_MP_MUL_DIGS_C
@@ -4469,18 +4365,14 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -4536,6 +4428,7 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -4544,7 +4437,6 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_COPY_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_SQR_C
@@ -4592,13 +4484,9 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -4606,8 +4494,6 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
@@ -4660,18 +4546,14 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -4800,18 +4682,14 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -4860,6 +4738,7 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -4868,7 +4747,6 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_MOD_C
 |   |   |   |   |   +--->BN_MP_DIV_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
@@ -4906,6 +4784,7 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -4914,7 +4793,6 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_COPY_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_SQR_C
@@ -4962,13 +4840,9 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -4976,8 +4850,6 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
@@ -5030,18 +4902,14 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -5110,13 +4978,9 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -5124,8 +4988,6 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -5175,6 +5037,7 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -5183,7 +5046,6 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_CLEAR_C
 |   +--->BN_MP_CLEAR_C
 +--->BN_MP_SUB_D_C
@@ -5251,13 +5113,9 @@ BN_MP_KARATSUBA_SQR_C
 |   +--->BN_S_MP_SQR_C
 |   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_CLEAR_C
-+--->BN_MP_SUB_C
-|   +--->BN_S_MP_ADD_C
-|   |   +--->BN_MP_GROW_C
-|   +--->BN_MP_CMP_MAG_C
-|   +--->BN_S_MP_SUB_C
-|   |   +--->BN_MP_GROW_C
 +--->BN_S_MP_ADD_C
+|   +--->BN_MP_GROW_C
++--->BN_S_MP_SUB_C
 |   +--->BN_MP_GROW_C
 +--->BN_MP_LSHD_C
 |   +--->BN_MP_GROW_C
@@ -5265,8 +5123,6 @@ BN_MP_KARATSUBA_SQR_C
 |   |   +--->BN_MP_ZERO_C
 +--->BN_MP_ADD_C
 |   +--->BN_MP_CMP_MAG_C
-|   +--->BN_S_MP_SUB_C
-|   |   +--->BN_MP_GROW_C
 +--->BN_MP_CLEAR_C
 
 
@@ -5296,20 +5152,14 @@ BN_MP_TOOM_SQR_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_INIT_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_ADD_C
 |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_CLEAR_C
 |   +--->BN_FAST_S_MP_SQR_C
 |   |   +--->BN_MP_GROW_C
@@ -5414,6 +5264,7 @@ BN_MP_MOD_C
 |   +--->BN_MP_CLAMP_C
 |   +--->BN_MP_CLEAR_C
 +--->BN_MP_CLEAR_C
++--->BN_MP_EXCH_C
 +--->BN_MP_ADD_C
 |   +--->BN_S_MP_ADD_C
 |   |   +--->BN_MP_GROW_C
@@ -5422,7 +5273,6 @@ BN_MP_MOD_C
 |   +--->BN_S_MP_SUB_C
 |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_CLAMP_C
-+--->BN_MP_EXCH_C
 
 
 BN_MP_INIT_C
@@ -5446,18 +5296,14 @@ BN_MP_TOOM_MUL_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_INIT_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_ADD_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_CLEAR_C
@@ -5607,6 +5453,7 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   |   |   +--->BN_MP_CLEAR_C
+|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -5615,7 +5462,6 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_DIV_2_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
@@ -5685,6 +5531,7 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   |   |   +--->BN_MP_CLEAR_C
+|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -5693,7 +5540,6 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_COPY_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_DIV_2_C
@@ -5819,18 +5665,14 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_FAST_S_MP_MUL_DIGS_C
@@ -5942,18 +5784,14 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -6009,6 +5847,7 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -6017,7 +5856,6 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_COPY_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_SQR_C
@@ -6065,13 +5903,9 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -6079,8 +5913,6 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
@@ -6133,18 +5965,14 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -6273,18 +6101,14 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -6333,6 +6157,7 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -6341,7 +6166,6 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_MOD_C
 |   |   |   |   +--->BN_MP_DIV_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
@@ -6379,6 +6203,7 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -6387,7 +6212,6 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_COPY_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_SQR_C
@@ -6435,13 +6259,9 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -6449,8 +6269,6 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
@@ -6503,18 +6321,14 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -6583,13 +6397,9 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -6597,8 +6407,6 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   +--->BN_MP_GROW_C
@@ -6648,6 +6456,7 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -6656,7 +6465,6 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_EXCH_C
 |   +--->BN_MP_CLEAR_C
 +--->BN_MP_CLEAR_C
 
@@ -6796,18 +6604,14 @@ BN_MP_EXPTMOD_FAST_C
 |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_SUB_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_RSHD_C
@@ -6866,6 +6670,7 @@ BN_MP_EXPTMOD_FAST_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   +--->BN_MP_CLAMP_C
+|   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_ADD_C
 |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   +--->BN_MP_GROW_C
@@ -6874,7 +6679,6 @@ BN_MP_EXPTMOD_FAST_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_EXCH_C
 +--->BN_MP_SET_C
 |   +--->BN_MP_ZERO_C
 +--->BN_MP_MOD_C
@@ -6923,6 +6727,7 @@ BN_MP_EXPTMOD_FAST_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_CLAMP_C
+|   +--->BN_MP_EXCH_C
 |   +--->BN_MP_ADD_C
 |   |   +--->BN_S_MP_ADD_C
 |   |   |   +--->BN_MP_GROW_C
@@ -6931,7 +6736,6 @@ BN_MP_EXPTMOD_FAST_C
 |   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   +--->BN_MP_EXCH_C
 +--->BN_MP_COPY_C
 |   +--->BN_MP_GROW_C
 +--->BN_MP_SQR_C
@@ -6980,13 +6784,9 @@ BN_MP_EXPTMOD_FAST_C
 |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
@@ -6994,8 +6794,6 @@ BN_MP_EXPTMOD_FAST_C
 |   |   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_ADD_C
 |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   +--->BN_FAST_S_MP_SQR_C
 |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_CLAMP_C
@@ -7049,18 +6847,14 @@ BN_MP_EXPTMOD_FAST_C
 |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_ADD_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_RSHD_C
@@ -7186,13 +6980,9 @@ BN_MP_SQR_C
 |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_INIT_C
 |   +--->BN_MP_CLAMP_C
-|   +--->BN_MP_SUB_C
-|   |   +--->BN_S_MP_ADD_C
-|   |   |   +--->BN_MP_GROW_C
-|   |   +--->BN_MP_CMP_MAG_C
-|   |   +--->BN_S_MP_SUB_C
-|   |   |   +--->BN_MP_GROW_C
 |   +--->BN_S_MP_ADD_C
+|   |   +--->BN_MP_GROW_C
+|   +--->BN_S_MP_SUB_C
 |   |   +--->BN_MP_GROW_C
 |   +--->BN_MP_LSHD_C
 |   |   +--->BN_MP_GROW_C
@@ -7200,8 +6990,6 @@ BN_MP_SQR_C
 |   |   |   +--->BN_MP_ZERO_C
 |   +--->BN_MP_ADD_C
 |   |   +--->BN_MP_CMP_MAG_C
-|   |   +--->BN_S_MP_SUB_C
-|   |   |   +--->BN_MP_GROW_C
 |   +--->BN_MP_CLEAR_C
 +--->BN_FAST_S_MP_SQR_C
 |   +--->BN_MP_GROW_C
@@ -7269,18 +7057,14 @@ BN_MP_MULMOD_C
 |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_ADD_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_RSHD_C
@@ -7343,6 +7127,7 @@ BN_MP_MULMOD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_CLAMP_C
+|   +--->BN_MP_EXCH_C
 |   +--->BN_MP_ADD_C
 |   |   +--->BN_S_MP_ADD_C
 |   |   |   +--->BN_MP_GROW_C
@@ -7351,7 +7136,6 @@ BN_MP_MULMOD_C
 |   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   +--->BN_MP_EXCH_C
 
 
 BN_MP_DIV_2D_C
@@ -7369,6 +7153,18 @@ BN_MP_DIV_2D_C
 
 BN_S_MP_ADD_C
 +--->BN_MP_GROW_C
++--->BN_MP_CLAMP_C
+
+
+BN_MP_IMPORT_C
++--->BN_MP_ZERO_C
++--->BN_MP_MUL_2D_C
+|   +--->BN_MP_COPY_C
+|   |   +--->BN_MP_GROW_C
+|   +--->BN_MP_GROW_C
+|   +--->BN_MP_LSHD_C
+|   |   +--->BN_MP_RSHD_C
+|   +--->BN_MP_CLAMP_C
 +--->BN_MP_CLAMP_C
 
 
@@ -7543,6 +7339,7 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   |   |   +--->BN_MP_CLEAR_C
+|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -7551,7 +7348,6 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_DIV_2_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
@@ -7621,6 +7417,7 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   |   |   +--->BN_MP_CLEAR_C
+|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -7629,7 +7426,6 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_COPY_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_DIV_2_C
@@ -7755,18 +7551,14 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_FAST_S_MP_MUL_DIGS_C
@@ -7878,18 +7670,14 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -7945,6 +7733,7 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -7953,7 +7742,6 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_COPY_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_SQR_C
@@ -8001,13 +7789,9 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -8015,8 +7799,6 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
@@ -8069,18 +7851,14 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -8209,18 +7987,14 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -8269,6 +8043,7 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -8277,7 +8052,6 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_MOD_C
 |   |   |   |   +--->BN_MP_DIV_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
@@ -8315,6 +8089,7 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -8323,7 +8098,6 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_COPY_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_SQR_C
@@ -8371,13 +8145,9 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -8385,8 +8155,6 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
@@ -8439,18 +8207,14 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -8519,13 +8283,9 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -8533,8 +8293,6 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   +--->BN_MP_GROW_C
@@ -8584,6 +8342,7 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -8592,7 +8351,6 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_EXCH_C
 |   +--->BN_MP_CLEAR_C
 +--->BN_MP_CLEAR_C
 
@@ -8658,6 +8416,7 @@ BN_MP_INVMOD_SLOW_C
 |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_CLEAR_C
 |   +--->BN_MP_CLEAR_C
+|   +--->BN_MP_EXCH_C
 |   +--->BN_MP_ADD_C
 |   |   +--->BN_S_MP_ADD_C
 |   |   |   +--->BN_MP_GROW_C
@@ -8666,7 +8425,6 @@ BN_MP_INVMOD_SLOW_C
 |   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   +--->BN_MP_EXCH_C
 +--->BN_MP_COPY_C
 |   +--->BN_MP_GROW_C
 +--->BN_MP_SET_C
@@ -8707,7 +8465,6 @@ BN_MP_LCM_C
 |   +--->BN_MP_ABS_C
 |   |   +--->BN_MP_COPY_C
 |   |   |   +--->BN_MP_GROW_C
-|   +--->BN_MP_ZERO_C
 |   +--->BN_MP_INIT_COPY_C
 |   |   +--->BN_MP_COPY_C
 |   |   |   +--->BN_MP_GROW_C
@@ -8715,6 +8472,7 @@ BN_MP_LCM_C
 |   +--->BN_MP_DIV_2D_C
 |   |   +--->BN_MP_COPY_C
 |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_MOD_2D_C
 |   |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_CLEAR_C
@@ -8732,6 +8490,7 @@ BN_MP_LCM_C
 |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_RSHD_C
+|   |   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_CLAMP_C
 |   +--->BN_MP_CLEAR_C
 +--->BN_MP_CMP_MAG_C
@@ -8837,16 +8596,13 @@ BN_MP_LCM_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_INIT_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_ADD_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_RSHD_C
@@ -8931,18 +8687,14 @@ BN_MP_REDUCE_2K_L_C
 |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_ADD_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_RSHD_C
@@ -9004,7 +8756,6 @@ BN_MP_GCD_C
 +--->BN_MP_ABS_C
 |   +--->BN_MP_COPY_C
 |   |   +--->BN_MP_GROW_C
-+--->BN_MP_ZERO_C
 +--->BN_MP_INIT_COPY_C
 |   +--->BN_MP_COPY_C
 |   |   +--->BN_MP_GROW_C
@@ -9012,6 +8763,7 @@ BN_MP_GCD_C
 +--->BN_MP_DIV_2D_C
 |   +--->BN_MP_COPY_C
 |   |   +--->BN_MP_GROW_C
+|   +--->BN_MP_ZERO_C
 |   +--->BN_MP_MOD_2D_C
 |   |   +--->BN_MP_CLAMP_C
 |   +--->BN_MP_CLEAR_C
@@ -9029,6 +8781,7 @@ BN_MP_GCD_C
 |   +--->BN_MP_GROW_C
 |   +--->BN_MP_LSHD_C
 |   |   +--->BN_MP_RSHD_C
+|   |   |   +--->BN_MP_ZERO_C
 |   +--->BN_MP_CLAMP_C
 +--->BN_MP_CLEAR_C
 
@@ -9149,8 +8902,8 @@ BN_MP_EXPT_D_C
 |   |   +--->BN_MP_GROW_C
 +--->BN_MP_SET_C
 |   +--->BN_MP_ZERO_C
-+--->BN_MP_SQR_C
-|   +--->BN_MP_TOOM_SQR_C
++--->BN_MP_MUL_C
+|   +--->BN_MP_TOOM_MUL_C
 |   |   +--->BN_MP_INIT_MULTI_C
 |   |   |   +--->BN_MP_CLEAR_C
 |   |   +--->BN_MP_MOD_2D_C
@@ -9199,37 +8952,33 @@ BN_MP_EXPT_D_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_CLEAR_MULTI_C
 |   |   |   +--->BN_MP_CLEAR_C
-|   +--->BN_MP_KARATSUBA_SQR_C
+|   +--->BN_MP_KARATSUBA_MUL_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_MP_ADD_C
 |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
-|   |   +--->BN_S_MP_ADD_C
+|   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_RSHD_C
 |   |   |   |   +--->BN_MP_ZERO_C
-|   |   +--->BN_MP_ADD_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_CLEAR_C
-|   +--->BN_FAST_S_MP_SQR_C
+|   +--->BN_FAST_S_MP_MUL_DIGS_C
 |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_CLAMP_C
-|   +--->BN_S_MP_SQR_C
+|   +--->BN_S_MP_MUL_DIGS_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_CLEAR_C
 +--->BN_MP_CLEAR_C
-+--->BN_MP_MUL_C
-|   +--->BN_MP_TOOM_MUL_C
++--->BN_MP_SQR_C
+|   +--->BN_MP_TOOM_SQR_C
 |   |   +--->BN_MP_INIT_MULTI_C
 |   |   +--->BN_MP_MOD_2D_C
 |   |   |   +--->BN_MP_ZERO_C
@@ -9275,29 +9024,23 @@ BN_MP_EXPT_D_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_CLEAR_MULTI_C
-|   +--->BN_MP_KARATSUBA_MUL_C
+|   +--->BN_MP_KARATSUBA_SQR_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   +--->BN_MP_ADD_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_RSHD_C
 |   |   |   |   +--->BN_MP_ZERO_C
-|   +--->BN_FAST_S_MP_MUL_DIGS_C
+|   |   +--->BN_MP_ADD_C
+|   |   |   +--->BN_MP_CMP_MAG_C
+|   +--->BN_FAST_S_MP_SQR_C
 |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_CLAMP_C
-|   +--->BN_S_MP_MUL_DIGS_C
+|   +--->BN_S_MP_SQR_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_EXCH_C
@@ -9411,18 +9154,14 @@ BN_S_MP_EXPTMOD_C
 |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_SUB_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_FAST_S_MP_MUL_DIGS_C
@@ -9547,18 +9286,14 @@ BN_S_MP_EXPTMOD_C
 |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_SUB_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_RSHD_C
@@ -9624,6 +9359,7 @@ BN_S_MP_EXPTMOD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_CLAMP_C
+|   +--->BN_MP_EXCH_C
 |   +--->BN_MP_ADD_C
 |   |   +--->BN_S_MP_ADD_C
 |   |   |   +--->BN_MP_GROW_C
@@ -9632,7 +9368,6 @@ BN_S_MP_EXPTMOD_C
 |   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   +--->BN_MP_EXCH_C
 +--->BN_MP_COPY_C
 |   +--->BN_MP_GROW_C
 +--->BN_MP_SQR_C
@@ -9681,13 +9416,9 @@ BN_S_MP_EXPTMOD_C
 |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
@@ -9695,8 +9426,6 @@ BN_S_MP_EXPTMOD_C
 |   |   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_ADD_C
 |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   +--->BN_FAST_S_MP_SQR_C
 |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_CLAMP_C
@@ -9750,18 +9479,14 @@ BN_S_MP_EXPTMOD_C
 |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_ADD_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_RSHD_C
@@ -10196,18 +9921,14 @@ BN_MP_REDUCE_C
 |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_ADD_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_CLEAR_C
@@ -10346,6 +10067,7 @@ BN_MP_JACOBI_C
 |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_CLEAR_C
 |   +--->BN_MP_CLEAR_C
+|   +--->BN_MP_EXCH_C
 |   +--->BN_MP_ADD_C
 |   |   +--->BN_S_MP_ADD_C
 |   |   |   +--->BN_MP_GROW_C
@@ -10354,7 +10076,6 @@ BN_MP_JACOBI_C
 |   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   +--->BN_MP_EXCH_C
 +--->BN_MP_CLEAR_C
 
 
@@ -10418,18 +10139,14 @@ BN_MP_MUL_C
 |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_INIT_C
 |   +--->BN_MP_CLAMP_C
-|   +--->BN_MP_SUB_C
-|   |   +--->BN_S_MP_ADD_C
-|   |   |   +--->BN_MP_GROW_C
-|   |   +--->BN_MP_CMP_MAG_C
-|   |   +--->BN_S_MP_SUB_C
-|   |   |   +--->BN_MP_GROW_C
+|   +--->BN_S_MP_ADD_C
+|   |   +--->BN_MP_GROW_C
 |   +--->BN_MP_ADD_C
-|   |   +--->BN_S_MP_ADD_C
-|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_CMP_MAG_C
 |   |   +--->BN_S_MP_SUB_C
 |   |   |   +--->BN_MP_GROW_C
+|   +--->BN_S_MP_SUB_C
+|   |   +--->BN_MP_GROW_C
 |   +--->BN_MP_LSHD_C
 |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_RSHD_C
@@ -10552,18 +10269,14 @@ BN_MP_EXTEUCLID_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_INIT_C
 |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_SUB_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_ADD_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_ADD_C
-|   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
+|   |   +--->BN_S_MP_SUB_C
+|   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_LSHD_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_RSHD_C
@@ -10741,18 +10454,14 @@ BN_MP_KARATSUBA_MUL_C
 +--->BN_MP_INIT_SIZE_C
 |   +--->BN_MP_INIT_C
 +--->BN_MP_CLAMP_C
-+--->BN_MP_SUB_C
-|   +--->BN_S_MP_ADD_C
-|   |   +--->BN_MP_GROW_C
-|   +--->BN_MP_CMP_MAG_C
-|   +--->BN_S_MP_SUB_C
-|   |   +--->BN_MP_GROW_C
++--->BN_S_MP_ADD_C
+|   +--->BN_MP_GROW_C
 +--->BN_MP_ADD_C
-|   +--->BN_S_MP_ADD_C
-|   |   +--->BN_MP_GROW_C
 |   +--->BN_MP_CMP_MAG_C
 |   +--->BN_S_MP_SUB_C
 |   |   +--->BN_MP_GROW_C
++--->BN_S_MP_SUB_C
+|   +--->BN_MP_GROW_C
 +--->BN_MP_LSHD_C
 |   +--->BN_MP_GROW_C
 |   +--->BN_MP_RSHD_C
@@ -10835,6 +10544,7 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   |   +--->BN_MP_CLEAR_C
+|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -10843,7 +10553,6 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_SET_C
 |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   +--->BN_MP_DIV_2_C
@@ -10916,6 +10625,7 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   +--->BN_MP_CLEAR_C
 |   |   |   |   +--->BN_MP_CLEAR_C
+|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -10924,7 +10634,6 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_COPY_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_SET_C
@@ -11053,18 +10762,14 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_FAST_S_MP_MUL_DIGS_C
@@ -11178,18 +10883,14 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -11246,6 +10947,7 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -11254,7 +10956,6 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_COPY_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_SQR_C
@@ -11302,13 +11003,9 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -11316,8 +11013,6 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
@@ -11370,18 +11065,14 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -11514,18 +11205,14 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -11575,6 +11262,7 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   |   +--->BN_MP_EXCH_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
@@ -11583,7 +11271,6 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_SET_C
 |   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_MOD_C
@@ -11623,6 +11310,7 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   |   +--->BN_MP_CLAMP_C
+|   |   |   +--->BN_MP_EXCH_C
 |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -11631,7 +11319,6 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_COPY_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   +--->BN_MP_SQR_C
@@ -11679,13 +11366,9 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
@@ -11693,8 +11376,6 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
@@ -11747,18 +11428,14 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   +--->BN_MP_KARATSUBA_MUL_C
 |   |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   |   +--->BN_MP_SUB_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_ADD_C
-|   |   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_CMP_MAG_C
 |   |   |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   |   |   +--->BN_MP_GROW_C
+|   |   |   |   +--->BN_S_MP_SUB_C
+|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   |   +--->BN_MP_RSHD_C
@@ -11827,13 +11504,9 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   +--->BN_MP_KARATSUBA_SQR_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_CLAMP_C
-|   |   |   +--->BN_MP_SUB_C
-|   |   |   |   +--->BN_S_MP_ADD_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_S_MP_ADD_C
+|   |   |   |   +--->BN_MP_GROW_C
+|   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_LSHD_C
 |   |   |   |   +--->BN_MP_GROW_C
@@ -11841,8 +11514,6 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   |   +--->BN_MP_ADD_C
 |   |   |   |   +--->BN_MP_CMP_MAG_C
-|   |   |   |   +--->BN_S_MP_SUB_C
-|   |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLEAR_C
 |   |   +--->BN_FAST_S_MP_SQR_C
 |   |   |   +--->BN_MP_GROW_C
@@ -11893,6 +11564,7 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
 |   |   |   +--->BN_MP_CLAMP_C
+|   |   +--->BN_MP_EXCH_C
 |   |   +--->BN_MP_ADD_C
 |   |   |   +--->BN_S_MP_ADD_C
 |   |   |   |   +--->BN_MP_GROW_C
@@ -11901,7 +11573,6 @@ BN_MP_PRIME_MILLER_RABIN_C
 |   |   |   +--->BN_S_MP_SUB_C
 |   |   |   |   +--->BN_MP_GROW_C
 |   |   |   |   +--->BN_MP_CLAMP_C
-|   |   +--->BN_MP_EXCH_C
 +--->BN_MP_CLEAR_C
 
 

--- a/libtommath_VS2005.vcproj
+++ b/libtommath_VS2005.vcproj
@@ -828,6 +828,28 @@
 			</FileConfiguration>
 		</File>
 		<File
+			RelativePath="bn_mp_export.c"
+			>
+			<FileConfiguration
+				Name="Debug|Win32"
+				>
+				<Tool
+					Name="VCCLCompilerTool"
+					AdditionalIncludeDirectories=""
+					PreprocessorDefinitions=""
+				/>
+			</FileConfiguration>
+			<FileConfiguration
+				Name="Release|Win32"
+				>
+				<Tool
+					Name="VCCLCompilerTool"
+					AdditionalIncludeDirectories=""
+					PreprocessorDefinitions=""
+				/>
+			</FileConfiguration>
+		</File>
+		<File
 			RelativePath="bn_mp_expt_d.c"
 			>
 			<FileConfiguration
@@ -1005,6 +1027,28 @@
 		</File>
 		<File
 			RelativePath="bn_mp_grow.c"
+			>
+			<FileConfiguration
+				Name="Debug|Win32"
+				>
+				<Tool
+					Name="VCCLCompilerTool"
+					AdditionalIncludeDirectories=""
+					PreprocessorDefinitions=""
+				/>
+			</FileConfiguration>
+			<FileConfiguration
+				Name="Release|Win32"
+				>
+				<Tool
+					Name="VCCLCompilerTool"
+					AdditionalIncludeDirectories=""
+					PreprocessorDefinitions=""
+				/>
+			</FileConfiguration>
+		</File>
+		<File
+			RelativePath="bn_mp_import.c"
 			>
 			<FileConfiguration
 				Name="Debug|Win32"

--- a/libtommath_VS2008.vcproj
+++ b/libtommath_VS2008.vcproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="Windows-1252"?>
 <VisualStudioProject
 	ProjectType="Visual C++"
-	Version="9,00"
+	Version="9.00"
 	Name="libtommath"
 	ProjectGUID="{42109FEE-B0B9-4FCD-9E56-2863BF8C55D2}"
 	RootNamespace="libtommath"
@@ -830,6 +830,10 @@
 			</FileConfiguration>
 		</File>
 		<File
+			RelativePath=".\bn_mp_export.c"
+			>
+		</File>
+		<File
 			RelativePath="bn_mp_expt_d.c"
 			>
 			<FileConfiguration
@@ -1026,6 +1030,10 @@
 					PreprocessorDefinitions=""
 				/>
 			</FileConfiguration>
+		</File>
+		<File
+			RelativePath=".\bn_mp_import.c"
+			>
 		</File>
 		<File
 			RelativePath="bn_mp_init.c"

--- a/makefile
+++ b/makefile
@@ -83,7 +83,7 @@ bn_mp_fread.o bn_mp_fwrite.o bn_mp_cnt_lsb.o bn_error.o \
 bn_mp_init_multi.o bn_mp_clear_multi.o bn_mp_exteuclid.o bn_mp_toradix_n.o \
 bn_mp_prime_random_ex.o bn_mp_get_int.o bn_mp_sqrt.o bn_mp_is_square.o bn_mp_init_set.o \
 bn_mp_init_set_int.o bn_mp_invmod_slow.o bn_mp_prime_rabin_miller_trials.o \
-bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin_n.o
+bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin_n.o bn_mp_import.o bn_mp_export.o
 
 $(LIBNAME):  $(OBJECTS)
 	$(AR) $(ARFLAGS) $@ $(OBJECTS)

--- a/makefile.bcc
+++ b/makefile.bcc
@@ -33,7 +33,7 @@ bn_mp_fread.obj bn_mp_fwrite.obj bn_mp_cnt_lsb.obj bn_error.obj \
 bn_mp_init_multi.obj bn_mp_clear_multi.obj bn_mp_exteuclid.obj bn_mp_toradix_n.obj \
 bn_mp_prime_random_ex.obj bn_mp_get_int.obj bn_mp_sqrt.obj bn_mp_is_square.obj \
 bn_mp_init_set.obj bn_mp_init_set_int.obj bn_mp_invmod_slow.obj bn_mp_prime_rabin_miller_trials.obj \
-bn_mp_to_signed_bin_n.obj bn_mp_to_unsigned_bin_n.obj
+bn_mp_to_signed_bin_n.obj bn_mp_to_unsigned_bin_n.obj bn_mp_import.obj bn_mp_export.obj
 
 TARGET = libtommath.lib
 

--- a/makefile.cygwin_dll
+++ b/makefile.cygwin_dll
@@ -38,7 +38,7 @@ bn_mp_fread.o bn_mp_fwrite.o bn_mp_cnt_lsb.o bn_error.o \
 bn_mp_init_multi.o bn_mp_clear_multi.o bn_mp_exteuclid.o bn_mp_toradix_n.o \
 bn_mp_prime_random_ex.o bn_mp_get_int.o bn_mp_sqrt.o bn_mp_is_square.o bn_mp_init_set.o \
 bn_mp_init_set_int.o bn_mp_invmod_slow.o bn_mp_prime_rabin_miller_trials.o \
-bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin_n.o
+bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin_n.o bn_mp_import.o bn_mp_export.o
 
 # make a Windows DLL via Cygwin
 windll:  $(OBJECTS)

--- a/makefile.icc
+++ b/makefile.icc
@@ -65,7 +65,7 @@ bn_mp_fread.o bn_mp_fwrite.o bn_mp_cnt_lsb.o bn_error.o \
 bn_mp_init_multi.o bn_mp_clear_multi.o bn_mp_exteuclid.o bn_mp_toradix_n.o \
 bn_mp_prime_random_ex.o bn_mp_get_int.o bn_mp_sqrt.o bn_mp_is_square.o bn_mp_init_set.o \
 bn_mp_init_set_int.o bn_mp_invmod_slow.o bn_mp_prime_rabin_miller_trials.o \
-bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin_n.o
+bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin_n.o bn_mp_import.o bn_mp_export.o
 
 libtommath.a:  $(OBJECTS)
 	$(AR) $(ARFLAGS) libtommath.a $(OBJECTS)

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -32,7 +32,7 @@ bn_mp_fread.obj bn_mp_fwrite.obj bn_mp_cnt_lsb.obj bn_error.obj \
 bn_mp_init_multi.obj bn_mp_clear_multi.obj bn_mp_exteuclid.obj bn_mp_toradix_n.obj \
 bn_mp_prime_random_ex.obj bn_mp_get_int.obj bn_mp_sqrt.obj bn_mp_is_square.obj \
 bn_mp_init_set.obj bn_mp_init_set_int.obj bn_mp_invmod_slow.obj bn_mp_prime_rabin_miller_trials.obj \
-bn_mp_to_signed_bin_n.obj bn_mp_to_unsigned_bin_n.obj
+bn_mp_to_signed_bin_n.obj bn_mp_to_unsigned_bin_n.obj bn_mp_import.obj bn_mp_export.obj
 
 HEADERS=tommath.h tommath_class.h tommath_superclass.h
 

--- a/makefile.shared
+++ b/makefile.shared
@@ -78,7 +78,7 @@ bn_mp_fread.o bn_mp_fwrite.o bn_mp_cnt_lsb.o bn_error.o \
 bn_mp_init_multi.o bn_mp_clear_multi.o bn_mp_exteuclid.o bn_mp_toradix_n.o \
 bn_mp_prime_random_ex.o bn_mp_get_int.o bn_mp_sqrt.o bn_mp_is_square.o bn_mp_init_set.o \
 bn_mp_init_set_int.o bn_mp_invmod_slow.o bn_mp_prime_rabin_miller_trials.o \
-bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin_n.o
+bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin_n.o bn_mp_import.o bn_mp_export.o
 
 objs: $(OBJECTS)
 

--- a/tommath.h
+++ b/tommath.h
@@ -249,6 +249,12 @@ int mp_init_copy(mp_int *a, mp_int *b);
 /* trim unused digits */
 void mp_clamp(mp_int *a);
 
+/* import binary data */
+int mp_import(mp_int* rop, size_t count, int order, size_t size, int endian, size_t nails, const void* op);
+
+/* export binary data */
+int mp_export(void* rop, size_t* countp, int order, size_t size, int endian, size_t nails, mp_int* op);
+
 /* ---> digit manipulation <--- */
 
 /* right shift by "b" digits */

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -38,6 +38,7 @@
 #define BN_MP_DR_REDUCE_C
 #define BN_MP_DR_SETUP_C
 #define BN_MP_EXCH_C
+#define BN_MP_EXPORT_C
 #define BN_MP_EXPT_D_C
 #define BN_MP_EXPTMOD_C
 #define BN_MP_EXPTMOD_FAST_C
@@ -47,6 +48,7 @@
 #define BN_MP_GCD_C
 #define BN_MP_GET_INT_C
 #define BN_MP_GROW_C
+#define BN_MP_IMPORT_C
 #define BN_MP_INIT_C
 #define BN_MP_INIT_COPY_C
 #define BN_MP_INIT_MULTI_C
@@ -315,12 +317,19 @@
 #if defined(BN_MP_EXCH_C)
 #endif
 
+#if defined(BN_MP_EXPORT_C)
+   #define BN_MP_INIT_COPY_C
+   #define BN_MP_COUNT_BITS_C
+   #define BN_MP_DIV_2D_C
+   #define BN_MP_CLEAR_C
+#endif
+
 #if defined(BN_MP_EXPT_D_C)
    #define BN_MP_INIT_COPY_C
    #define BN_MP_SET_C
-   #define BN_MP_SQR_C
-   #define BN_MP_CLEAR_C
    #define BN_MP_MUL_C
+   #define BN_MP_CLEAR_C
+   #define BN_MP_SQR_C
 #endif
 
 #if defined(BN_MP_EXPTMOD_C)
@@ -387,7 +396,6 @@
 #if defined(BN_MP_GCD_C)
    #define BN_MP_ISZERO_C
    #define BN_MP_ABS_C
-   #define BN_MP_ZERO_C
    #define BN_MP_INIT_COPY_C
    #define BN_MP_CNT_LSB_C
    #define BN_MP_DIV_2D_C
@@ -402,6 +410,12 @@
 #endif
 
 #if defined(BN_MP_GROW_C)
+#endif
+
+#if defined(BN_MP_IMPORT_C)
+   #define BN_MP_ZERO_C
+   #define BN_MP_MUL_2D_C
+   #define BN_MP_CLAMP_C
 #endif
 
 #if defined(BN_MP_INIT_C)
@@ -481,8 +495,9 @@
    #define BN_MP_MUL_C
    #define BN_MP_INIT_SIZE_C
    #define BN_MP_CLAMP_C
-   #define BN_MP_SUB_C
+   #define BN_S_MP_ADD_C
    #define BN_MP_ADD_C
+   #define BN_S_MP_SUB_C
    #define BN_MP_LSHD_C
    #define BN_MP_CLEAR_C
 #endif
@@ -491,8 +506,8 @@
    #define BN_MP_INIT_SIZE_C
    #define BN_MP_CLAMP_C
    #define BN_MP_SQR_C
-   #define BN_MP_SUB_C
    #define BN_S_MP_ADD_C
+   #define BN_S_MP_SUB_C
    #define BN_MP_LSHD_C
    #define BN_MP_ADD_C
    #define BN_MP_CLEAR_C
@@ -516,8 +531,9 @@
    #define BN_MP_INIT_C
    #define BN_MP_DIV_C
    #define BN_MP_CLEAR_C
-   #define BN_MP_ADD_C
+   #define BN_MP_ISZERO_C
    #define BN_MP_EXCH_C
+   #define BN_MP_ADD_C
 #endif
 
 #if defined(BN_MP_MOD_2D_C)
@@ -668,8 +684,8 @@
 
 #if defined(BN_MP_RADIX_SIZE_C)
    #define BN_MP_COUNT_BITS_C
-   #define BN_MP_INIT_COPY_C
    #define BN_MP_ISZERO_C
+   #define BN_MP_INIT_COPY_C
    #define BN_MP_DIV_D_C
    #define BN_MP_CLEAR_C
 #endif
@@ -687,7 +703,6 @@
 #if defined(BN_MP_READ_RADIX_C)
    #define BN_MP_ZERO_C
    #define BN_MP_S_RMAP_C
-   #define BN_MP_RADIX_SMAP_C
    #define BN_MP_MUL_D_C
    #define BN_MP_ADD_D_C
    #define BN_MP_ISZERO_C
@@ -993,7 +1008,3 @@
 #else
 #define LTM_LAST
 #endif
-
-/* $Source$ */
-/* $Revision$ */
-/* $Date$ */


### PR DESCRIPTION
Often we need to serialize or deserialize large numbers, for example to store or read them from files or send them over a network.  We don't often have control over the format that these numbers need to be stored or transferred in, and tommath's read and write functions are pretty limited in what they can do.

This patch adds two new functions: mp_import and mp_export, which are based on GMP's powerful mpz_import and mpz_export functions:

http://gmplib.org/manual/Integer-Import-and-Export.html

These functions can import and export integers according to the format specified by its arguments, which can adhere to virtually any common specification.
