### PR TITLE
efficienty enhancements for get/set routimes

### DIFF
--- a/bn_fast_s_mp_sqr.c
+++ b/bn_fast_s_mp_sqr.c
@@ -79,7 +79,7 @@ int fast_s_mp_sqr(const mp_int *a, mp_int *b)
       }
 
       /* store it */
-      W[ix] = _W & MP_MASK;
+      W[ix] = (mp_digit)_W & MP_MASK;
 
       /* make next carry */
       W1 = _W >> (mp_word)DIGIT_BIT;

--- a/bn_mp_get_bit.c
+++ b/bn_mp_get_bit.c
@@ -27,18 +27,8 @@ int mp_get_bit(const mp_int *a, int b)
 
    limb = b / DIGIT_BIT;
 
-   /*
-    * Zero is a special value with the member "used" set to zero.
-    * Needs to be tested before the check for the upper boundary
-    * otherwise (limb >= a->used) would be true for a = 0
-    */
-
-   if (IS_ZERO(a)) {
-      return MP_NO;
-   }
-
    if (limb >= a->used) {
-      return MP_VAL;
+      return MP_NO;
    }
 
    bit = (mp_digit)(1) << (b % DIGIT_BIT);

--- a/bn_mp_get_double.c
+++ b/bn_mp_get_double.c
@@ -20,7 +20,7 @@ double mp_get_double(const mp_int *a)
       fac *= 2.0;
    }
    for (i = a->used; i --> 0;) {
-      d = (d * fac) + (double)DIGIT(a, i);
+      d = (d * fac) + (double)a->dp[i];
    }
    return (a->sign == MP_NEG) ? -d : d;
 }

--- a/bn_mp_get_int.c
+++ b/bn_mp_get_int.c
@@ -15,25 +15,8 @@
 /* get the lower 32-bits of an mp_int */
 unsigned long mp_get_int(const mp_int *a)
 {
-   int i;
-   mp_min_u32 res;
-
-   if (IS_ZERO(a)) {
-      return 0;
-   }
-
-   /* get number of digits of the lsb we have to read */
-   i = MIN(a->used, ((((int)sizeof(unsigned long) * CHAR_BIT) + DIGIT_BIT - 1) / DIGIT_BIT)) - 1;
-
-   /* get most significant digit of result */
-   res = DIGIT(a, i);
-
-   while (--i >= 0) {
-      res = (res << DIGIT_BIT) | DIGIT(a, i);
-   }
-
    /* force result to 32-bits always so it is consistent on non 32-bit platforms */
-   return res & 0xFFFFFFFFUL;
+   return mp_get_long(a) & 0xFFFFFFFFUL;
 }
 #endif
 

--- a/bn_mp_get_long.c
+++ b/bn_mp_get_long.c
@@ -26,11 +26,11 @@ unsigned long mp_get_long(const mp_int *a)
    i = MIN(a->used, ((((int)sizeof(unsigned long) * CHAR_BIT) + DIGIT_BIT - 1) / DIGIT_BIT)) - 1;
 
    /* get most significant digit of result */
-   res = DIGIT(a, i);
+   res = (unsigned long)a->dp[i];
 
-#if (ULONG_MAX != 0xffffffffuL) || (DIGIT_BIT < 32)
+#if (ULONG_MAX != 0xFFFFFFFFUL) || (DIGIT_BIT < 32)
    while (--i >= 0) {
-      res = (res << DIGIT_BIT) | DIGIT(a, i);
+      res = (res << DIGIT_BIT) | (unsigned long)a->dp[i];
    }
 #endif
    return res;

--- a/bn_mp_get_long_long.c
+++ b/bn_mp_get_long_long.c
@@ -26,11 +26,11 @@ unsigned long long mp_get_long_long(const mp_int *a)
    i = MIN(a->used, ((((int)sizeof(unsigned long long) * CHAR_BIT) + DIGIT_BIT - 1) / DIGIT_BIT)) - 1;
 
    /* get most significant digit of result */
-   res = DIGIT(a, i);
+   res = (unsigned long long)a->dp[i];
 
 #if DIGIT_BIT < 64
    while (--i >= 0) {
-      res = (res << DIGIT_BIT) | DIGIT(a, i);
+      res = (res << DIGIT_BIT) | (unsigned long long)a->dp[i];
    }
 #endif
    return res;

--- a/bn_mp_is_square.c
+++ b/bn_mp_is_square.c
@@ -54,7 +54,7 @@ int mp_is_square(const mp_int *arg, int *ret)
    }
 
    /* First check mod 128 (suppose that DIGIT_BIT is at least 7) */
