### PR TITLE
remove OPT_CAST

### DIFF
--- a/bn_mp_fwrite.c
+++ b/bn_mp_fwrite.c
@@ -22,7 +22,7 @@ int mp_fwrite(const mp_int *a, int radix, FILE *stream)
       return err;
    }
 
-   buf = OPT_CAST(char) XMALLOC((size_t)len);
+   buf = (char*) XMALLOC((size_t)len);
    if (buf == NULL) {
       return MP_MEM;
    }

--- a/bn_mp_grow.c
+++ b/bn_mp_grow.c
@@ -29,7 +29,7 @@ int mp_grow(mp_int *a, int size)
        * in case the operation failed we don't want
        * to overwrite the dp member of a.
        */
-      tmp = OPT_CAST(mp_digit) XREALLOC(a->dp, sizeof(mp_digit) * (size_t)size);
+      tmp = (mp_digit*) XREALLOC(a->dp, sizeof(mp_digit) * (size_t)size);
       if (tmp == NULL) {
          /* reallocation failed but "a" is still valid [can be freed] */
          return MP_MEM;

--- a/bn_mp_init.c
+++ b/bn_mp_init.c
@@ -18,7 +18,7 @@ int mp_init(mp_int *a)
    int i;
 
    /* allocate memory required and clear it */
-   a->dp = OPT_CAST(mp_digit) XMALLOC(sizeof(mp_digit) * (size_t)MP_PREC);
+   a->dp = (mp_digit*) XMALLOC(sizeof(mp_digit) * (size_t)MP_PREC);
    if (a->dp == NULL) {
       return MP_MEM;
    }

--- a/bn_mp_init_size.c
+++ b/bn_mp_init_size.c
@@ -21,7 +21,7 @@ int mp_init_size(mp_int *a, int size)
    size += (MP_PREC * 2) - (size % MP_PREC);
 
    /* alloc mem */
-   a->dp = OPT_CAST(mp_digit) XMALLOC(sizeof(mp_digit) * (size_t)size);
+   a->dp = (mp_digit*) XMALLOC(sizeof(mp_digit) * (size_t)size);
    if (a->dp == NULL) {
       return MP_MEM;
    }

--- a/bn_mp_prime_random_ex.c
+++ b/bn_mp_prime_random_ex.c
@@ -46,7 +46,7 @@ int mp_prime_random_ex(mp_int *a, int t, int size, int flags, ltm_prime_callback
    bsize = (size>>3) + ((size&7)?1:0);
 
    /* we need a buffer of bsize bytes */
-   tmp = OPT_CAST(unsigned char) XMALLOC((size_t)bsize);
+   tmp = (unsigned char*) XMALLOC((size_t)bsize);
    if (tmp == NULL) {
       return MP_MEM;
    }

--- a/bn_mp_shrink.c
+++ b/bn_mp_shrink.c
@@ -23,7 +23,7 @@ int mp_shrink(mp_int *a)
    }
 
    if (a->alloc != used) {
-      if ((tmp = OPT_CAST(mp_digit) XREALLOC(a->dp, sizeof(mp_digit) * (size_t)used)) == NULL) {
+      if ((tmp = (mp_digit*) XREALLOC(a->dp, sizeof(mp_digit) * (size_t)used)) == NULL) {
          return MP_MEM;
       }
       a->dp    = tmp;

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -24,15 +24,6 @@
 
 #ifdef __cplusplus
 extern "C" {
-
-/* C++ compilers don't like assigning void * to mp_digit * */
-#define OPT_CAST(x) (x *)
-
-#else
-
-/* C on the other hand doesn't care */
-#define OPT_CAST(x)
-
 #endif
 
 /* define heap macros */


### PR DESCRIPTION
The explicit cast does not hurt in C. Furthermore the explicit cast is needed
if tommath is compiled as C with strict warning settings.