### PR TITLE
do not include stdio.h if LTM_NO_FILE is defined

### DIFF
--- a/tommath.h
+++ b/tommath.h
@@ -12,10 +12,13 @@
 #ifndef BN_H_
 #define BN_H_
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <limits.h>
+
+#ifndef LTM_NO_FILE
+#  include <stdio.h>
+#endif
 
 #include "tommath_class.h"
 


### PR DESCRIPTION
stdio.h might not be available on constraint environments