### PR TITLE
Better interoperability between MSVC and mingw-w64

### DIFF
--- a/tommath.h
+++ b/tommath.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /* MS Visual C++ doesn't have a 128bit type for words, so fall back to 32bit MPI's (where words are 64bit) */
-#if defined(_MSC_VER) || defined(__LLP64__) || defined(__e2k__) || defined(__LCC__)
+#if (defined(_WIN32) || defined(__LLP64__) || defined(__e2k__) || defined(__LCC__)) && !defined(MP_64BIT)
 #   define MP_32BIT
 #endif
 
@@ -38,7 +38,7 @@ extern "C" {
     defined(__sparcv9) || defined(__sparc_v9__) || defined(__sparc64__) || \
     defined(__ia64) || defined(__ia64__) || defined(__itanium__) || defined(_M_IA64) || \
     defined(__LP64__) || defined(_LP64) || defined(__64BIT__)
-#   if !(defined(MP_32BIT) || defined(MP_16BIT) || defined(MP_8BIT))
+#   if !(defined(MP_64BIT) || defined(MP_32BIT) || defined(MP_16BIT) || defined(MP_8BIT))
 #      if defined(__GNUC__)
 /* we support 128bit integers only via: __attribute__((mode(TI))) */
 #         define MP_64BIT


### PR DESCRIPTION
The decision whether to compile with MP_64BIT or MP_32BIT mode should not be dependent on the compiler but on the platform. For example, it should be possible to compile libtommath as a dll, using mingw-w64, but then using that dll in a MSVC application. Currently mingw-w64 uses MP_64BIT as default, but MSVC only operates in MP_32BIT. So they cannot co-operate.

Therefore I propose to make MP_32BIT the default on mingw-w64 too, but make it overridable setting -DMP_64BIT explicitly. This way, applications or dll's compiled with MSVC or mingw-w64 can always operate together, no matter which module/application was compiled with which compiler.

The same change (I suppose) should be made in libtomcrypt as well.