### PR TITLE
When MP_64BIT and sizeof(int) == 4, mp_rand leaves bits untouched in each digit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
 
 branches:
   only:
+    - master
     - develop
 notifications:
   irc: "chat.freenode.net#libtom"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ compiler:
   - gcc
 
 script:
-  - make
-  - make test
-  - make mtest
-  - ./mtest/mtest 666666 | ./test > test.log
+  - make travis_mtest
   - head -n 5 test.log
   - tail -n 2 test.log
   - ./testme.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build Status](https://travis-ci.org/libtom/libtommath.png?branch=develop)](https://travis-ci.org/libtom/libtommath)
+[![Build Status - master](https://travis-ci.org/libtom/libtommath.png?branch=master)](https://travis-ci.org/libtom/libtommath)
+
+[![Build Status - develop](https://travis-ci.org/libtom/libtommath.png?branch=develop)](https://travis-ci.org/libtom/libtommath)
 
 This is the git repository for [LibTomMath](http://www.libtom.org/), a free open source portable number theoretic multiple-precision integer (MPI) library written entirely in C.
 

--- a/bn_mp_add_d.c
+++ b/bn_mp_add_d.c
@@ -49,9 +49,6 @@ mp_add_d (mp_int * a, mp_digit b, mp_int * c)
   /* old number of used digits in c */
   oldused = c->used;
 
-  /* sign always positive */
-  c->sign = MP_ZPOS;
-
   /* source alias */
   tmpa    = a->dp;
 
@@ -95,6 +92,9 @@ mp_add_d (mp_int * a, mp_digit b, mp_int * c)
       */
      ix       = 1;
   }
+
+  /* sign always positive */
+  c->sign = MP_ZPOS;
 
   /* now zero to oldused */
   while (ix++ < oldused) {

--- a/bn_mp_exptmod_fast.c
+++ b/bn_mp_exptmod_fast.c
@@ -150,15 +150,15 @@ int mp_exptmod_fast (mp_int * G, mp_int * X, mp_int * P, mp_int * Y, int redmode
      if ((err = mp_montgomery_calc_normalization (&res, P)) != MP_OKAY) {
        goto LBL_RES;
      }
-#else 
-     err = MP_VAL;
-     goto LBL_RES;
-#endif
 
      /* now set M[1] to G * R mod m */
      if ((err = mp_mulmod (G, &res, P, &M[1])) != MP_OKAY) {
        goto LBL_RES;
      }
+#else
+     err = MP_VAL;
+     goto LBL_RES;
+#endif
   } else {
      mp_set(&res, 1);
      if ((err = mp_mod(G, P, &M[1])) != MP_OKAY) {

--- a/bn_mp_init_copy.c
+++ b/bn_mp_init_copy.c
@@ -23,7 +23,12 @@ int mp_init_copy (mp_int * a, mp_int * b)
   if ((res = mp_init_size (a, b->used)) != MP_OKAY) {
     return res;
   }
-  return mp_copy (b, a);
+
+  if((res = mp_copy (b, a)) != MP_OKAY) {
+    mp_clear(a);
+  }
+
+  return res;
 }
 #endif
 

--- a/bn_mp_rand.c
+++ b/bn_mp_rand.c
@@ -15,15 +15,28 @@
  * Tom St Denis, tstdenis82@gmail.com, http://libtom.org
  */
 
+#if MP_GEN_RANDOM_MAX == 0xffffffff
+  #define MP_GEN_RANDOM_SHIFT  32
+#elif MP_GEN_RANDOM_MAX == 32767
+  /* SHRT_MAX */
+  #define MP_GEN_RANDOM_SHIFT  15
+#elif MP_GEN_RANDOM_MAX == 2147483647
+  /* INT_MAX */
+  #define MP_GEN_RANDOM_SHIFT  31
+#elif !defined(MP_GEN_RANDOM_SHIFT)
+#error Thou shalt define their own valid MP_GEN_RANDOM_SHIFT
+#endif
+
 /* makes a pseudo-random int of a given size */
 static mp_digit mp_gen_random(void)
 {
-  mp_digit d;
-  d = ((mp_digit) abs (MP_GEN_RANDOM()));
-#if MP_DIGIT_BIT > 32
-  d <<= 32;
-  d |= ((mp_digit) abs (MP_GEN_RANDOM()));
-#endif
+  mp_digit d = 0, msk = 0;
+  do {
+    d <<= MP_GEN_RANDOM_SHIFT;
+    d |= ((mp_digit) MP_GEN_RANDOM());
+    msk <<= MP_GEN_RANDOM_SHIFT;
+    msk |= MP_GEN_RANDOM_MAX;
+  } while ((MP_MASK & msk) != MP_MASK);
   d &= MP_MASK;
   return d;
 }

--- a/bn_mp_rand.c
+++ b/bn_mp_rand.c
@@ -16,6 +16,18 @@
  */
 
 /* makes a pseudo-random int of a given size */
+static mp_digit mp_gen_random(void)
+{
+  mp_digit d;
+  d = ((mp_digit) abs (MP_GEN_RANDOM()));
+#if MP_DIGIT_BIT > 32
+  d <<= 32;
+  d |= ((mp_digit) abs (MP_GEN_RANDOM()));
+#endif
+  d &= MP_MASK;
+  return d;
+}
+
 int
 mp_rand (mp_int * a, int digits)
 {
@@ -29,7 +41,7 @@ mp_rand (mp_int * a, int digits)
 
   /* first place a random non-zero digit */
   do {
-    d = ((mp_digit) abs (MP_GEN_RANDOM())) & MP_MASK;
+    d = mp_gen_random();
   } while (d == 0);
 
   if ((res = mp_add_d (a, d, a)) != MP_OKAY) {
@@ -41,7 +53,7 @@ mp_rand (mp_int * a, int digits)
       return res;
     }
 
-    if ((res = mp_add_d (a, ((mp_digit) abs (MP_GEN_RANDOM())), a)) != MP_OKAY) {
+    if ((res = mp_add_d (a, mp_gen_random(), a)) != MP_OKAY) {
       return res;
     }
   }

--- a/demo/demo.c
+++ b/demo/demo.c
@@ -184,7 +184,9 @@ int main(void)
 
 #if LTM_DEMO_TEST_VS_MTEST == 0
    // trivial stuff
+   // a: 0->5
    mp_set_int(&a, 5);
+   // a: 5-> b: -5
    mp_neg(&a, &b);
    if (mp_cmp(&a, &b) != MP_GT) {
       return EXIT_FAILURE;
@@ -192,16 +194,34 @@ int main(void)
    if (mp_cmp(&b, &a) != MP_LT) {
       return EXIT_FAILURE;
    }
+   // a: 5-> a: -5
    mp_neg(&a, &a);
    if (mp_cmp(&b, &a) != MP_EQ) {
       return EXIT_FAILURE;
    }
+   // a: -5-> b: 5
    mp_abs(&a, &b);
    if (mp_isneg(&b) != MP_NO) {
       return EXIT_FAILURE;
    }
+   // a: -5-> b: -4
    mp_add_d(&a, 1, &b);
+   if (mp_isneg(&b) != MP_YES) {
+      return EXIT_FAILURE;
+   }
+   if (mp_get_int(&b) != 4) {
+      return EXIT_FAILURE;
+   }
+   // a: -5-> b: 1
    mp_add_d(&a, 6, &b);
+   if (mp_get_int(&b) != 1) {
+      return EXIT_FAILURE;
+   }
+   // a: -5-> a: 1
+   mp_add_d(&a, 6, &a);
+   if (mp_get_int(&a) != 1) {
+      return EXIT_FAILURE;
+   }
 
 
    mp_set_int(&a, 0);

--- a/demo/demo.c
+++ b/demo/demo.c
@@ -222,6 +222,12 @@ int main(void)
    if (mp_get_int(&a) != 1) {
       return EXIT_FAILURE;
    }
+   mp_zero(&a);
+   // a: 0-> a: 6
+   mp_add_d(&a, 6, &a);
+   if (mp_get_int(&a) != 6) {
+      return EXIT_FAILURE;
+   }
 
 
    mp_set_int(&a, 0);

--- a/makefile
+++ b/makefile
@@ -96,6 +96,10 @@ test_standalone: $(LIBNAME) demo/demo.o
 mtest:
 	cd mtest ; $(CC) $(CFLAGS) -O0 mtest.c $(LFLAGS) -o mtest
 
+travis_mtest: test mtest
+	@ for i in `seq 1 10` ; do sleep 500 && echo alive; done &
+	./mtest/mtest 666666 | ./test > test.log
+
 timing: $(LIBNAME)
 	$(CC) $(CFLAGS) -DTIMER demo/timing.c $(LIBNAME) $(LFLAGS) -o ltmtest
 

--- a/tommath.h
+++ b/tommath.h
@@ -102,8 +102,10 @@ extern "C" {
 /* use arc4random on platforms that support it */
 #ifdef MP_USE_ALT_RAND
     #define MP_GEN_RANDOM()    arc4random()
+    #define MP_GEN_RANDOM_MAX  0xffffffff
 #else
     #define MP_GEN_RANDOM()    rand()
+    #define MP_GEN_RANDOM_MAX  RAND_MAX
 #endif
 
 #define MP_DIGIT_BIT     DIGIT_BIT


### PR DESCRIPTION

On machines where MP_64BIT is set, sizeof(int) is often still 32-bit, and rand()
returns only 32 random bits.  This leaves 28 bits zeroed in each digit (as DIGIT_BIT ==  60).

This C program will demonstrate the issue:

#include <stdio.h>
#include <stdlib.h>
#include <tommath.h>

$ cat > /tmp/foo.c
void main(void) {

   srandom(time(NULL));
   fprintf(stdout, "%llx %i %i\n",rand(), sizeof(int), DIGIT_BIT);

   mp_int m;
   mp_init(&m);

   mp_rand(&m,10);

   char s[65535];

   mp_tohex(&m, s);

   fprintf(stdout, "%s\n", s);

}
^D
$ gcc -I /home/bri/.local/include/libtommath/ /tmp/foo.c -o /tmp/foo -ltommath
$ /tmp/foo
77426760 4 60
7B62CF7800000006E3339CD000000012E4E3960000000121B7F97000000009274DAA0000000417A629700000001C9CFA06000000032F2D0A600000003F850DC70000000074FAA03

