### PR TITLE
Add travis build-job that checks the source-code format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,14 @@ matrix:
     # We have only one program and the variable $BUILDOPTIONS
     # has only the options to that program: testme.sh
 
+    # Check source code format
+    - env: BUILDOPTIONS='--format'
+      addons:
+        apt:
+          packages:
+            - astyle
+      sudo: required
+
     # GCC for the 32-bit architecture (no valgrind yet)
     - env: BUILDOPTIONS='--with-cc=gcc --with-m32'
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@
 #                                                                           #
 #############################################################################
 
+# Run the tests based on Ubuntu 16.04
+dist: xenial
+
 # Compilation failures are in gcc_errors_*.log
 # Failed tests in test_*.log
 # Files do not exist in case of success

--- a/bn_mp_clear.c
+++ b/bn_mp_clear.c
@@ -25,7 +25,7 @@ void mp_clear(mp_int *a)
       }
 
       /* free ram */
-      XFREE(a->dp, sizeof (mp_digit) * (size_t)a->alloc);
+      XFREE(a->dp, sizeof(mp_digit) * (size_t)a->alloc);
 
       /* reset members to make debugging easier */
       a->dp    = NULL;

--- a/bn_mp_decr.c
+++ b/bn_mp_decr.c
@@ -40,9 +40,8 @@ int mp_decr(mp_int *a)
    }
    return mp_sub_d(a, 1uL,a);
 }
-
-
 #endif
-/* ref:         \$Format:\%D$ */
-/* git commit:  \$Format:\%H$ */
-/* commit time: \$Format:\%ai$ */
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/bn_mp_grow.c
+++ b/bn_mp_grow.c
@@ -30,7 +30,7 @@ int mp_grow(mp_int *a, int size)
        * to overwrite the dp member of a.
        */
       tmp = (mp_digit *) XREALLOC(a->dp,
-                                  (size_t)a->alloc * sizeof (mp_digit),
+                                  (size_t)a->alloc * sizeof(mp_digit),
                                   (size_t)size * sizeof(mp_digit));
       if (tmp == NULL) {
          /* reallocation failed but "a" is still valid [can be freed] */

--- a/bn_mp_incr.c
+++ b/bn_mp_incr.c
@@ -35,8 +35,8 @@ int mp_incr(mp_int *a)
    }
    return mp_add_d(a, 1uL,a);
 }
-
 #endif
-/* ref:         \$Format:\%D$ */
-/* git commit:  \$Format:\%H$ */
-/* commit time: \$Format:\%ai$ */
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/bn_mp_iseven.c
+++ b/bn_mp_iseven.c
@@ -9,8 +9,7 @@
  * Michael Fromberger but has been written from scratch with
  * additional optimizations in place.
  *
- * The library is free for all purposes without any express
- * guarantee it works.
+ * SPDX-License-Identifier: Unlicense
  */
 
 int mp_iseven(const mp_int *a)

--- a/bn_mp_isodd.c
+++ b/bn_mp_isodd.c
@@ -9,8 +9,7 @@
  * Michael Fromberger but has been written from scratch with
  * additional optimizations in place.
  *
- * The library is free for all purposes without any express
- * guarantee it works.
+ * SPDX-License-Identifier: Unlicense
  */
 
 int mp_isodd(const mp_int *a)

