### PR TITLE
Added valgrind tests to testme.sh and travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,133 @@
-language: c
+#############################################################################
+#                                                                           #
+#      Travis-ci test-suite for LibTomMath                                  #
+#      (https://github.com/libtom/libtommath.git)                           #
+#                                                                           #
+#############################################################################
 
-install:
-    - sudo apt-get update -qq
-    - sudo apt-get install gcc-multilib
+# Compilation failures are in gcc_errors_*.log
+# Failed tests in test_*.log
+# Files do not exist in case of success
+after_failure:
+  - cat test_*.log
+  - cat gcc_errors_*.log
 
-matrix:
-  fast_finish: true
+# In case of a Travis error a success might get signaled
+# even without any test run. This file also keeps any notes
+# printed from the tests which might come handy from time
+# to time.
+# Valgrid will print its output to stderr which will not show up
+# in test_*.log. testme.sh accepts one additional option to
+# valgrind and "--valgrind-options=--log-fd=1" sends the output
+# of Valgrind to stdout instead.
+after_success:
+  - cat test_*.log
+
+# Tests restricted to the following branches of LTM.
 branches:
   only:
     - master
     - develop
     - /^release\/.*$/
 
-compiler:
-  - gcc
-  - clang
-script:
-  - ./testme.sh --with-cc=$CC ${BUILDOPTIONS}
-env:
-  - |
-    BUILDOPTIONS="--test-vs-mtest=333333"
-  - |
-    BUILDOPTIONS="--test-vs-mtest=333333 --mtest-real-rand"
-  - |
-    BUILDOPTIONS="--with-low-mp"
-  - |
-    BUILDOPTIONS="--with-m64 --with-m32 --with-mx32"
+# Additional installs are Valgrind for the memory-tests
+# and gcc-multilib for the compilation of the different
+# architectures.
+install:
+  - sudo apt-get update -qq
+  - sudo apt-get install valgrind
+  - sudo apt-get install gcc-multilib
 
-after_failure:
-  - cat test_*.log
-  - cat gcc_errors_*.log
+# The language is C and it will load the respective dependencies
+language: c
 
+# The actual workspace. Will run the individual jobs in parallel
+# which also means that the jobs must be able to run in parallel.
+# Either specify sets which will be combined or, as in this case,
+# specify all builds individually. The number of jobs is currently
+# restricted to 200 jobs at most.
+matrix:
+  # Will mark as finished if all of the remaining tests are allowed to fail
+  # or one test has failed already.
+  fast_finish: true
+
+  # The individual jobs
+  include:
+    # The environment given to the programs in the build
+    # We have only one program and the variable $BUILDOPTIONS
+    # has only the options to that program: testme.sh
+
+    # GCC for the 32-bit architecture (no valgrind yet)
+    - env: BUILDOPTIONS='--with-cc=gcc --with-m32'
+      addons:
+        apt:
+          packages:
+            - libc6-dev-i386
+      sudo: required
+
+    # clang for the 32-bit architecture (no valgrind yet)
+    - env: BUILDOPTIONS='--with-cc=clang --with-m32'
+      addons:
+        apt:
+          packages:
+            - libc6-dev-i386
+      sudo: required
+
+    # GCC for the x64_32 architecture (32-bit longs and 32-bit pointers)
+    # TODO: Probably not possible to run anything in x32 in Travis
+    #       but needs to be checked to be sure.
+    - env: BUILDOPTIONS='--with-cc=gcc --with-mx32'
+      addons:
+        apt:
+          packages:
+            - libc6-dev-x32
+      sudo: required
+
+    # clang for the x64_32 architecture
+    - env:  BUILDOPTIONS='--with-cc=clang --with-mx32'
+      addons:
+        apt:
+          packages:
+            - libc6-dev-x32
+      sudo: required
+
+    # GCC for the x86-64 architecture (64-bit longs and 64-bit pointers)
+    - env:  BUILDOPTIONS='--with-cc=gcc --with-m64 --with-valgrind'
+    # clang for x86-64 architecture (64-bit longs and 64-bit pointers)
+    - env:  BUILDOPTIONS='--with-cc=clang --with-m64 --with-valgrind'
+
+    # GCC for the x86-64 architecture with restricted limb sizes
+    # formerly started with the option "--with-low-mp" to testme.sh
+    # but testing all three in one run took to long and timed out.
+    - env:  BUILDOPTIONS='--with-cc=gcc --cflags=-DMP_8BIT  --with-valgrind'
+    - env:  BUILDOPTIONS='--with-cc=gcc --cflags=-DMP_16BIT --with-valgrind'
+    - env:  BUILDOPTIONS='--with-cc=gcc --cflags=-DMP_32BIT --with-valgrind'
+
+    # clang for the x86-64 architecture with restricted limb sizes
+    - env:  BUILDOPTIONS='--with-cc=clang --cflags=-DMP_8BIT  --with-valgrind'
+    - env:  BUILDOPTIONS='--with-cc=clang --cflags=-DMP_16BIT --with-valgrind'
+    - env:  BUILDOPTIONS='--with-cc=clang --cflags=-DMP_32BIT --with-valgrind'
+
+    # GCC for the x86-64 architecture testing against a different Bigint-implementation
+    # with 333333 different inputs.
+    - env:  BUILDOPTIONS='--with-cc=gcc --test-vs-mtest=333333 --with-valgrind'
+    - env:  BUILDOPTIONS='--with-cc=clang --test-vs-mtest=333333 --with-valgrind'
+
+    # clang for the x86-64 architecture testing against a different Bigint-implementation
+    # with a better random source.
+    - env:  BUILDOPTIONS='--with-cc=gcc --test-vs-mtest=333333 --mtest-real-rand --with-valgrind'
+    - env:  BUILDOPTIONS='--with-cc=clang --test-vs-mtest=333333 --mtest-real-rand --with-valgrind'
+
+# Notifications go to
+# An email address is also possible.
 notifications:
   irc: "chat.freenode.net#libtom-notifications"
