### PR TITLE
Fix bad detection of 64bit arch on x32

### DIFF
--- a/tommath.h
+++ b/tommath.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /* detect 64-bit mode if possible */
-#if defined(__x86_64__)
+#if defined(__x86_64__) && !defined(__ILP32__)
    #if !(defined(MP_32BIT) || defined(MP_16BIT) || defined(MP_8BIT))
       #define MP_64BIT
    #endif


### PR DESCRIPTION
This commit comes from a [Debian bug 850723](  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850723).

The important part is:

> As for libtommath… its build logs do not show this warning, but
> that may be due to a difference in CFLAGS, and it does not have
> such an extensive testsuite as heimdal, so it might also need to
> have this patch applied (and forwarded upstream).
> 
> A better fix *might* be to fix MP_MASK to read something along
> the lines of shifting 1ULL left, but the cast should already do
> that, so I’m unsure why this doesn’t help. Do note that x32 is
> an ILP32 architecture with 64-bit wide CPU registers (but 32-bit
> pointers and longs), so 64-bit mode “should” work (and fast, at
> that) but can be a bit tricky, and that the patch I attached is
> positively known to fix several issues the heimdal testsuite shows.


This PR is a port of the patch proposed by Thorsten. On my side, I will patch Debian's version of libtommath.

All the best