### PR TITLE
Make the build logic more robust for BSD systems

### DIFF
--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -17,15 +17,34 @@ ifndef CROSS_COMPILE
   CROSS_COMPILE=
 endif
 
-ifeq ($(CC),cc)
-  CC = $(CROSS_COMPILE)gcc
+# We only need to go through this dance of determining the right compiler if we're using
+# cross compilation, otherwise $(CC) is fine as-is.
+ifneq (,$(CROSS_COMPILE))
+ifeq ($(origin CC),default)
+CSTR := "\#ifdef __clang__\nCLANG\n\#endif\n"
+ifeq ($(PLATFORM),FreeBSD)
+  # XXX: FreeBSD needs extra escaping for some reason
+  CSTR := $$$(CSTR)
 endif
+ifneq (,$(shell echo $(CSTR) | $(CC) -E - | grep CLANG))
+  CC := $(CROSS_COMPILE)clang
+else
+  CC := $(CROSS_COMPILE)gcc
+endif # Clang
+endif # cc is Make's default
+endif # CROSS_COMPILE non-empty
+
 LD=$(CROSS_COMPILE)ld
 AR=$(CROSS_COMPILE)ar
 RANLIB=$(CROSS_COMPILE)ranlib
 
 ifndef MAKE
-   MAKE=make
+# BSDs refer to GNU Make as gmake
+ifneq (,$(findstring $(PLATFORM),FreeBSD OpenBSD DragonFly NetBSD))
+  MAKE=gmake
+else
+  MAKE=make
+endif
 endif
 
 CFLAGS += -I./ -Wall -Wsign-compare -Wextra -Wshadow
@@ -67,8 +86,14 @@ ifeq ($(PLATFORM), Darwin)
 CFLAGS += -Wno-nullability-completeness
 endif
 
+ifeq ($(PLATFORM),FreeBSD)
+  _ARCH := $(shell sysctl -b hw.machine_arch)
+else
+  _ARCH := $(shell arch)
+endif
+
 # adjust coverage set
-ifneq ($(filter $(shell arch), i386 i686 x86_64 amd64 ia64),)
+ifneq ($(filter $(_ARCH), i386 i686 x86_64 amd64 ia64),)
    COVERAGE = test_standalone timing
    COVERAGE_APP = ./test && ./timing
 else


### PR DESCRIPTION
This properly sets MAKE on BSDs to `gmake` rather than `make`, which refers to the incompatible BSD Make. Further, it betters detection of Clang as the default compiler, which is the case on FreeBSD 11.0+ and OpenBSD 6.0+, and it fixes the unrecognized call to `arch` on FreeBSD.