--- a/bn_mp_shrink.c
+++ b/bn_mp_shrink.c
@@ -24,7 +24,7 @@ int mp_shrink(mp_int *a)
 
    if (a->alloc != used) {
       if ((tmp = (mp_digit *) XREALLOC(a->dp,
-                                       (size_t)a->alloc * sizeof (mp_digit),
+                                       (size_t)a->alloc * sizeof(mp_digit),
                                        (size_t)used * sizeof(mp_digit))) == NULL) {
          return MP_MEM;
       }

--- a/callgraph.txt
+++ b/callgraph.txt
@@ -2416,8 +2416,6 @@ BN_MP_INIT_SET_INT_C
 +--->BN_MP_INIT_C
 +--->BN_MP_SET_INT_C
 |   +--->BN_MP_SET_LONG_C
-|   |   +--->BN_MP_GROW_C
-|   |   +--->BN_MP_ZERO_C
 
 
 BN_MP_INIT_SIZE_C
@@ -2743,8 +2741,6 @@ BN_MP_IS_SQUARE_C
 |   +--->BN_MP_INIT_C
 |   +--->BN_MP_SET_INT_C
 |   |   +--->BN_MP_SET_LONG_C
-|   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_ZERO_C
 +--->BN_MP_MOD_C
 |   +--->BN_MP_INIT_SIZE_C
 |   |   +--->BN_MP_INIT_C
@@ -5659,8 +5655,6 @@ BN_MP_PRIME_FROBENIUS_UNDERWOOD_C
 |   |   |   +--->BN_MP_INIT_C
 |   |   |   +--->BN_MP_SET_INT_C
 |   |   |   |   +--->BN_MP_SET_LONG_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_MOD_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_INIT_C
@@ -7264,8 +7258,6 @@ BN_MP_PRIME_FROBENIUS_UNDERWOOD_C
 |   |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_INIT_C
 |   |   +--->BN_MP_SET_LONG_C
-|   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_MUL_C
 |   |   |   +--->BN_MP_TOOM_MUL_C
 |   |   |   |   +--->BN_MP_INIT_MULTI_C
@@ -7616,8 +7608,6 @@ BN_MP_PRIME_FROBENIUS_UNDERWOOD_C
 |   +--->BN_MP_INIT_C
 |   +--->BN_MP_CLEAR_C
 +--->BN_MP_SET_LONG_C
-|   +--->BN_MP_GROW_C
-|   +--->BN_MP_ZERO_C
 +--->BN_MP_SQR_C
 |   +--->BN_MP_TOOM_SQR_C
 |   |   +--->BN_MP_MOD_2D_C
@@ -7975,8 +7965,6 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   +--->BN_MP_INIT_C
 |   |   +--->BN_MP_SET_INT_C
 |   |   |   +--->BN_MP_SET_LONG_C
-|   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   +--->BN_MP_ZERO_C
 |   +--->BN_MP_MOD_C
 |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_INIT_C
@@ -9579,8 +9567,6 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   +--->BN_MP_INIT_C
 |   |   +--->BN_MP_CLEAR_C
 |   +--->BN_MP_SET_LONG_C
-|   |   +--->BN_MP_GROW_C
-|   |   +--->BN_MP_ZERO_C
 |   +--->BN_MP_SQR_C
 |   |   +--->BN_MP_TOOM_SQR_C
 |   |   |   +--->BN_MP_MOD_2D_C
@@ -9890,8 +9876,6 @@ BN_MP_PRIME_IS_PRIME_C
 |   |   +--->BN_MP_CLAMP_C
 |   +--->BN_MP_INIT_C
 |   +--->BN_MP_SET_LONG_C
-|   |   +--->BN_MP_GROW_C
-|   |   +--->BN_MP_ZERO_C
 |   +--->BN_MP_MUL_C
 |   |   +--->BN_MP_TOOM_MUL_C
 |   |   |   +--->BN_MP_INIT_MULTI_C
@@ -11371,8 +11355,6 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   +--->BN_MP_INIT_SET_INT_C
 |   |   |   +--->BN_MP_SET_INT_C
 |   |   |   |   +--->BN_MP_SET_LONG_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_MOD_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   +--->BN_MP_DIV_C
@@ -12909,8 +12891,6 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   +--->BN_MP_INIT_MULTI_C
 |   |   |   +--->BN_MP_CLEAR_C
 |   |   +--->BN_MP_SET_LONG_C
-|   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_SQR_C
 |   |   |   +--->BN_MP_TOOM_SQR_C
 |   |   |   |   +--->BN_MP_MOD_2D_C
@@ -13200,8 +13180,6 @@ BN_MP_PRIME_NEXT_PRIME_C
 |   |   |   +--->BN_MP_GROW_C
 |   |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_SET_LONG_C
-|   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_MUL_C
 |   |   |   +--->BN_MP_TOOM_MUL_C
 |   |   |   |   +--->BN_MP_INIT_MULTI_C
@@ -13568,8 +13546,6 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   +--->BN_MP_INIT_C
 |   |   |   +--->BN_MP_SET_INT_C
 |   |   |   |   +--->BN_MP_SET_LONG_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_MOD_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_INIT_C
@@ -15172,8 +15148,6 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   +--->BN_MP_INIT_C
 |   |   |   +--->BN_MP_CLEAR_C
 |   |   +--->BN_MP_SET_LONG_C
-|   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_SQR_C
 |   |   |   +--->BN_MP_TOOM_SQR_C
 |   |   |   |   +--->BN_MP_MOD_2D_C
@@ -15483,8 +15457,6 @@ BN_MP_PRIME_RANDOM_EX_C
 |   |   |   +--->BN_MP_CLAMP_C
 |   |   +--->BN_MP_INIT_C
 |   |   +--->BN_MP_SET_LONG_C
-|   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_MUL_C
 |   |   |   +--->BN_MP_TOOM_MUL_C
 |   |   |   |   +--->BN_MP_INIT_MULTI_C
@@ -15874,8 +15846,6 @@ BN_MP_PRIME_STRONG_LUCAS_SELFRIDGE_C
 |   |   |   +--->BN_MP_INIT_C
 |   |   |   +--->BN_MP_SET_INT_C
 |   |   |   |   +--->BN_MP_SET_LONG_C
-|   |   |   |   |   +--->BN_MP_GROW_C
-|   |   |   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_MOD_C
 |   |   |   +--->BN_MP_INIT_SIZE_C
 |   |   |   |   +--->BN_MP_INIT_C
@@ -17478,8 +17448,6 @@ BN_MP_PRIME_STRONG_LUCAS_SELFRIDGE_C
 |   |   |   +--->BN_MP_INIT_C
 |   |   |   +--->BN_MP_CLEAR_C
 |   |   +--->BN_MP_SET_LONG_C
-|   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_ZERO_C
 |   |   +--->BN_MP_SQR_C
 |   |   |   +--->BN_MP_TOOM_SQR_C
 |   |   |   |   +--->BN_MP_MOD_2D_C
@@ -17822,8 +17790,6 @@ BN_MP_PRIME_STRONG_LUCAS_SELFRIDGE_C
 |   +--->BN_MP_CLAMP_C
 +--->BN_MP_INIT_C
 +--->BN_MP_SET_LONG_C
-|   +--->BN_MP_GROW_C
-|   +--->BN_MP_ZERO_C
 +--->BN_MP_MUL_C
 |   +--->BN_MP_TOOM_MUL_C
 |   |   +--->BN_MP_INIT_MULTI_C
@@ -18666,13 +18632,9 @@ BN_MP_SET_DOUBLE_C
 
 BN_MP_SET_INT_C
 +--->BN_MP_SET_LONG_C
-|   +--->BN_MP_GROW_C
-|   +--->BN_MP_ZERO_C
 
 
 BN_MP_SET_LONG_C
-+--->BN_MP_GROW_C
-+--->BN_MP_ZERO_C
 
 
 BN_MP_SET_LONG_LONG_C
@@ -19855,7 +19817,6 @@ BN_MP_SQRTMOD_PRIME_C
 |   +--->BN_MP_CLAMP_C
 +--->BN_MP_SET_INT_C
 |   +--->BN_MP_SET_LONG_C
-|   |   +--->BN_MP_GROW_C
 +--->BN_MP_SQRMOD_C
 |   +--->BN_MP_INIT_C
 |   +--->BN_MP_SQR_C
@@ -20593,8 +20554,6 @@ BN_MP_TC_AND_C
 |   +--->BN_MP_INIT_C
 |   +--->BN_MP_SET_INT_C
 |   |   +--->BN_MP_SET_LONG_C
-|   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_ZERO_C
 +--->BN_MP_MUL_2D_C
 |   +--->BN_MP_COPY_C
 |   |   +--->BN_MP_GROW_C
@@ -20655,8 +20614,6 @@ BN_MP_TC_OR_C
 |   +--->BN_MP_INIT_C
 |   +--->BN_MP_SET_INT_C
 |   |   +--->BN_MP_SET_LONG_C
-|   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_ZERO_C
 +--->BN_MP_MUL_2D_C
 |   +--->BN_MP_COPY_C
 |   |   +--->BN_MP_GROW_C
@@ -20698,8 +20655,6 @@ BN_MP_TC_XOR_C
 |   +--->BN_MP_INIT_C
 |   +--->BN_MP_SET_INT_C
 |   |   +--->BN_MP_SET_LONG_C
-|   |   |   +--->BN_MP_GROW_C
-|   |   |   +--->BN_MP_ZERO_C
 +--->BN_MP_MUL_2D_C
 |   +--->BN_MP_COPY_C
 |   |   +--->BN_MP_GROW_C

--- a/makefile
+++ b/makefile
@@ -156,4 +156,5 @@ perlcritic:
 	perlcritic *.pl doc/*.pl
 
 astyle:
-	astyle --options=astylerc $(OBJECTS:.o=.c) tommath*.h demo/*.c etc/*.c mtest/mtest.c
+	@echo "   * run astyle on all sources"
+	@astyle --options=astylerc --formatted $(OBJECTS:.o=.c) tommath*.h demo/*.c etc/*.c mtest/mtest.c

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -937,8 +937,6 @@
 #endif
 
 #if defined(BN_MP_SET_LONG_C)
-#   define BN_MP_GROW_C
-#   define BN_MP_ZERO_C
 #endif
 
 #if defined(BN_MP_SET_LONG_LONG_C)


### PR DESCRIPTION
This adds a new `--format` option to `testme.sh` which runs all the source-code format checkers and the generators of `callgraph.txt` and `tommath_class.h` and adds a travis job which runs this.

This also fixes all the issues found in the current develop branch.