### PR TITLE
cppcheck: va_list 'args' used before va_start() was called

### DIFF
--- a/bn_mp_init_multi.c
+++ b/bn_mp_init_multi.c
@@ -31,9 +31,6 @@ int mp_init_multi(mp_int *mp, ...)
             */
             va_list clean_args;
             
-            /* end the current list */
-            va_end(args);
-            
             /* now start cleaning up */            
             cur_arg = mp;
             va_start(clean_args, mp);


### PR DESCRIPTION
Remove extra va_end on args in loop since it'll be called when breaking