### PR TITLE
Speed up bn_map_toradix

### DIFF
--- a/bn_mp_toradix.c
+++ b/bn_mp_toradix.c
@@ -18,10 +18,12 @@
 /* stores a bignum as a ASCII string in a given radix (2..64) */
 int mp_toradix (mp_int * a, char *str, int radix)
 {
-  int     res, digs;
+  int     res, digits_at_a_time;
   mp_int  t;
-  mp_digit d;
+  mp_digit d, divide_by;
   char   *_s = str;
+  static int pow_of_radix[64] = {0};
+  static mp_digit radix_to_pow[64];
 
   /* check range of the radix */
   if (radix < 2 || radix > 64) {
@@ -35,6 +37,22 @@ int mp_toradix (mp_int * a, char *str, int radix)
      return MP_OKAY;
   }
 
+  /* Find the largest power of radix which doesn't exceed MP_DIGIT_MAX */
+  if( pow_of_radix[radix-1] ) {
+    digits = pow_of_radix[radix-1];
+    divide_by = radix_to_pow[radix-1];
+  } else {
+    mp_digit test = radix;
+    digits_at_a_time = 0;
+    do {
+      divide_by = test;
+      ++digits_at_a_time;
+      test *= radix;
+    } while( test <= MP_DIGIT_MAX && test > divide_by );
+    pow_of_radix[radix-1] = digits;
+    radix_to_pow[radix-1] = divide_by;
+  }
+
   if ((res = mp_init_copy (&t, a)) != MP_OKAY) {
     return res;
   }
@@ -46,20 +64,34 @@ int mp_toradix (mp_int * a, char *str, int radix)
     t.sign = MP_ZPOS;
   }
 
-  digs = 0;
+  if ((res = mp_div_d (&t, divide_by, &t, &d)) != MP_OKAY) {
+    mp_clear (&t);
+    return res;
+  }
   while (mp_iszero (&t) == 0) {
-    if ((res = mp_div_d (&t, (mp_digit) radix, &t, &d)) != MP_OKAY) {
+    int digits;
+    for( digits = digits_at_a_time; digits > 1; --digits ) {
+      *str++ = mp_s_rmap[ d % radix ];
+      d /= radix;
+    }
+    *str++ = mp_s_rmap[d];
+    if ((res = mp_div_d (&t, divide_by, &t, &d)) != MP_OKAY) {
       mp_clear (&t);
       return res;
     }
-    *str++ = mp_s_rmap[d];
-    ++digs;
+  }
+  while( d >= radix ) {
+    *str++ = mp_s_rmap[ d % radix ];
+    d /= radix;
+  }
+  if( d ) {
+    *str++ = mp_s_rmap[ d ];
   }
 
   /* reverse the digits of the string.  In this case _s points
    * to the first digit [exluding the sign] of the number]
    */
-  bn_reverse ((unsigned char *)_s, digs);
+  bn_reverse ((unsigned char *)_s, str - _s);
 
   /* append a NULL so the string is properly terminated */
   *str = '\0';


### PR DESCRIPTION
Instead of repeatedly performing big number division by radix, we repeadly perform big number division by the largest power of radix which is <= MP_DIGIT_MAX.

Each remainder (which is an mp_digit) is repeatedly divided by radix, using ordinary integer division.

Since integer division is much faster than mp_div_d, this is a huge speedup.

When radix > sqrt(MP_DIGIT_MAX), the function should be the same speed as the original version.

I have not tested or benchmarked this code, but I know that the basic idea is sound.
