### PR TITLE
more linting

### DIFF
--- a/bn_mp_ilogb.c
+++ b/bn_mp_ilogb.c
@@ -145,7 +145,7 @@ int mp_ilogb(mp_int *a, mp_digit base, mp_int *c)
          err = MP_VAL;
          goto LBL_ERR;
       }
-      if ((err = mp_expt_d(&bi_base, (mid - low), &t)) != MP_OKAY) {
+      if ((err = mp_expt_d(&bi_base, (mp_digit)(mid - low), &t)) != MP_OKAY) {
          goto LBL_ERR;
       }
       if ((err = mp_mul(&bracket_low, &t, &bracket_mid)) != MP_OKAY) {

--- a/bn_mp_ilogb.c
+++ b/bn_mp_ilogb.c
@@ -87,23 +87,25 @@ int mp_ilogb(mp_int *a, mp_digit base, mp_int *c)
 
    if (base < 2u) {
       return MP_VAL;
-   } else if (base == 2u) {
+   }
+   if (base == 2u) {
       cmp = mp_count_bits(a) - 1;
       mp_set_int(c, (unsigned long)cmp);
       return err;
-   } else if (a->used == 1) {
+   }
+   if (a->used == 1) {
       tmp = s_digit_ilogb(base, a->dp[0]);
       mp_set(c, tmp);
       return err;
    }
-
 
    cmp = mp_cmp_d(a, base);
 
    if (cmp == MP_LT) {
       mp_zero(c);
       return err;
-   } else if (cmp == MP_EQ) {
+   }
+   if (cmp == MP_EQ) {
       mp_set(c, (mp_digit)1uL);
       return err;
    }

--- a/bn_mp_ilogb.c
+++ b/bn_mp_ilogb.c
@@ -8,7 +8,7 @@ static mp_word s_pow(mp_word base, mp_word exponent)
 {
    mp_word result = 1uLL;
    while (exponent != 0u) {
-      if ((exponent & 0x1) == 1) {
+      if ((exponent & 1u) == 1u) {
          result *= base;
       }
       exponent >>= 1;
@@ -85,9 +85,9 @@ int mp_ilogb(mp_int *a, mp_digit base, mp_int *c)
       return MP_VAL;
    }
 
-   if (base < 2) {
+   if (base < 2u) {
       return MP_VAL;
-   } else if (base == 2) {
+   } else if (base == 2u) {
       cmp = mp_count_bits(a) - 1;
       mp_set_int(c, (unsigned long)cmp);
       return err;
@@ -114,9 +114,9 @@ int mp_ilogb(mp_int *a, mp_digit base, mp_int *c)
       return err;
    }
 
-   low = 0uL;
+   low = 0u;
    mp_set(&bracket_low, 1uL);
-   high = 1uL;
+   high = 1u;
 
    mp_set(&bracket_high, base);
 
@@ -138,7 +138,7 @@ int mp_ilogb(mp_int *a, mp_digit base, mp_int *c)
    }
    mp_set(&bi_base, base);
 
-   while ((high - low) > 1) {
+   while ((high - low) > 1u) {
       mid = (high + low) >> 1;
       /* Difference can be larger then the type behind mp_digit can hold */
       if ((mid - low) > (unsigned int)(MP_MASK)) {

--- a/bn_mp_ilogb.c
+++ b/bn_mp_ilogb.c
@@ -7,7 +7,7 @@
 static mp_word s_pow(mp_word base, mp_word exponent)
 {
    mp_word result = 1uLL;
-   while (exponent) {
+   while (exponent != 0u) {
       if ((exponent & 0x1) == 1) {
          result *= base;
       }


### PR DESCRIPTION
after merge of #191

the return value of `mp_set_int` is never checked in this new file `bn_mp_ilogb.c`

```
      mp_set_int(c, (unsigned long)cmp);
bn_mp_ilogb.c  93  Warning 534: Ignoring return value of function 'mp_set_int(mp_int *, unsigned long)' (compare with line 200, file tommath.h, module bn_error.c) [MISRA 2012 Directive 4.7, required], [MISRA 2012 Rule 17.7, required]

         mp_set_int(c, (unsigned long)mid);
bn_mp_ilogb.c  166  Warning 534: Ignoring return value of function 'mp_set_int(mp_int *, unsigned long)' (compare with line 200, file tommath.h, module bn_error.c) [MISRA 2012 Directive 4.7, required], [MISRA 2012 Rule 17.7, required]

      mp_set_int(c, (unsigned long)high);
bn_mp_ilogb.c  172  Warning 534: Ignoring return value of function 'mp_set_int(mp_int *, unsigned long)' (compare with line 200, file tommath.h, module bn_error.c) [MISRA 2012 Directive 4.7, required], [MISRA 2012 Rule 17.7, required]

      mp_set_int(c, (unsigned long)low);
bn_mp_ilogb.c  174  Warning 534: Ignoring return value of function 'mp_set_int(mp_int *, unsigned long)' (compare with line 200, file tommath.h, module bn_error.c) [MISRA 2012 Directive 4.7, required], [MISRA 2012 Rule 17.7, required]
```