### PR TITLE
Fixes for Native Client build.

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,6 +11,8 @@ ifndef MAKE
    MAKE=make
 endif
 
+RANLIB ?= ranlib
+
 ifndef IGNORE_SPEED
 
 #for speed 
@@ -87,7 +89,7 @@ bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin_n.o
 
 $(LIBNAME):  $(OBJECTS)
 	$(AR) $(ARFLAGS) $@ $(OBJECTS)
-	ranlib $@
+	$(RANLIB) $@
 
 #make a profiled library (takes a while!!!)
 #
@@ -119,7 +121,7 @@ install: $(LIBNAME)
 	install -g $(GROUP) -o $(USER) $(HEADERS) $(DESTDIR)$(INCPATH)
 
 test: $(LIBNAME) demo/demo.o
-	$(CC) $(CFLAGS) demo/demo.o $(LIBNAME) -o test
+	$(CC) $(CFLAGS) demo/demo.o $(LIBNAME) -o test$(EXE_EXT)
 	
 mtest: test	
 	cd mtest ; $(CC) $(CFLAGS) mtest.c -o mtest

--- a/tommath.h
+++ b/tommath.h
@@ -46,7 +46,7 @@ extern "C" {
 
 
 /* detect 64-bit mode if possible */
-#if defined(__x86_64__) 
+#if defined(__x86_64__) && !defined(__native_client__)
    #if !(defined(MP_64BIT) && defined(MP_16BIT) && defined(MP_8BIT))
       #define MP_64BIT
    #endif


### PR DESCRIPTION
Allow RANLIB to be overwridden like the other compiler tools.

Don't assume 64-bit pointer size on x86_64 architecutre.