+
+# The actual script the jobs run.
+# Because of a default timeout of 10 minutes it was necessary to use
+# a Travis tool to extend that timeout to 40 minutes. 50 minutes
+# seem to be the max and 20 the default if travis_wait is called without
+# any options.
+script:
+  - travis_wait 40 sh -c "./testme.sh  ${BUILDOPTIONS}"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,5 +129,5 @@ notifications:
 # seem to be the max and 20 the default if travis_wait is called without
 # any options.
 script:
-  - travis_wait 40 sh -c "./testme.sh  ${BUILDOPTIONS}"
+  - ./testme.sh  ${BUILDOPTIONS}
 

--- a/testme.sh
+++ b/testme.sh
@@ -269,7 +269,7 @@ then
    for i in `seq 1 10` ; do sleep 500 && echo alive; done &
    alive_pid=$!
    _timeout=""
-   which timeout >/dev/null && _timeout="timeout --foreground 900"
+   which timeout >/dev/null && _timeout="timeout --foreground 1800"
    $_timeout ./mtest/mtest $TEST_VS_MTEST | $VALGRIND_BIN $VALGRIND_OPTS  ./test > test.log
    disown $alive_pid
    kill $alive_pid 2>/dev/null

--- a/testme.sh
+++ b/testme.sh
@@ -226,6 +226,8 @@ do
   shift
 done
 
+[[ "$VALGRIND_BIN" == "" ]] && VALGRIND_OPTS=""
+
 # default to CC environment variable if no compiler is defined but some other options
 if [[ "$COMPILERS" == "" ]] && [[ "$ARCHFLAGS$MAKE_OPTIONS$CFLAGS" != "" ]]
 then
@@ -267,7 +269,7 @@ then
    alive_pid=$!
    _timeout=""
    which timeout >/dev/null && _timeout="timeout --foreground 900"
-   $_TIMEOUT./mtest/mtest $TEST_VS_MTEST |  $VALGRIND_BIN $VALGRIND_OPTS  ./test > test.log
+   $_timeout ./mtest/mtest $TEST_VS_MTEST | $VALGRIND_BIN $VALGRIND_OPTS  ./test > test.log
    disown $alive_pid
    kill $alive_pid 2>/dev/null
    head -n 5 test.log

--- a/testme.sh
+++ b/testme.sh
@@ -226,19 +226,19 @@ do
   shift
 done
 
-# default to gcc if no compiler is defined but some other options
+# default to CC environment variable if no compiler is defined but some other options
 if [[ "$COMPILERS" == "" ]] && [[ "$ARCHFLAGS$MAKE_OPTIONS$CFLAGS" != "" ]]
 then
-   COMPILERS="gcc"
-# default to gcc and run only default config if no option is given
+   COMPILERS="$CC"
+# default to CC environment variable and run only default config if no option is given
 elif [[ "$COMPILERS" == "" ]]
 then
-  _banner gcc
+  _banner "$CC"
   if [[ "$VALGRIND_BIN" != "" ]]
   then
-    _runvalgrind "gcc" ""
+    _runvalgrind "$CC" ""
   else
-    _runtest "gcc" ""
+    _runtest "$CC" ""
   fi
   _exit
 fi

--- a/testme.sh
+++ b/testme.sh
@@ -4,6 +4,7 @@
 #   0  success
 # 128  a test failed
 #  >0  the number of timed-out tests
+# 255  parsing of parameters failed
 
 set -e
 
@@ -202,7 +203,7 @@ do
       if ! [ "$TEST_VS_MTEST" -eq "$TEST_VS_MTEST" ] 2> /dev/null
       then
          echo "--test-vs-mtest Parameter has to be int"
-         exit -1
+         exit 255
       fi
     ;;
     --mtest-real-rand)


### PR DESCRIPTION
It has been hinted at by somebody here, that the integration of a memory checker like e.g.:  [Valgrind](http://valgrind.org/) would be appreciated.

It extends the runtime of the Travis check to about 10 minutes per job.

The Travis-timeout is at 50 minutes per job and the total time is not counted (yet), so the jobs can be split further (e.g.: the low-mp one) to reduce the total runtime but the highest amount of parallel jobs I encountered was 6 (six) and just 4 (four) on average.