### PR TITLE
allocation functions: pass size to XREALLOC and XFREE

### DIFF
--- a/bn_mp_clear.c
+++ b/bn_mp_clear.c
@@ -25,7 +25,7 @@ void mp_clear(mp_int *a)
       }
 
       /* free ram */
-      XFREE(a->dp);
+      XFREE(a->dp, sizeof (mp_digit) * (size_t)a->alloc);
 
       /* reset members to make debugging easier */
       a->dp    = NULL;

--- a/bn_mp_fwrite.c
+++ b/bn_mp_fwrite.c
@@ -28,18 +28,18 @@ int mp_fwrite(const mp_int *a, int radix, FILE *stream)
    }
 
    if ((err = mp_toradix(a, buf, radix)) != MP_OKAY) {
-      XFREE(buf);
+      XFREE(buf, len);
       return err;
    }
 
    for (x = 0; x < len; x++) {
       if (fputc((int)buf[x], stream) == EOF) {
-         XFREE(buf);
+         XFREE(buf, len);
          return MP_VAL;
       }
    }
 
-   XFREE(buf);
+   XFREE(buf, len);
    return MP_OKAY;
 }
 #endif

--- a/bn_mp_grow.c
+++ b/bn_mp_grow.c
@@ -29,7 +29,9 @@ int mp_grow(mp_int *a, int size)
        * in case the operation failed we don't want
        * to overwrite the dp member of a.
        */
-      tmp = (mp_digit *) XREALLOC(a->dp, (size_t)size * sizeof(mp_digit));
+      tmp = (mp_digit *) XREALLOC(a->dp,
+                                  (size_t)a->alloc * sizeof (mp_digit),
+                                  (size_t)size * sizeof(mp_digit));
       if (tmp == NULL) {
          /* reallocation failed but "a" is still valid [can be freed] */
          return MP_MEM;

--- a/bn_mp_prime_random_ex.c
+++ b/bn_mp_prime_random_ex.c
@@ -123,7 +123,7 @@ int mp_prime_random_ex(mp_int *a, int t, int size, int flags, ltm_prime_callback
 
    err = MP_OKAY;
 error:
-   XFREE(tmp);
+   XFREE(tmp, bsize);
    return err;
 }
 

--- a/bn_mp_shrink.c
+++ b/bn_mp_shrink.c
@@ -23,7 +23,9 @@ int mp_shrink(mp_int *a)
    }
 
    if (a->alloc != used) {
-      if ((tmp = (mp_digit *) XREALLOC(a->dp, (size_t)used * sizeof(mp_digit))) == NULL) {
+      if ((tmp = (mp_digit *) XREALLOC(a->dp,
+                                       (size_t)a->alloc * sizeof (mp_digit),
+                                       (size_t)used * sizeof(mp_digit))) == NULL) {
          return MP_MEM;
       }
       a->dp    = tmp;

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -29,14 +29,14 @@ extern "C" {
 /* define heap macros */
 #ifndef XMALLOC
 /* default to libc stuff */
-#   define XMALLOC   malloc
-#   define XFREE     free
-#   define XREALLOC  realloc
+#   define XMALLOC(size)                   malloc(size)
+#   define XFREE(mem, size)                free(mem)
+#   define XREALLOC(mem, oldsize, newsize) realloc(mem, newsize)
 #else
 /* prototypes for our heap functions */
-extern void *XMALLOC(size_t n);
-extern void *XREALLOC(void *p, size_t n);
-extern void XFREE(void *p);
+extern void *XMALLOC(size_t size);
+extern void *XREALLOC(void *mem, size_t oldsize, size_t newsize);
+extern void XFREE(void *mem, size_t size);
 #endif
 
 /* ---> Basic Manipulations <--- */


### PR DESCRIPTION
This is similar to the signatures of the custom allocation functions provided by GMP.
The allocation sizes are useful if the allocator has no easy way to access the allocation size.