### PR TITLE
Tcl fixes

### DIFF
--- a/bn_mp_read_radix.c
+++ b/bn_mp_read_radix.c
@@ -71,7 +71,13 @@ int mp_read_radix (mp_int * a, const char *str, int radix)
     }
     ++str;
   }
-  
+
+  /* if an illegal character was found, fail. */
+  if (*str != '\0') {
+      mp_zero(a);
+      return MP_VAL;
+  }
+
   /* set the sign only if a != 0 */
   if (mp_iszero(a) != MP_YES) {
      a->sign = neg;

--- a/bn_mp_read_radix.c
+++ b/bn_mp_read_radix.c
@@ -73,7 +73,7 @@ int mp_read_radix (mp_int * a, const char *str, int radix)
   }
 
   /* if an illegal character was found, fail. */
-  if (*str != '\0') {
+  if (!(*str == '\0' || *str == '\r' || *str == '\n')) {
       mp_zero(a);
       return MP_VAL;
   }

--- a/tommath.h
+++ b/tommath.h
@@ -203,7 +203,7 @@ int mp_init_size(mp_int *a, int size);
 
 /* ---> Basic Manipulations <--- */
 #define mp_iszero(a) (((a)->used == 0) ? MP_YES : MP_NO)
-#define mp_iseven(a) ((((a)->used > 0) && (((a)->dp[0] & 1u) == 0u)) ? MP_YES : MP_NO)
+#define mp_iseven(a) ((((a)->used == 0) || (((a)->dp[0] & 1u) == 0u)) ? MP_YES : MP_NO)
 #define mp_isodd(a)  ((((a)->used > 0) && (((a)->dp[0] & 1u) == 1u)) ? MP_YES : MP_NO)
 #define mp_isneg(a)  (((a)->sign != MP_ZPOS) ? MP_YES : MP_NO)
 


### PR DESCRIPTION
Backport of the fixes on https://github.com/tcltk/tcl

This is only part of the fixes, tcl/tk has as well some changes of `mp_int*` API-parameters to `const mp_int*`. Because it's only a minimal subset of the API I didn't include that as I prefer to go all or nothing :)

@kennykb is it fine for you if I include these patches here? (esp. regarding licensing)

Regarding the `mp_iseven()` patch... that one was in early versions like in this PR and changed by @tomstdenis in v0.22 with the comment

> Fixed a bug in both mp_invmod() and fast_mp_invmod() which tested for odd via "mp_iseven() == 0" which is not valid [since zero is not even either].

I also wasn't sure so I asked the interwebs [[1]](http://www.wolframalpha.com/input/?i=is+0+even+or+odd%3F) [[2]](https://en.wikipedia.org/wiki/Parity_of_zero) and the conclusion is that the original version was correct.