### PR TITLE
Do not use tommath.h from the system for building

### DIFF
--- a/bn_error.c
+++ b/bn_error.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_ERROR_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_fast_mp_invmod.c
+++ b/bn_fast_mp_invmod.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_FAST_MP_INVMOD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_fast_mp_montgomery_reduce.c
+++ b/bn_fast_mp_montgomery_reduce.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_FAST_MP_MONTGOMERY_REDUCE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_fast_s_mp_mul_digs.c
+++ b/bn_fast_s_mp_mul_digs.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_FAST_S_MP_MUL_DIGS_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_fast_s_mp_mul_high_digs.c
+++ b/bn_fast_s_mp_mul_high_digs.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_FAST_S_MP_MUL_HIGH_DIGS_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_fast_s_mp_sqr.c
+++ b/bn_fast_s_mp_sqr.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_FAST_S_MP_SQR_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_2expt.c
+++ b/bn_mp_2expt.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_2EXPT_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_abs.c
+++ b/bn_mp_abs.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_ABS_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_add.c
+++ b/bn_mp_add.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_ADD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_add_d.c
+++ b/bn_mp_add_d.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_ADD_D_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_addmod.c
+++ b/bn_mp_addmod.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_ADDMOD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_and.c
+++ b/bn_mp_and.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_AND_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_clamp.c
+++ b/bn_mp_clamp.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_CLAMP_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_clear.c
+++ b/bn_mp_clear.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_CLEAR_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_clear_multi.c
+++ b/bn_mp_clear_multi.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_CLEAR_MULTI_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_cmp.c
+++ b/bn_mp_cmp.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_CMP_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_cmp_d.c
+++ b/bn_mp_cmp_d.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_CMP_D_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_cmp_mag.c
+++ b/bn_mp_cmp_mag.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_CMP_MAG_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_cnt_lsb.c
+++ b/bn_mp_cnt_lsb.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_CNT_LSB_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_copy.c
+++ b/bn_mp_copy.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_COPY_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_count_bits.c
+++ b/bn_mp_count_bits.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_COUNT_BITS_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_div.c
+++ b/bn_mp_div.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_DIV_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_div_2.c
+++ b/bn_mp_div_2.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_DIV_2_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_div_2d.c
+++ b/bn_mp_div_2d.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_DIV_2D_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_div_3.c
+++ b/bn_mp_div_3.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_DIV_3_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_div_d.c
+++ b/bn_mp_div_d.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_DIV_D_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_dr_is_modulus.c
+++ b/bn_mp_dr_is_modulus.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_DR_IS_MODULUS_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_dr_reduce.c
+++ b/bn_mp_dr_reduce.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_DR_REDUCE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_dr_setup.c
+++ b/bn_mp_dr_setup.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_DR_SETUP_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_exch.c
+++ b/bn_mp_exch.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_EXCH_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_export.c
+++ b/bn_mp_export.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_EXPORT_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_expt_d.c
+++ b/bn_mp_expt_d.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_EXPT_D_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_expt_d_ex.c
+++ b/bn_mp_expt_d_ex.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_EXPT_D_EX_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_exptmod.c
+++ b/bn_mp_exptmod.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_EXPTMOD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_exptmod_fast.c
+++ b/bn_mp_exptmod_fast.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_EXPTMOD_FAST_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_exteuclid.c
+++ b/bn_mp_exteuclid.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_EXTEUCLID_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_fread.c
+++ b/bn_mp_fread.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_FREAD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_fwrite.c
+++ b/bn_mp_fwrite.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_FWRITE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_gcd.c
+++ b/bn_mp_gcd.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_GCD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_get_int.c
+++ b/bn_mp_get_int.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_GET_INT_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_get_long.c
+++ b/bn_mp_get_long.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_GET_LONG_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_get_long_long.c
+++ b/bn_mp_get_long_long.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_GET_LONG_LONG_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_grow.c
+++ b/bn_mp_grow.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_GROW_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_import.c
+++ b/bn_mp_import.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_IMPORT_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_init.c
+++ b/bn_mp_init.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_INIT_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_init_copy.c
+++ b/bn_mp_init_copy.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_INIT_COPY_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_init_multi.c
+++ b/bn_mp_init_multi.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_INIT_MULTI_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_init_set.c
+++ b/bn_mp_init_set.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_INIT_SET_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_init_set_int.c
+++ b/bn_mp_init_set_int.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_INIT_SET_INT_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_init_size.c
+++ b/bn_mp_init_size.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_INIT_SIZE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_invmod.c
+++ b/bn_mp_invmod.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_INVMOD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_invmod_slow.c
+++ b/bn_mp_invmod_slow.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_INVMOD_SLOW_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_is_square.c
+++ b/bn_mp_is_square.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_IS_SQUARE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_jacobi.c
+++ b/bn_mp_jacobi.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_JACOBI_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_karatsuba_mul.c
+++ b/bn_mp_karatsuba_mul.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_KARATSUBA_MUL_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_karatsuba_sqr.c
+++ b/bn_mp_karatsuba_sqr.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_KARATSUBA_SQR_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_lcm.c
+++ b/bn_mp_lcm.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_LCM_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_lshd.c
+++ b/bn_mp_lshd.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_LSHD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_mod.c
+++ b/bn_mp_mod.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_MOD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_mod_2d.c
+++ b/bn_mp_mod_2d.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_MOD_2D_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_mod_d.c
+++ b/bn_mp_mod_d.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_MOD_D_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_montgomery_calc_normalization.c
+++ b/bn_mp_montgomery_calc_normalization.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_MONTGOMERY_CALC_NORMALIZATION_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_montgomery_reduce.c
+++ b/bn_mp_montgomery_reduce.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_MONTGOMERY_REDUCE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_montgomery_setup.c
+++ b/bn_mp_montgomery_setup.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_MONTGOMERY_SETUP_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_mul.c
+++ b/bn_mp_mul.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_MUL_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_mul_2.c
+++ b/bn_mp_mul_2.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_MUL_2_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_mul_2d.c
+++ b/bn_mp_mul_2d.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_MUL_2D_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_mul_d.c
+++ b/bn_mp_mul_d.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_MUL_D_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_mulmod.c
+++ b/bn_mp_mulmod.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_MULMOD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_n_root.c
+++ b/bn_mp_n_root.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_N_ROOT_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_n_root_ex.c
+++ b/bn_mp_n_root_ex.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_N_ROOT_EX_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_neg.c
+++ b/bn_mp_neg.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_NEG_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_or.c
+++ b/bn_mp_or.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_OR_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_prime_fermat.c
+++ b/bn_mp_prime_fermat.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_PRIME_FERMAT_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_prime_is_divisible.c
+++ b/bn_mp_prime_is_divisible.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_PRIME_IS_DIVISIBLE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_prime_is_prime.c
+++ b/bn_mp_prime_is_prime.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_PRIME_IS_PRIME_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_prime_miller_rabin.c
+++ b/bn_mp_prime_miller_rabin.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_PRIME_MILLER_RABIN_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_prime_next_prime.c
+++ b/bn_mp_prime_next_prime.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_PRIME_NEXT_PRIME_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_prime_rabin_miller_trials.c
+++ b/bn_mp_prime_rabin_miller_trials.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_PRIME_RABIN_MILLER_TRIALS_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_prime_random_ex.c
+++ b/bn_mp_prime_random_ex.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_PRIME_RANDOM_EX_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_radix_size.c
+++ b/bn_mp_radix_size.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_RADIX_SIZE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_radix_smap.c
+++ b/bn_mp_radix_smap.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_RADIX_SMAP_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_rand.c
+++ b/bn_mp_rand.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_RAND_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_read_radix.c
+++ b/bn_mp_read_radix.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_READ_RADIX_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_read_signed_bin.c
+++ b/bn_mp_read_signed_bin.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_READ_SIGNED_BIN_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_read_unsigned_bin.c
+++ b/bn_mp_read_unsigned_bin.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_READ_UNSIGNED_BIN_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_reduce.c
+++ b/bn_mp_reduce.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_REDUCE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_reduce_2k.c
+++ b/bn_mp_reduce_2k.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_REDUCE_2K_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_reduce_2k_l.c
+++ b/bn_mp_reduce_2k_l.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_REDUCE_2K_L_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_reduce_2k_setup.c
+++ b/bn_mp_reduce_2k_setup.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_REDUCE_2K_SETUP_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_reduce_2k_setup_l.c
+++ b/bn_mp_reduce_2k_setup_l.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_REDUCE_2K_SETUP_L_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_reduce_is_2k.c
+++ b/bn_mp_reduce_is_2k.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_REDUCE_IS_2K_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_reduce_is_2k_l.c
+++ b/bn_mp_reduce_is_2k_l.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_REDUCE_IS_2K_L_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_reduce_setup.c
+++ b/bn_mp_reduce_setup.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_REDUCE_SETUP_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_rshd.c
+++ b/bn_mp_rshd.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_RSHD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_set.c
+++ b/bn_mp_set.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_SET_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_set_int.c
+++ b/bn_mp_set_int.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_SET_INT_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_set_long.c
+++ b/bn_mp_set_long.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_SET_LONG_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_set_long_long.c
+++ b/bn_mp_set_long_long.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_SET_LONG_LONG_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_shrink.c
+++ b/bn_mp_shrink.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_SHRINK_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_signed_bin_size.c
+++ b/bn_mp_signed_bin_size.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_SIGNED_BIN_SIZE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_sqr.c
+++ b/bn_mp_sqr.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_SQR_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_sqrmod.c
+++ b/bn_mp_sqrmod.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_SQRMOD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_sqrt.c
+++ b/bn_mp_sqrt.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_SQRT_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_sqrtmod_prime.c
+++ b/bn_mp_sqrtmod_prime.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_SQRTMOD_PRIME_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_sub.c
+++ b/bn_mp_sub.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_SUB_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_sub_d.c
+++ b/bn_mp_sub_d.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_SUB_D_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_submod.c
+++ b/bn_mp_submod.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_SUBMOD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_to_signed_bin.c
+++ b/bn_mp_to_signed_bin.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_TO_SIGNED_BIN_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_to_signed_bin_n.c
+++ b/bn_mp_to_signed_bin_n.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_TO_SIGNED_BIN_N_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_to_unsigned_bin.c
+++ b/bn_mp_to_unsigned_bin.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_TO_UNSIGNED_BIN_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_to_unsigned_bin_n.c
+++ b/bn_mp_to_unsigned_bin_n.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_TO_UNSIGNED_BIN_N_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_toom_mul.c
+++ b/bn_mp_toom_mul.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_TOOM_MUL_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_toom_sqr.c
+++ b/bn_mp_toom_sqr.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_TOOM_SQR_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_toradix.c
+++ b/bn_mp_toradix.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_TORADIX_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_toradix_n.c
+++ b/bn_mp_toradix_n.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_TORADIX_N_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_unsigned_bin_size.c
+++ b/bn_mp_unsigned_bin_size.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_UNSIGNED_BIN_SIZE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_xor.c
+++ b/bn_mp_xor.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_XOR_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_mp_zero.c
+++ b/bn_mp_zero.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_MP_ZERO_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_prime_tab.c
+++ b/bn_prime_tab.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_PRIME_TAB_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_reverse.c
+++ b/bn_reverse.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_REVERSE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_s_mp_add.c
+++ b/bn_s_mp_add.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_S_MP_ADD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_s_mp_exptmod.c
+++ b/bn_s_mp_exptmod.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_S_MP_EXPTMOD_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_s_mp_mul_digs.c
+++ b/bn_s_mp_mul_digs.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_S_MP_MUL_DIGS_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_s_mp_mul_high_digs.c
+++ b/bn_s_mp_mul_high_digs.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_S_MP_MUL_HIGH_DIGS_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_s_mp_sqr.c
+++ b/bn_s_mp_sqr.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_S_MP_SQR_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bn_s_mp_sub.c
+++ b/bn_s_mp_sub.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BN_S_MP_SUB_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/bncore.c
+++ b/bncore.c
@@ -1,4 +1,4 @@
-#include <tommath_private.h>
+#include "tommath_private.h"
 #ifdef BNCORE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis
  *

