### PR TITLE
bug-fix in bn_mp_get_bit.c: handle overflow correctly

### DIFF
--- a/bn_mp_get_bit.c
+++ b/bn_mp_get_bit.c
@@ -27,18 +27,8 @@ int mp_get_bit(const mp_int *a, int b)
 
    limb = b / DIGIT_BIT;
 
-   /*
-    * Zero is a special value with the member "used" set to zero.
-    * Needs to be tested before the check for the upper boundary
-    * otherwise (limb >= a->used) would be true for a = 0
-    */
-
-   if (IS_ZERO(a)) {
-      return MP_NO;
-   }
-
    if (limb >= a->used) {
-      return MP_VAL;
+      return MP_NO;
    }
 
    bit = (mp_digit)(1) << (b % DIGIT_BIT);


### PR DESCRIPTION
Split off from "efficienty enhancements for get/set routines", as a separate issue.