### PR TITLE
Initialize variable "res" to MP_NO.

### DIFF
--- a/bn_mp_prime_next_prime.c
+++ b/bn_mp_prime_next_prime.c
@@ -22,7 +22,7 @@
  */
 int mp_prime_next_prime(mp_int *a, int t, int bbs_style)
 {
-   int      err, res, x, y;
+   int      err, res = MP_NO, x, y;
    mp_digit res_tab[PRIME_SIZE], step, kstep;
    mp_int   b;
 


### PR DESCRIPTION
This avoids an unitialized variable warning in the compiler.

This change originally came from Heimdal's bundled copy of libtommath.

This was originally part of #18 . I'm splitting it into its own pull request for easier review and acceptance.
