### PR TITLE
makefile.shared: Respect LIBTOOL.

### DIFF
--- a/makefile.shared
+++ b/makefile.shared
@@ -10,14 +10,14 @@ endif
 include makefile_include.mk
 
 
-ifndef LT
+ifndef LIBTOOL
   ifeq ($(PLATFORM), Darwin)
-    LT:=glibtool
+    LIBTOOL:=glibtool
   else
-    LT:=libtool
+    LIBTOOL:=libtool
   endif
 endif
-LTCOMPILE = $(LT) --mode=compile --tag=CC $(CC)
+LTCOMPILE = $(LIBTOOL) --mode=compile --tag=CC $(CC)
 
 LCOV_ARGS=--directory .libs --directory .
 
@@ -57,32 +57,32 @@ objs: $(OBJECTS)
 LOBJECTS = $(OBJECTS:.o=.lo)
 
 $(LIBNAME):  $(OBJECTS)
-	$(LT) --mode=link --tag=CC $(CC) $(LDFLAGS) $(LOBJECTS) -o $(LIBNAME) -rpath $(LIBPATH) -version-info $(VERSION_SO)
+	$(LIBTOOL) --mode=link --tag=CC $(CC) $(LDFLAGS) $(LOBJECTS) -o $(LIBNAME) -rpath $(LIBPATH) -version-info $(VERSION_SO)
 
 install: $(LIBNAME)
 	install -d $(DESTDIR)$(LIBPATH)
 	install -d $(DESTDIR)$(INCPATH)
-	$(LT) --mode=install install -m 644 $(LIBNAME) $(DESTDIR)$(LIBPATH)/$(LIBNAME)
+	$(LIBTOOL) --mode=install install -m 644 $(LIBNAME) $(DESTDIR)$(LIBPATH)/$(LIBNAME)
 	install -m 644 $(HEADERS_PUB) $(DESTDIR)$(INCPATH)
 	sed -e 's,^prefix=.*,prefix=$(PREFIX),' -e 's,^Version:.*,Version: $(VERSION_PC),' libtommath.pc.in > libtommath.pc
 	install -d $(DESTDIR)$(LIBPATH)/pkgconfig
 	install -m 644 libtommath.pc $(DESTDIR)$(LIBPATH)/pkgconfig/
 
 uninstall:
-	$(LT) --mode=uninstall rm $(DESTDIR)$(LIBPATH)/$(LIBNAME)
+	$(LIBTOOL) --mode=uninstall rm $(DESTDIR)$(LIBPATH)/$(LIBNAME)
 	rm $(HEADERS_PUB:%=$(DESTDIR)$(INCPATH)/%)
 	rm $(DESTDIR)$(LIBPATH)/pkgconfig/libtommath.pc
 
 test: $(LIBNAME) demo/demo.o
 	$(CC) $(CFLAGS) -c demo/demo.c -o demo/demo.o
-	$(LT) --mode=link $(CC) $(LDFLAGS) -o test demo/demo.o $(LIBNAME)
+	$(LIBTOOL) --mode=link $(CC) $(LDFLAGS) -o test demo/demo.o $(LIBNAME)
 
 test_standalone: $(LIBNAME) demo/demo.o
 	$(CC) $(CFLAGS) -c demo/demo.c -o demo/demo.o
-	$(LT) --mode=link $(CC) $(LDFLAGS) -o test demo/demo.o $(LIBNAME)
+	$(LIBTOOL) --mode=link $(CC) $(LDFLAGS) -o test demo/demo.o $(LIBNAME)
 
 mtest:
 	cd mtest ; $(CC) $(CFLAGS) $(LDFLAGS) mtest.c -o mtest
 
 timing: $(LIBNAME) demo/timing.c
-	$(LT) --mode=link $(CC) $(CFLAGS) $(LDFLAGS) -DTIMER demo/timing.c $(LIBNAME) -o timing
+	$(LIBTOOL) --mode=link $(CC) $(CFLAGS) $(LDFLAGS) -DTIMER demo/timing.c $(LIBNAME) -o timing


### PR DESCRIPTION
Hi,

I am using the libtool implementation called slibtool which seems to work just fine with libtommath.

https://git.midipix.org/cgit.cgi/slibtool
https://git.midipix.org/cgit.cgi/slibtool/plain/README

The problem is that the standard way to use slibtool is to export `LIBTOOL` in `MAKEFLAGS`.
```
export MAKEFLAGS='LIBTOOL=slibtool'
```
Which will work with almost all autotools builds. However libtommath doesn't respect this variable and wants `LT` instead.

If the `makefile.shared` can use `LIBTOOL` instead of `LT` this would make it a lot easier for anyone that doesn't want the default libtool.