### PR TITLE
some linting

### DIFF
--- a/bn_mp_get_bit.c
+++ b/bn_mp_get_bit.c
@@ -45,7 +45,7 @@ int mp_get_bit(const mp_int *a, int b)
    bit = (mp_digit)(1) << (b % DIGIT_BIT);
 
    isset = a->dp[limb] & bit;
-   return (isset != 0) ? MP_YES : MP_NO;
+   return (isset != 0u) ? MP_YES : MP_NO;
 }
 
 #endif

--- a/bn_mp_get_bit.c
+++ b/bn_mp_get_bit.c
@@ -34,7 +34,7 @@ int mp_get_bit(const mp_int *a, int b)
     * otherwise (limb >= a->used) would be true for a = 0
     */
 
-   if (mp_iszero(a)) {
+   if (mp_iszero(a) != MP_NO) {
       return MP_NO;
    }
 

--- a/bn_mp_jacobi.c
+++ b/bn_mp_jacobi.c
@@ -28,7 +28,7 @@ int mp_jacobi(const mp_int *a, const mp_int *n, int *c)
       return MP_VAL;
    }
 
-   return mp_kronecker(a,n,c);
+   return mp_kronecker(a, n, c);
 }
 #endif
 

--- a/bn_mp_kronecker.c
+++ b/bn_mp_kronecker.c
@@ -36,7 +36,7 @@ int mp_kronecker(const mp_int *a, const mp_int *p, int *c)
 
    static const int table[8] = {0, 1, 0, -1, 0, -1, 0, 1};
 