-   if (rem_128[127u & DIGIT(arg, 0)] == (char)1) {
+   if (rem_128[127u & arg->dp[0]] == (char)1) {
       return MP_OKAY;
    }
 

--- a/bn_mp_set_int.c
+++ b/bn_mp_set_int.c
@@ -15,28 +15,7 @@
 /* set a 32-bit const */
 int mp_set_int(mp_int *a, unsigned long b)
 {
-   int     x, res;
-
-   mp_zero(a);
-
-   /* set four bits at a time */
-   for (x = 0; x < 8; x++) {
-      /* shift the number up four bits */
-      if ((res = mp_mul_2d(a, 4, a)) != MP_OKAY) {
-         return res;
-      }
-
-      /* OR in the top four bits of the source */
-      a->dp[0] |= (mp_digit)(b >> 28) & 15uL;
-
-      /* shift the source up to the next four bits */
-      b <<= 4;
-
-      /* ensure that digits are not clamped off */
-      a->used += 1;
-   }
-   mp_clamp(a);
-   return MP_OKAY;
+   return mp_set_long(a, b & 0xFFFFFFFFUL);
 }
 #endif
 

--- a/bn_mp_set_long.c
+++ b/bn_mp_set_long.c
@@ -13,7 +13,24 @@
  */
 
 /* set a platform dependent unsigned long int */
+#if (DIGIT_BIT < 32) || (ULONG_MAX > 0xFFFFFFFFU)
 MP_SET_XLONG(mp_set_long, unsigned long)
+#else
+int func_name (mp_int * a, unsigned long b)
+{
+   int x = 0;
+   int res = mp_grow(a, (CHAR_BIT * sizeof(type) + DIGIT_BIT - 1) / DIGIT_BIT);
+   if (res == MP_OKAY) {
+     mp_zero(a);
+     if (b) {
+        a->dp[x++] = ((mp_digit)b & MP_MASK);
+     }
+     a->used = x;
+   }
+   return res;
+}
+
+#endif
 #endif
 
 /* ref:         $Format:%D$ */

--- a/bn_mp_set_long.c
+++ b/bn_mp_set_long.c
@@ -23,7 +23,7 @@ int mp_set_long(mp_int *a, unsigned long b)
    if (res == MP_OKAY) {
      mp_zero(a);
      if (b) {
-        a->dp[x++] = ((mp_digit)b & MP_MASK);
+        a->dp[x++] = (mp_digit)b;
      }
      a->used = x;
    }

--- a/bn_mp_set_long.c
+++ b/bn_mp_set_long.c
@@ -19,7 +19,7 @@ MP_SET_XLONG(mp_set_long, unsigned long)
 int func_name (mp_int * a, unsigned long b)
 {
    int x = 0;
-   int res = mp_grow(a, (CHAR_BIT * sizeof(type) + DIGIT_BIT - 1) / DIGIT_BIT);
+   int res = mp_grow(a, (CHAR_BIT * sizeof(long) + DIGIT_BIT - 1) / DIGIT_BIT);
    if (res == MP_OKAY) {
      mp_zero(a);
      if (b) {

--- a/bn_mp_set_long.c
+++ b/bn_mp_set_long.c
@@ -13,7 +13,7 @@
  */
 
 /* set a platform dependent unsigned long int */
-#if (DIGIT_BIT < 32) || (ULONG_MAX > 0xFFFFFFFFU)
+#if (ULONG_MAX != 0xFFFFFFFFUL) || (DIGIT_BIT < 32)
 MP_SET_XLONG(mp_set_long, unsigned long)
 #else
 int func_name (mp_int * a, unsigned long b)

--- a/bn_mp_set_long.c
+++ b/bn_mp_set_long.c
@@ -16,10 +16,10 @@
 #if (ULONG_MAX != 0xFFFFFFFFUL) || (DIGIT_BIT < 32)
 MP_SET_XLONG(mp_set_long, unsigned long)
 #else
-int func_name (mp_int * a, unsigned long b)
+int mp_set_long(mp_int *a, unsigned long b)
 {
    int x = 0;
-   int res = mp_grow(a, (CHAR_BIT * sizeof(long) + DIGIT_BIT - 1) / DIGIT_BIT);
+   int res = mp_grow(a, (CHAR_BIT * sizeof(unsigned long) + DIGIT_BIT - 1) / DIGIT_BIT);
    if (res == MP_OKAY) {
      mp_zero(a);
      if (b) {

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -83,36 +83,24 @@ extern const size_t mp_s_rmap_reverse_sz;
 
 /* Fancy macro to set an MPI from another type.
  * There are several things assumed:
- *  x is the counter and unsigned
+ *  x is the counter
  *  a is the pointer to the MPI
  *  b is the original value that should be set in the MPI.
  */
 #define MP_SET_XLONG(func_name, type)                    \
 int func_name (mp_int * a, type b)                       \
 {                                                        \
-  unsigned int  x;                                       \
-  int           res;                                     \
-                                                         \
-  mp_zero (a);                                           \
-                                                         \
-  /* set four bits at a time */                          \
-  for (x = 0; x < (sizeof(type) * 2u); x++) {            \
-    /* shift the number up four bits */                  \
-    if ((res = mp_mul_2d (a, 4, a)) != MP_OKAY) {        \
-      return res;                                        \
-    }                                                    \
-                                                         \
-    /* OR in the top four bits of the source */          \
-    a->dp[0] |= (mp_digit)(b >> ((sizeof(type) * 8u) - 4u)) & 15uL;\
-                                                         \
-    /* shift the source up to the next four bits */      \
-    b <<= 4;                                             \
-                                                         \
-    /* ensure that digits are not clamped off */         \
-    a->used += 1;                                        \
-  }                                                      \
-  mp_clamp (a);                                          \
-  return MP_OKAY;                                        \
+   int x = 0;                                   \
+   int res = mp_grow(a, (CHAR_BIT * sizeof(type) + DIGIT_BIT - 1) / DIGIT_BIT); \
+   if (res == MP_OKAY) {                                 \
+     mp_zero(a);                                         \
+     while (b) {                                         \
+        a->dp[x++] = ((mp_digit)b & MP_MASK);            \
+        b >>= DIGIT_BIT;                                 \
+     }                                                   \
+     a->used = x;                                        \
+   }                                                     \
+   return res;                                           \
 }
 
 #ifdef __cplusplus

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -90,29 +90,16 @@ extern const size_t mp_s_rmap_reverse_sz;
 #define MP_SET_XLONG(func_name, type)                    \
 int func_name (mp_int * a, type b)                       \
 {                                                        \
-  unsigned int  x;                                       \
-  int           res;                                     \
-                                                         \
-  mp_zero (a);                                           \
-                                                         \
-  /* set four bits at a time */                          \
-  for (x = 0; x < (sizeof(type) * 2u); x++) {            \
-    /* shift the number up four bits */                  \
-    if ((res = mp_mul_2d (a, 4, a)) != MP_OKAY) {        \
-      return res;                                        \
-    }                                                    \
-                                                         \
-    /* OR in the top four bits of the source */          \
-    a->dp[0] |= (mp_digit)(b >> ((sizeof(type) * 8u) - 4u)) & 15uL;\
-                                                         \
-    /* shift the source up to the next four bits */      \
-    b <<= 4;                                             \
-                                                         \
-    /* ensure that digits are not clamped off */         \
-    a->used += 1;                                        \
-  }                                                      \
-  mp_clamp (a);                                          \
-  return MP_OKAY;                                        \
+   unsigned int x = 0;                                   \
+   int res = mp_grow(a, (CHAR_BIT * sizeof(type) + DIGIT_BIT - 1) / DIGIT_BIT); \
+   if (res == MP_OKAY) {                                 \
+     while (b) {                                         \
+        a->dp[x++] = ((mp_digit)b & MP_MASK);            \
+        b >>= DIGIT_BIT;                              \
+     }                                                   \
+     a->used = x;                                        \
+   }                                                     \
+   return res;                                           \
 }
 
 #ifdef __cplusplus

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -87,6 +87,23 @@ extern const size_t mp_s_rmap_reverse_sz;
  *  a is the pointer to the MPI
  *  b is the original value that should be set in the MPI.
  */
+#if DIGIT_BIT < 32
+#define MP_SET_XLONG(func_name, type)                    \
+int func_name (mp_int * a, type b)                       \
+{                                                        \
+   int x = 0;                                            \
+   int res = mp_grow(a, (CHAR_BIT * sizeof(type) + DIGIT_BIT - 1) / DIGIT_BIT); \
+   if (res == MP_OKAY) {                                 \
+     mp_zero(a);                                         \
+     while (b) {                                         \
+        a->dp[x++] = ((mp_digit)b & MP_MASK);            \
+        b >>= DIGIT_BIT;                                 \
+     }                                                   \
+     a->used = x;                                        \
+   }                                                     \
+   return res;                                           \
+}
+#else
 #define MP_SET_XLONG(func_name, type)                    \
 int func_name (mp_int * a, type b)                       \
 {                                                        \
@@ -103,6 +120,7 @@ int func_name (mp_int * a, type b)                       \
    }                                                     \
    return res;                                           \
 }
+#endif
 
 #ifdef __cplusplus
 }

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -90,13 +90,14 @@ extern const size_t mp_s_rmap_reverse_sz;
 #define MP_SET_XLONG(func_name, type)                    \
 int func_name (mp_int * a, type b)                       \
 {                                                        \
-   int x = 0;                                   \
+   int x = 0;                                            \
+   mp_digit c = b;                                       \
    int res = mp_grow(a, (CHAR_BIT * sizeof(type) + DIGIT_BIT - 1) / DIGIT_BIT); \
    if (res == MP_OKAY) {                                 \
      mp_zero(a);                                         \
-     while (b) {                                         \
-        a->dp[x++] = ((mp_digit)b & MP_MASK);            \
-        b >>= DIGIT_BIT;                                 \
+     while (c) {                                         \
+        a->dp[x++] = (c & MP_MASK);                      \
+        c >>= DIGIT_BIT;                                 \
      }                                                   \
      a->used = x;                                        \
    }                                                     \

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -90,16 +90,29 @@ extern const size_t mp_s_rmap_reverse_sz;
 #define MP_SET_XLONG(func_name, type)                    \
 int func_name (mp_int * a, type b)                       \
 {                                                        \
-   unsigned int x = 0;                                   \
-   int res = mp_grow(a, (CHAR_BIT * sizeof(type) + DIGIT_BIT - 1) / DIGIT_BIT); \
-   if (res == MP_OKAY) {                                 \
-     while (b) {                                         \
-        a->dp[x++] = ((mp_digit)b & MP_MASK);            \
-        b >>= DIGIT_BIT;                              \
-     }                                                   \
-     a->used = x;                                        \
-   }                                                     \
-   return res;                                           \
+  unsigned int  x;                                       \
+  int           res;                                     \
+                                                         \
+  mp_zero (a);                                           \
+                                                         \
+  /* set four bits at a time */                          \
+  for (x = 0; x < (sizeof(type) * 2u); x++) {            \
+    /* shift the number up four bits */                  \
+    if ((res = mp_mul_2d (a, 4, a)) != MP_OKAY) {        \
+      return res;                                        \
+    }                                                    \
+                                                         \
+    /* OR in the top four bits of the source */          \
+    a->dp[0] |= (mp_digit)(b >> ((sizeof(type) * 8u) - 4u)) & 15uL;\
+                                                         \
+    /* shift the source up to the next four bits */      \
+    b <<= 4;                                             \
+                                                         \
+    /* ensure that digits are not clamped off */         \
+    a->used += 1;                                        \
+  }                                                      \
+  mp_clamp (a);                                          \
+  return MP_OKAY;                                        \
 }
 
 #ifdef __cplusplus

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -87,7 +87,6 @@ extern const size_t mp_s_rmap_reverse_sz;
  *  a is the pointer to the MPI
  *  b is the original value that should be set in the MPI.
  */
-#if DIGIT_BIT < 32
 #define MP_SET_XLONG(func_name, type)                    \
 int func_name (mp_int * a, type b)                       \
 {                                                        \
@@ -103,24 +102,6 @@ int func_name (mp_int * a, type b)                       \
    }                                                     \
    return res;                                           \
 }
-#else
-#define MP_SET_XLONG(func_name, type)                    \
-int func_name (mp_int * a, type b)                       \
-{                                                        \
-   int x = 0;                                            \
-   mp_digit c = b;                                       \
-   int res = mp_grow(a, (CHAR_BIT * sizeof(type) + DIGIT_BIT - 1) / DIGIT_BIT); \
-   if (res == MP_OKAY) {                                 \
-     mp_zero(a);                                         \
-     while (c) {                                         \
-        a->dp[x++] = (c & MP_MASK);                      \
-        c >>= DIGIT_BIT;                                 \
-     }                                                   \
-     a->used = x;                                        \
-   }                                                     \
-   return res;                                           \
-}
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
mp_get_bit() doesnt handle well when limb >= a->used:  It should return 0 in that case, not MP_VAL.

The MP_SET_XLONG() macro is quite inefficient, doing only 4 bits at a time in the loop. I rewrote this macro, handling DIGIT_BIT's at a time in each loop iteration.

Also I would like to add some (unsigned long) or (unsigned long long) casts: The lack of those caused some MSVC warnings in my environment.