--- a/dep.pl
+++ b/dep.pl
@@ -120,8 +120,8 @@ print {$class} << 'EOS';
 #   define LTM_LAST
 #endif
 
-#include "tommath_superclass.h"
-#include "tommath_class.h"
+#include <tommath_superclass.h>
+#include <tommath_class.h>
 #else
 #   define LTM_LAST
 #endif

--- a/dep.pl
+++ b/dep.pl
@@ -45,7 +45,7 @@ EOS
       print {$out} $line;
    } else {
       print {$out} << "EOS";
-#include <tommath.h>
+#include "tommath_private.h"
 #ifdef $define
 $line
 EOS
@@ -120,8 +120,8 @@ print {$class} << 'EOS';
 #   define LTM_LAST
 #endif
 
-#include <tommath_superclass.h>
-#include <tommath_class.h>
+#include "tommath_superclass.h"
+#include "tommath_class.h"
 #else
 #   define LTM_LAST
 #endif

--- a/tommath.h
+++ b/tommath.h
@@ -18,7 +18,7 @@
 #include <stdint.h>
 #include <limits.h>
 
-#include <tommath_class.h>
+#include "tommath_class.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/tommath.h
+++ b/tommath.h
@@ -18,7 +18,7 @@
 #include <stdint.h>
 #include <limits.h>
 
-#include "tommath_class.h"
+#include <tommath_class.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -1051,8 +1051,8 @@
 #   define LTM_LAST
 #endif
 
-#include <tommath_superclass.h>
-#include <tommath_class.h>
+#include "tommath_superclass.h"
+#include "tommath_class.h"
 #else
 #   define LTM_LAST
 #endif

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -1051,8 +1051,8 @@
 #   define LTM_LAST
 #endif
 
-#include "tommath_superclass.h"
-#include "tommath_class.h"
+#include <tommath_superclass.h>
+#include <tommath_class.h>
 #else
 #   define LTM_LAST
 #endif

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -13,7 +13,7 @@
 #ifndef TOMMATH_PRIV_H_
 #define TOMMATH_PRIV_H_
 
-#include <tommath.h>
+#include "tommath.h"
 #include <ctype.h>
 
 #ifndef MIN


### PR DESCRIPTION
The source files include `tommath_private.h` globally (with angle brackets ) which itself does include `tommath.h` globally. The first is not much more than a matter of style but the latter can cause problems if the system `tommath.h` is too different from the header in the packet. I had such a problem with my system header which is so old that it does not use `const` which gave `clang` a little hiccup but it missed the definition of the new file I tried to add and which I had put in the local `tommath.h` but not in the system's `tommath.h`.

It is unlikely that it can cause any grave problems but it is easy to change and should not cause any surprising side effects.

Changing the form of inclusion of the `tommath_*class.h` headers caused too much trouble and had to be dropped, hence the two commits.