### PR TITLE
do not use mp_min_u32

### DIFF
--- a/bn_mp_get_int.c
+++ b/bn_mp_get_int.c
@@ -17,7 +17,7 @@
 unsigned long mp_get_int(const mp_int *a)
 {
    int i;
-   mp_min_u32 res;
+   unsigned long res;
 
    if (a->used == 0) {
       return 0;

--- a/bn_mp_get_int.c
+++ b/bn_mp_get_int.c
@@ -17,7 +17,7 @@
 unsigned long mp_get_int(const mp_int *a)
 {
    int i;
-   unsigned long res;
+   unsigned long long res;
 
    if (a->used == 0) {
       return 0;
@@ -34,7 +34,7 @@ unsigned long mp_get_int(const mp_int *a)
    }
 
    /* force result to 32-bits always so it is consistent on non 32-bit platforms */
-   return res & 0xFFFFFFFFUL;
+   return (unsigned long)(res & 0xFFFFFFFFUL);
 }
 #endif
 

--- a/dep.pl
+++ b/dep.pl
@@ -93,7 +93,7 @@ EOS
           $line = $';
           # now $& is the match, we want to skip over LTM keywords like
           # mp_int, mp_word, mp_digit
-          if (!($& eq 'mp_digit') && !($& eq 'mp_word') && !($& eq 'mp_int') && !($& eq 'mp_min_u32')) {
+          if (!($& eq 'mp_digit') && !($& eq 'mp_word') && !($& eq 'mp_int')) {
              my $a = $&;
              $a =~ tr/[a-z]/[A-Z]/;
              $a = 'BN_' . $a . '_C';

--- a/tommath.h
+++ b/tommath.h
@@ -95,9 +95,6 @@ typedef uint64_t             mp_word;
 /* otherwise the bits per digit is calculated automatically from the size of a mp_digit */
 #ifndef DIGIT_BIT
 #   define DIGIT_BIT (((CHAR_BIT * MP_SIZEOF_MP_DIGIT) - 1))  /* bits per digit */
-typedef uint_least32_t mp_min_u32;
-#else
-typedef mp_digit mp_min_u32;
 #endif
 
 #define MP_DIGIT_BIT     DIGIT_BIT


### PR DESCRIPTION
The only place where we use `mp_min_u32` is `mp_get_int` but it is IMO more appropriate to use `unsigned long res` instead so that it matches the function's return type.