-   if (mp_iszero(p)) {
+   if (mp_iszero(p) != MP_NO) {
       if (a->used == 1 && a->dp[0] == 1u) {
          *c = 1;
          return e;
@@ -46,7 +46,7 @@ int mp_kronecker(const mp_int *a, const mp_int *p, int *c)
       }
    }
 
-   if (mp_iseven(a) && mp_iseven(p)) {
+   if ((mp_iseven(a) != MP_NO) && (mp_iseven(p) != MP_NO)) {
       *c = 0;
       return e;
    }
@@ -81,7 +81,7 @@ int mp_kronecker(const mp_int *a, const mp_int *p, int *c)
    }
 
    for (;;) {
-      if (mp_iszero(&a1)) {
+      if (mp_iszero(&a1) != MP_NO) {
          if (mp_cmp_d(&p1, 1uL) == MP_EQ) {
             *c = k;
             goto LBL_KRON;
@@ -106,12 +106,12 @@ int mp_kronecker(const mp_int *a, const mp_int *p, int *c)
           * a1.dp[0] + 1 cannot overflow because the MSB
           * of the type mp_digit is not set by definition
           */
-         if ((a1.dp[0] + 1u) & p1.dp[0] & 2u) {
+         if (((a1.dp[0] + 1u) & p1.dp[0] & 2u) != 0u) {
             k = -k;
          }
       } else {
          /* compute k = (-1)^((a1-1)*(p1-1)/4) * k */
-         if (a1.dp[0] & p1.dp[0] & 2u) {
+         if ((a1.dp[0] & p1.dp[0] & 2u) != 0u) {
             k = -k;
          }
       }

--- a/bn_mp_kronecker.c
+++ b/bn_mp_kronecker.c
@@ -37,7 +37,7 @@ int mp_kronecker(const mp_int *a, const mp_int *p, int *c)
    static const int table[8] = {0, 1, 0, -1, 0, -1, 0, 1};
 
    if (mp_iszero(p)) {
-      if (a->used == 1 && a->dp[0] == 1) {
+      if (a->used == 1 && a->dp[0] == 1u) {
          *c = 1;
          return e;
       } else {
@@ -66,7 +66,7 @@ int mp_kronecker(const mp_int *a, const mp_int *p, int *c)
    if ((v & 0x1) == 0) {
       k = 1;
    } else {
-      k = table[a->dp[0] & 7];
+      k = table[a->dp[0] & 7u];
    }
 
    if (p1.sign == MP_NEG) {
@@ -82,7 +82,7 @@ int mp_kronecker(const mp_int *a, const mp_int *p, int *c)
 
    for (;;) {
       if (mp_iszero(&a1)) {
-         if (mp_cmp_d(&p1, 1) == MP_EQ) {
+         if (mp_cmp_d(&p1, 1uL) == MP_EQ) {
             *c = k;
             goto LBL_KRON;
          } else {
@@ -97,7 +97,7 @@ int mp_kronecker(const mp_int *a, const mp_int *p, int *c)
       }
 
       if ((v & 0x1) == 1) {
-         k = k * table[p1.dp[0] & 7];
+         k = k * table[p1.dp[0] & 7u];
       }
 
       if (a1.sign == MP_NEG) {
@@ -106,7 +106,7 @@ int mp_kronecker(const mp_int *a, const mp_int *p, int *c)
           * a1.dp[0] + 1 cannot overflow because the MSB
           * of the type mp_digit is not set by definition
           */
-         if ((a1.dp[0] + 1) & p1.dp[0] & 2u) {
+         if ((a1.dp[0] + 1u) & p1.dp[0] & 2u) {
             k = -k;
          }
       } else {

--- a/bn_mp_kronecker.c
+++ b/bn_mp_kronecker.c
@@ -37,7 +37,7 @@ int mp_kronecker(const mp_int *a, const mp_int *p, int *c)
    static const int table[8] = {0, 1, 0, -1, 0, -1, 0, 1};
 
    if (mp_iszero(p) != MP_NO) {
-      if (a->used == 1 && a->dp[0] == 1u) {
+      if ((a->used == 1) && (a->dp[0] == 1u)) {
          *c = 1;
          return e;
       } else {

--- a/bn_mp_kronecker.c
+++ b/bn_mp_kronecker.c
@@ -34,7 +34,7 @@ int mp_kronecker(const mp_int *a, const mp_int *p, int *c)
    int e = MP_OKAY;
    int v, k;
 
-   const int table[8] = {0, 1, 0, -1, 0, -1, 0, 1};
+   static const int table[8] = {0, 1, 0, -1, 0, -1, 0, 1};
 
    if (mp_iszero(p)) {
       if (a->used == 1 && a->dp[0] == 1) {

--- a/bn_mp_kronecker.c
+++ b/bn_mp_kronecker.c
@@ -116,7 +116,7 @@ int mp_kronecker(const mp_int *a, const mp_int *p, int *c)
          }
       }
 
-      if ((e = mp_copy(&a1,&r)) != MP_OKAY) {
+      if ((e = mp_copy(&a1, &r)) != MP_OKAY) {
          goto LBL_KRON;
       }
       r.sign = MP_ZPOS;

--- a/bn_mp_prime_frobenius_underwood.c
+++ b/bn_mp_prime_frobenius_underwood.c
@@ -60,7 +60,7 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
          goto LBL_FU_ERR;
       }
 
-      if ((e = mp_sub_d(&T1z,4,&T1z)) != MP_OKAY) {
+      if ((e = mp_sub_d(&T1z, 4uL, &T1z)) != MP_OKAY) {
          goto LBL_FU_ERR;
       }
 
@@ -96,12 +96,12 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
    }
 
    ap2 = a + 2;
-   if ((e = mp_add_d(N,1u,&Np1z)) != MP_OKAY) {
+   if ((e = mp_add_d(N, 1uL, &Np1z)) != MP_OKAY) {
       goto LBL_FU_ERR;
    }
 
-   mp_set(&sz,1u);
-   mp_set(&tz,2u);
+   mp_set(&sz, 1uL);
+   mp_set(&tz, 2uL);
    length = mp_count_bits(&Np1z);
 
    for (i = length - 2; i >= 0; i--) {

--- a/bn_mp_prime_frobenius_underwood.c
+++ b/bn_mp_prime_frobenius_underwood.c
@@ -180,7 +180,7 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
    if ((e = mp_mod(&T1z,N,&T1z)) != MP_OKAY) {
       goto LBL_FU_ERR;
    }
-   if (mp_iszero(&sz) && (mp_cmp(&tz, &T1z) == MP_EQ)) {
+   if ((mp_iszero(&sz) != MP_NO) && (mp_cmp(&tz, &T1z) == MP_EQ)) {
       *result = MP_YES;
       goto LBL_FU_ERR;
    }

--- a/bn_mp_prime_frobenius_underwood.c
+++ b/bn_mp_prime_frobenius_underwood.c
@@ -48,7 +48,8 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
 
    for (a = 0; a < LTM_FROBENIUS_UNDERWOOD_A; a++) {
       /* TODO: That's ugly! No, really, it is! */
-      if (a==2||a==4||a==7||a==8||a==10||a==14||a==18||a==23||a==26||a==28) {
+      if ((a==2) || (a==4) || (a==7) || (a==8) || (a==10) ||
+          (a==14) || (a==18) || (a==23) || (a==26) || (a==28)) {
          continue;
       }
       /* (32764^2 - 4) < 2^31, no bigint for >MP_8BIT needed) */
@@ -83,7 +84,7 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
       goto LBL_FU_ERR;
    }
    /* Composite if N and (a+4)*(2*a+5) are not coprime */
-   if ((e = mp_set_long(&T1z, (unsigned long)((a+4)*(2*a+5)))) != MP_OKAY) {
+   if ((e = mp_set_long(&T1z, (unsigned long)((a+4)*((2*a)+5)))) != MP_OKAY) {
       goto LBL_FU_ERR;
    }
 
@@ -91,7 +92,7 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
       goto LBL_FU_ERR;
    }
 
-   if (!(T1z.used == 1 && T1z.dp[0] == 1u)) {
+   if (!((T1z.used == 1) && (T1z.dp[0] == 1u))) {
       goto LBL_FU_ERR;
    }
 
@@ -174,7 +175,7 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
       }
    }
 
-   if ((e = mp_set_long(&T1z, (unsigned long)(2 * a + 5))) != MP_OKAY) {
+   if ((e = mp_set_long(&T1z, (unsigned long)((2 * a) + 5))) != MP_OKAY) {
       goto LBL_FU_ERR;
    }
    if ((e = mp_mod(&T1z,N,&T1z)) != MP_OKAY) {

--- a/bn_mp_prime_frobenius_underwood.c
+++ b/bn_mp_prime_frobenius_underwood.c
@@ -38,7 +38,7 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
    mp_int T1z,T2z,Np1z,sz,tz;
 
    int a, ap2, length, i, j, isset;
-   int e = MP_OKAY;
+   int e;
 
    *result = MP_NO;
 

--- a/bn_mp_prime_frobenius_underwood.c
+++ b/bn_mp_prime_frobenius_underwood.c
@@ -35,14 +35,14 @@
 #endif
 int mp_prime_frobenius_underwood(const mp_int *N, int *result)
 {
-   mp_int T1z,T2z,Np1z,sz,tz;
+   mp_int T1z, T2z, Np1z, sz, tz;
 
    int a, ap2, length, i, j, isset;
    int e;
 
    *result = MP_NO;
 
-   if ((e = mp_init_multi(&T1z,&T2z,&Np1z,&sz,&tz, NULL)) != MP_OKAY) {
+   if ((e = mp_init_multi(&T1z, &T2z, &Np1z, &sz, &tz, NULL)) != MP_OKAY) {
       return e;
    }
 
@@ -53,11 +53,11 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
          continue;
       }
       /* (32764^2 - 4) < 2^31, no bigint for >MP_8BIT needed) */
-      if ((e = mp_set_long(&T1z,(unsigned long)a)) != MP_OKAY) {
+      if ((e = mp_set_long(&T1z, (unsigned long)a)) != MP_OKAY) {
          goto LBL_FU_ERR;
       }
 
-      if ((e = mp_sqr(&T1z,&T1z)) != MP_OKAY) {
+      if ((e = mp_sqr(&T1z, &T1z)) != MP_OKAY) {
          goto LBL_FU_ERR;
       }
 
@@ -88,7 +88,7 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
       goto LBL_FU_ERR;
    }
 
-   if ((e = mp_gcd(N,&T1z,&T1z)) != MP_OKAY) {
+   if ((e = mp_gcd(N, &T1z, &T1z)) != MP_OKAY) {
       goto LBL_FU_ERR;
    }
 
@@ -111,16 +111,16 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
        * tz   = ((tz-sz)*(tz+sz))%N;
        * sz   = temp;
        */
-      if ((e = mp_mul_2(&tz,&T2z)) != MP_OKAY) {
+      if ((e = mp_mul_2(&tz, &T2z)) != MP_OKAY) {
          goto LBL_FU_ERR;
       }
 
       /* a = 0 at about 50% of the cases (non-square and odd input) */
       if (a != 0) {
-         if ((e = mp_mul_d(&sz,(mp_digit)a,&T1z)) != MP_OKAY) {
+         if ((e = mp_mul_d(&sz, (mp_digit)a, &T1z)) != MP_OKAY) {
             goto LBL_FU_ERR;
          }
-         if ((e = mp_add(&T1z,&T2z,&T2z)) != MP_OKAY) {
+         if ((e = mp_add(&T1z, &T2z, &T2z)) != MP_OKAY) {
             goto LBL_FU_ERR;
          }
       }
@@ -143,7 +143,7 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
       if ((e = mp_mod(&T1z, N, &sz)) != MP_OKAY) {
          goto LBL_FU_ERR;
       }
-      if ((isset = mp_get_bit(&Np1z,i)) == MP_VAL) {
+      if ((isset = mp_get_bit(&Np1z, i)) == MP_VAL) {
          e = isset;
          goto LBL_FU_ERR;
       }
@@ -154,11 +154,11 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
           *  sz   = temp
           */
          if (a == 0) {
-            if ((e = mp_mul_2(&sz,&T1z)) != MP_OKAY) {
+            if ((e = mp_mul_2(&sz, &T1z)) != MP_OKAY) {
                goto LBL_FU_ERR;
             }
          } else {
-            if ((e = mp_mul_d(&sz, (mp_digit) ap2, &T1z)) != MP_OKAY) {
+            if ((e = mp_mul_d(&sz, (mp_digit)ap2, &T1z)) != MP_OKAY) {
                goto LBL_FU_ERR;
             }
          }
@@ -171,14 +171,14 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
          if ((e = mp_sub(&T2z, &sz, &tz)) != MP_OKAY) {
             goto LBL_FU_ERR;
          }
-         mp_exch(&sz,&T1z);
+         mp_exch(&sz, &T1z);
       }
    }
 
    if ((e = mp_set_long(&T1z, (unsigned long)((2 * a) + 5))) != MP_OKAY) {
       goto LBL_FU_ERR;
    }
-   if ((e = mp_mod(&T1z,N,&T1z)) != MP_OKAY) {
+   if ((e = mp_mod(&T1z, N, &T1z)) != MP_OKAY) {
       goto LBL_FU_ERR;
    }
    if ((mp_iszero(&sz) != MP_NO) && (mp_cmp(&tz, &T1z) == MP_EQ)) {
@@ -187,7 +187,7 @@ int mp_prime_frobenius_underwood(const mp_int *N, int *result)
    }
 
 LBL_FU_ERR:
-   mp_clear_multi(&tz,&sz,&Np1z,&T2z,&T1z, NULL);
+   mp_clear_multi(&tz, &sz, &Np1z, &T2z, &T1z, NULL);
    return e;
 }
 

--- a/bn_mp_prime_is_prime.c
+++ b/bn_mp_prime_is_prime.c
@@ -307,7 +307,7 @@ int mp_prime_is_prime(const mp_int *a, int t, int *result)
          }
 #endif
          /* Ceil, because small numbers have a right to live, too, */
-         len = (int)((fips_rand + DIGIT_BIT) / DIGIT_BIT);
+         len = (((int)fips_rand + DIGIT_BIT) / DIGIT_BIT);
          /*  Unlikely. */
          if (len < 0) {
             ix--;

--- a/bn_mp_prime_is_prime.c
+++ b/bn_mp_prime_is_prime.c
@@ -41,7 +41,7 @@ int mp_prime_is_prime(const mp_int *a, int t, int *result)
    /* Some shortcuts */
    /* N > 3 */
    if (a->used == 1) {
-      if (a->dp[0] == 0u || a->dp[0] == 1u) {
+      if ((a->dp[0] == 0u) || (a->dp[0] == 1u)) {
          *result = 0;
          return MP_OKAY;
       }

--- a/bn_mp_prime_is_prime.c
+++ b/bn_mp_prime_is_prime.c
@@ -197,7 +197,7 @@ int mp_prime_is_prime(const mp_int *a, int t, int *result)
          goto LBL_B;
       }
 
-      if (mp_cmp(a,&b) == MP_LT) {
+      if (mp_cmp(a, &b) == MP_LT) {
          p_max = 12;
       } else {
          /* 0x2be6951adc5b22410a5fd = 3317044064679887385961981 */
@@ -205,7 +205,7 @@ int mp_prime_is_prime(const mp_int *a, int t, int *result)
             goto LBL_B;
          }
 
-         if (mp_cmp(a,&b) == MP_LT) {
+         if (mp_cmp(a, &b) == MP_LT) {
             p_max = 13;
          } else {
             err = MP_VAL;
@@ -224,7 +224,7 @@ int mp_prime_is_prime(const mp_int *a, int t, int *result)
       }
       /* we did bases 2 and 3  already, skip them */
       for (ix = 2; ix < p_max; ix++) {
-         mp_set(&b,ltm_prime_tab[ix]);
+         mp_set(&b, ltm_prime_tab[ix]);
          if ((err = mp_prime_miller_rabin(a, &b, &res)) != MP_OKAY) {
             goto LBL_B;
          }

--- a/bn_mp_prime_is_prime.c
+++ b/bn_mp_prime_is_prime.c
@@ -41,11 +41,11 @@ int mp_prime_is_prime(const mp_int *a, int t, int *result)
    /* Some shortcuts */
    /* N > 3 */
    if (a->used == 1) {
-      if (a->dp[0] == 0 || a->dp[0] == 1) {
+      if (a->dp[0] == 0u || a->dp[0] == 1u) {
          *result = 0;
          return MP_OKAY;
       }
-      if (a->dp[0] == 2) {
+      if (a->dp[0] == 2u) {
          *result = 1;
          return MP_OKAY;
       }
@@ -90,7 +90,7 @@ int mp_prime_is_prime(const mp_int *a, int t, int *result)
    /*
        Run the Miller-Rabin test with base 2 for the BPSW test.
     */
-   if ((err = mp_init_set(&b,2)) != MP_OKAY) {
+   if ((err = mp_init_set(&b, 2uL)) != MP_OKAY) {
       return err;
    }
 
@@ -339,7 +339,7 @@ int mp_prime_is_prime(const mp_int *a, int t, int *result)
          }
 
          /* Although the chance for b <= 3 is miniscule, try again. */
-         if (mp_cmp_d(&b,3) != MP_GT) {
+         if (mp_cmp_d(&b, 3uL) != MP_GT) {
             ix--;
             continue;
          }

--- a/bn_mp_prime_strong_lucas_selfridge.c
+++ b/bn_mp_prime_strong_lucas_selfridge.c
@@ -85,7 +85,7 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
    mp_int Dz, gcd, Np1, Uz, Vz, U2mz, V2mz, Qmz, Q2mz, Qkdz, T1z, T2z, T3z, T4z, Q2kdz;
    /* CZ TODO: Some of them need the full 32 bit, hence the (temporary) exclusion of MP_8BIT */
    int32_t D, Ds, J, sign, P, Q, r, s, u, Nbits;
-   int e = MP_OKAY;
+   int e;
    int isset;
 
    *result = MP_NO;

--- a/bn_mp_prime_strong_lucas_selfridge.c
+++ b/bn_mp_prime_strong_lucas_selfridge.c
@@ -118,7 +118,7 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
       /* if 1 < GCD < N then N is composite with factor "D", and
          Jacobi(D,N) is technically undefined (but often returned
          as zero). */
-      if ((mp_cmp_d(&gcd,1u) == MP_GT) && (mp_cmp(&gcd,a) == MP_LT)) {
+      if ((mp_cmp_d(&gcd, 1uL) == MP_GT) && (mp_cmp(&gcd, a) == MP_LT)) {
          goto LBL_LS_ERR;
       }
       if (Ds < 0) {
@@ -172,7 +172,7 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
       Baillie-PSW test based on the strong Lucas-Selfridge test
       should be more reliable. */
 
-   if ((e = mp_add_d(a,1u,&Np1)) != MP_OKAY) {
+   if ((e = mp_add_d(a, 1uL, &Np1)) != MP_OKAY) {
       goto LBL_LS_ERR;
    }
    s = mp_cnt_lsb(&Np1);
@@ -198,9 +198,9 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
       combined with the previous totals for U and V, using the
       composition formulas for addition of indices. */
 
-   mp_set(&Uz, 1u);    /* U=U_1 */
+   mp_set(&Uz, 1uL);    /* U=U_1 */
    mp_set(&Vz, (mp_digit)P);    /* V=V_1 */
-   mp_set(&U2mz, 1u);  /* U_1 */
+   mp_set(&U2mz, 1uL);  /* U_1 */
    mp_set(&V2mz, (mp_digit)P);  /* V_1 */
 
    if (Q < 0) {
@@ -314,7 +314,7 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
             goto LBL_LS_ERR;
          }
          if ((Uz.sign == MP_NEG) && mp_isodd(&Uz)) {
-            if ((e = mp_sub_d(&Uz,1u,&Uz)) != MP_OKAY) {
+            if ((e = mp_sub_d(&Uz, 1uL, &Uz)) != MP_OKAY) {
                goto LBL_LS_ERR;
             }
          }
@@ -330,7 +330,7 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
             goto LBL_LS_ERR;
          }
          if (Vz.sign == MP_NEG && mp_isodd(&Vz)) {
-            if ((e = mp_sub_d(&Vz,1,&Vz)) != MP_OKAY) {
+            if ((e = mp_sub_d(&Vz, 1uL, &Vz)) != MP_OKAY) {
                goto LBL_LS_ERR;
             }
          }

--- a/bn_mp_prime_strong_lucas_selfridge.c
+++ b/bn_mp_prime_strong_lucas_selfridge.c
@@ -133,7 +133,7 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
       }
       D += 2;
 
-      if (D > INT_MAX - 2) {
+      if (D > (INT_MAX - 2)) {
          e = MP_VAL;
          goto LBL_LS_ERR;
       }

--- a/bn_mp_prime_strong_lucas_selfridge.c
+++ b/bn_mp_prime_strong_lucas_selfridge.c
@@ -109,7 +109,7 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
    for (;;) {
       Ds   = sign * D;
       sign = -sign;
-      if ((e = mp_set_long(&Dz,(unsigned long) D)) != MP_OKAY) {
+      if ((e = mp_set_long(&Dz, (unsigned long)D)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
       if ((e = mp_gcd(a, &Dz, &gcd)) != MP_OKAY) {
@@ -205,14 +205,14 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
 
    if (Q < 0) {
       Q = -Q;
-      if ((e = mp_set_long(&Qmz, (unsigned long) Q)) != MP_OKAY) {
+      if ((e = mp_set_long(&Qmz, (unsigned long)Q)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
       if ((e = mp_mul_2(&Qmz, &Q2mz)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
       /* Initializes calculation of Q^d */
-      if ((e = mp_set_long(&Qkdz, (unsigned long) Q)) != MP_OKAY) {
+      if ((e = mp_set_long(&Qkdz, (unsigned long)Q)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
       Qmz.sign = MP_NEG;
@@ -220,14 +220,14 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
       Qkdz.sign = MP_NEG;
       Q = -Q;
    } else {
-      if ((e = mp_set_long(&Qmz, (unsigned long) Q)) != MP_OKAY) {
+      if ((e = mp_set_long(&Qmz, (unsigned long)Q)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
       if ((e = mp_mul_2(&Qmz, &Q2mz)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
       /* Initializes calculation of Q^d */
-      if ((e = mp_set_long(&Qkdz, (unsigned long) Q)) != MP_OKAY) {
+      if ((e = mp_set_long(&Qkdz, (unsigned long)Q)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
    }
@@ -242,34 +242,34 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
        * V_2m = V_m*V_m - 2*Q^m
        */
 
-      if ((e = mp_mul(&U2mz,&V2mz,&U2mz)) != MP_OKAY) {
+      if ((e = mp_mul(&U2mz, &V2mz, &U2mz)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
-      if ((e = mp_mod(&U2mz,a,&U2mz)) != MP_OKAY) {
+      if ((e = mp_mod(&U2mz, a, &U2mz)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
-      if ((e = mp_sqr(&V2mz,&V2mz)) != MP_OKAY) {
+      if ((e = mp_sqr(&V2mz, &V2mz)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
-      if ((e = mp_sub(&V2mz,&Q2mz,&V2mz)) != MP_OKAY) {
+      if ((e = mp_sub(&V2mz, &Q2mz, &V2mz)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
-      if ((e = mp_mod(&V2mz,a,&V2mz)) != MP_OKAY) {
+      if ((e = mp_mod(&V2mz, a, &V2mz)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
       /* Must calculate powers of Q for use in V_2m, also for Q^d later */
-      if ((e = mp_sqr(&Qmz,&Qmz)) != MP_OKAY) {
+      if ((e = mp_sqr(&Qmz, &Qmz)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
       /* prevents overflow */ /* CZ  still necessary without a fixed prealloc'd mem.? */
-      if ((e = mp_mod(&Qmz,a,&Qmz)) != MP_OKAY) {
+      if ((e = mp_mod(&Qmz, a, &Qmz)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
-      if ((e = mp_mul_2(&Qmz,&Q2mz)) != MP_OKAY) {
+      if ((e = mp_mul_2(&Qmz, &Q2mz)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
 
-      if ((isset = mp_get_bit(&Dz,u)) == MP_VAL) {
+      if ((isset = mp_get_bit(&Dz, u)) == MP_VAL) {
          e = isset;
          goto LBL_LS_ERR;
       }
@@ -282,26 +282,26 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
           * Be careful with division by 2 (mod N)!
           */
 
-         if ((e = mp_mul(&U2mz,&Vz,&T1z)) != MP_OKAY) {
+         if ((e = mp_mul(&U2mz, &Vz, &T1z)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
-         if ((e = mp_mul(&Uz,&V2mz,&T2z)) != MP_OKAY) {
+         if ((e = mp_mul(&Uz, &V2mz, &T2z)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
-         if ((e = mp_mul(&V2mz,&Vz,&T3z)) != MP_OKAY) {
+         if ((e = mp_mul(&V2mz, &Vz, &T3z)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
-         if ((e = mp_mul(&U2mz,&Uz,&T4z)) != MP_OKAY) {
+         if ((e = mp_mul(&U2mz, &Uz, &T4z)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
-         if ((e = s_mp_mul_si(&T4z,(long)Ds,&T4z)) != MP_OKAY) {
+         if ((e = s_mp_mul_si(&T4z, (long)Ds, &T4z)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
-         if ((e = mp_add(&T1z,&T2z,&Uz)) != MP_OKAY) {
+         if ((e = mp_add(&T1z, &T2z, &Uz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
          if (mp_isodd(&Uz) != MP_NO) {
-            if ((e = mp_add(&Uz,a,&Uz)) != MP_OKAY) {
+            if ((e = mp_add(&Uz, a, &Uz)) != MP_OKAY) {
                goto LBL_LS_ERR;
             }
          }
@@ -310,7 +310,7 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
           * Thomas R. Nicely used GMP's mpz_fdiv_q_2exp().
           * But mp_div_2() does not do so, it is truncating instead.
           */
-         if ((e = mp_div_2(&Uz,&Uz)) != MP_OKAY) {
+         if ((e = mp_div_2(&Uz, &Uz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
          if ((Uz.sign == MP_NEG) && (mp_isodd(&Uz) != MP_NO)) {
@@ -318,15 +318,15 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
                goto LBL_LS_ERR;
             }
          }
-         if ((e = mp_add(&T3z,&T4z,&Vz)) != MP_OKAY) {
+         if ((e = mp_add(&T3z, &T4z, &Vz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
          if (mp_isodd(&Vz) != MP_NO) {
-            if ((e = mp_add(&Vz,a,&Vz)) != MP_OKAY) {
+            if ((e = mp_add(&Vz, a, &Vz)) != MP_OKAY) {
                goto LBL_LS_ERR;
             }
          }
-         if ((e = mp_div_2(&Vz,&Vz)) != MP_OKAY) {
+         if ((e = mp_div_2(&Vz, &Vz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
          if ((Vz.sign == MP_NEG) && (mp_isodd(&Vz) != MP_NO)) {
@@ -334,17 +334,17 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
                goto LBL_LS_ERR;
             }
          }
-         if ((e = mp_mod(&Uz,a,&Uz)) != MP_OKAY) {
+         if ((e = mp_mod(&Uz, a, &Uz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
-         if ((e = mp_mod(&Vz,a,&Vz)) != MP_OKAY) {
+         if ((e = mp_mod(&Vz, a, &Vz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
          /* Calculating Q^d for later use */
-         if ((e = mp_mul(&Qkdz,&Qmz,&Qkdz)) != MP_OKAY) {
+         if ((e = mp_mul(&Qkdz, &Qmz, &Qkdz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
-         if ((e = mp_mod(&Qkdz,a,&Qkdz)) != MP_OKAY) {
+         if ((e = mp_mod(&Qkdz, a, &Qkdz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
       }
@@ -369,18 +369,18 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
       Lucas pseudoprime. */
 
    /* Initialize 2*Q^(d*2^r) for V_2m */
-   if ((e = mp_mul_2(&Qkdz,&Q2kdz)) != MP_OKAY) {
+   if ((e = mp_mul_2(&Qkdz, &Q2kdz)) != MP_OKAY) {
       goto LBL_LS_ERR;
    }
 
    for (r = 1; r < s; r++) {
-      if ((e = mp_sqr(&Vz,&Vz)) != MP_OKAY) {
+      if ((e = mp_sqr(&Vz, &Vz)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
-      if ((e = mp_sub(&Vz,&Q2kdz,&Vz)) != MP_OKAY) {
+      if ((e = mp_sub(&Vz, &Q2kdz, &Vz)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
-      if ((e = mp_mod(&Vz,a,&Vz)) != MP_OKAY) {
+      if ((e = mp_mod(&Vz, a, &Vz)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
       if (mp_iszero(&Vz) != MP_NO) {
@@ -389,13 +389,13 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
       }
       /* Calculate Q^{d*2^r} for next r (final iteration irrelevant). */
       if (r < (s - 1)) {
-         if ((e = mp_sqr(&Qkdz,&Qkdz)) != MP_OKAY) {
+         if ((e = mp_sqr(&Qkdz, &Qkdz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
-         if ((e = mp_mod(&Qkdz,a,&Qkdz)) != MP_OKAY) {
+         if ((e = mp_mod(&Qkdz, a, &Qkdz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
-         if ((e = mp_mul_2(&Qkdz,&Q2kdz)) != MP_OKAY) {
+         if ((e = mp_mul_2(&Qkdz, &Q2kdz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
       }

--- a/bn_mp_prime_strong_lucas_selfridge.c
+++ b/bn_mp_prime_strong_lucas_selfridge.c
@@ -300,7 +300,7 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
          if ((e = mp_add(&T1z,&T2z,&Uz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
-         if (mp_isodd(&Uz)) {
+         if (mp_isodd(&Uz) != MP_NO) {
             if ((e = mp_add(&Uz,a,&Uz)) != MP_OKAY) {
                goto LBL_LS_ERR;
             }
@@ -313,7 +313,7 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
          if ((e = mp_div_2(&Uz,&Uz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
-         if ((Uz.sign == MP_NEG) && mp_isodd(&Uz)) {
+         if ((Uz.sign == MP_NEG) && (mp_isodd(&Uz) != MP_NO)) {
             if ((e = mp_sub_d(&Uz, 1uL, &Uz)) != MP_OKAY) {
                goto LBL_LS_ERR;
             }
@@ -321,7 +321,7 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
          if ((e = mp_add(&T3z,&T4z,&Vz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
-         if (mp_isodd(&Vz)) {
+         if (mp_isodd(&Vz) != MP_NO) {
             if ((e = mp_add(&Vz,a,&Vz)) != MP_OKAY) {
                goto LBL_LS_ERR;
             }
@@ -329,7 +329,7 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
          if ((e = mp_div_2(&Vz,&Vz)) != MP_OKAY) {
             goto LBL_LS_ERR;
          }
-         if (Vz.sign == MP_NEG && mp_isodd(&Vz)) {
+         if ((Vz.sign == MP_NEG) && (mp_isodd(&Vz) != MP_NO)) {
             if ((e = mp_sub_d(&Vz, 1uL, &Vz)) != MP_OKAY) {
                goto LBL_LS_ERR;
             }
@@ -352,7 +352,7 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
 
    /* If U_d or V_d is congruent to 0 mod N, then N is a prime or a
       strong Lucas pseudoprime. */
-   if (mp_iszero(&Uz) || mp_iszero(&Vz)) {
+   if ((mp_iszero(&Uz) != MP_NO) || (mp_iszero(&Vz) != MP_NO)) {
       *result = MP_YES;
       goto LBL_LS_ERR;
    }
@@ -383,7 +383,7 @@ int mp_prime_strong_lucas_selfridge(const mp_int *a, int *result)
       if ((e = mp_mod(&Vz,a,&Vz)) != MP_OKAY) {
          goto LBL_LS_ERR;
       }
-      if (mp_iszero(&Vz)) {
+      if (mp_iszero(&Vz) != MP_NO) {
          *result = MP_YES;
          goto LBL_LS_ERR;
       }


### PR DESCRIPTION
after merge of #113 

the following warning at https://github.com/libtom/libtommath/blob/develop/bn_mp_prime_is_prime.c#L338 is not fixed
```
bn_mp_prime_is_prime.c  338  Warning 534: Ignoring return value of function 'mp_div_2d(const mp_int *, int, mp_int *, mp_int *)'
```
