### PR TITLE
fix order in mp_radix_size

### DIFF
--- a/bn_mp_radix_size.c
+++ b/bn_mp_radix_size.c
@@ -24,12 +24,6 @@ int mp_radix_size (mp_int * a, int radix, int *size)
 
   *size = 0;
 
-  /* special case for binary */
-  if (radix == 2) {
-    *size = mp_count_bits (a) + (a->sign == MP_NEG ? 1 : 0) + 1;
-    return MP_OKAY;
-  }
-
   /* make sure the radix is in range */
   if (radix < 2 || radix > 64) {
     return MP_VAL;
@@ -37,6 +31,12 @@ int mp_radix_size (mp_int * a, int radix, int *size)
 
   if (mp_iszero(a) == MP_YES) {
     *size = 2;
+    return MP_OKAY;
+  }
+
+  /* special case for binary */
+  if (radix == 2) {
+    *size = mp_count_bits (a) + (a->sign == MP_NEG ? 1 : 0) + 1;
     return MP_OKAY;
   }
 


### PR DESCRIPTION
We are meant to check for zero-ness first.

This fixes: https://github.com/perl6/nqp/issues/181
