### PR TITLE
Adding LTM_NO_FILE flag

### DIFF
--- a/tommath.h
+++ b/tommath.h
@@ -577,8 +577,10 @@ int mp_toradix(mp_int *a, char *str, int radix);
 int mp_toradix_n(mp_int * a, char *str, int radix, int maxlen);
 int mp_radix_size(mp_int *a, int radix, int *size);
 
+#ifndef LTM_NO_FILE
 int mp_fread(mp_int *a, int radix, FILE *stream);
 int mp_fwrite(mp_int *a, int radix, FILE *stream);
+#endif
 
 #define mp_read_raw(mp, str, len) mp_read_signed_bin((mp), (str), (len))
 #define mp_raw_size(mp)           mp_signed_bin_size(mp)


### PR DESCRIPTION
Certain embedded implementatino does not have FILE defined, adding
LTM_NO_FILE flag to avoid compiler errors

Signed-off-by: Donald Chan <hoiho.chan@gmail.com>