### PR TITLE
Fix Mingw x64 configuration

### DIFF
--- a/tommath.h
+++ b/tommath.h
@@ -81,8 +81,13 @@ extern "C" {
    typedef signed long long   long64;
 #endif
 
-   typedef unsigned long long mp_digit;
+#if defined(_WIN32)
+   typedef unsigned long long     mp_digit;
+   typedef unsigned __int128      mp_word;
+#else
+   typedef unsigned long      mp_digit;
    typedef unsigned long      mp_word __attribute__ ((mode(TI)));
+#endif
 
    #define DIGIT_BIT          60
 #else


### PR DESCRIPTION
On Mingw64 long is a 32-bit type even though pointers are 64-bit types, as a result while the library builds OK on Mingw64, the functions return garbage as all the internal logic is messed up.  This patch defines mp_digit and mp_word correctly in this situation.