### PR TITLE
No grow necessary in mp_set_int* functions

### DIFF
--- a/bn_mp_grow.c
+++ b/bn_mp_grow.c
@@ -11,8 +11,8 @@ int mp_grow(mp_int *a, int size)
 
    /* if the alloc size is smaller alloc more ram */
    if (a->alloc < size) {
-      /* ensure there are always at least MP_PREC digits extra on top */
-      size += ((MP_PREC * 2) - 1) - ((size + (MP_PREC - 1)) % MP_PREC);
+      /* round up to a multiple of MP_PREC */
+      size += (MP_PREC - 1) - ((size + (MP_PREC - 1)) % MP_PREC);
 
       /* reallocate the array a->dp
        *

--- a/bn_mp_grow.c
+++ b/bn_mp_grow.c
@@ -12,7 +12,7 @@ int mp_grow(mp_int *a, int size)
    /* if the alloc size is smaller alloc more ram */
    if (a->alloc < size) {
       /* ensure there are always at least MP_PREC digits extra on top */
-      size += (MP_PREC * 2) - (size % MP_PREC);
+      size += ((MP_PREC * 2) - 1) - ((size + (MP_PREC - 1)) % MP_PREC);
 
       /* reallocate the array a->dp
        *

--- a/bn_mp_init.c
+++ b/bn_mp_init.c
@@ -7,7 +7,7 @@
 int mp_init(mp_int *a)
 {
    /* allocate memory required and clear it */
-   a->dp = (mp_digit *) MP_CALLOC((size_t)MP_PREC, sizeof(mp_digit));
+   a->dp = (mp_digit *) MP_CALLOC((size_t)MP_MIN_REC, sizeof(mp_digit));
    if (a->dp == NULL) {
       return MP_MEM;
    }
@@ -15,7 +15,7 @@ int mp_init(mp_int *a)
    /* set the used to zero, allocated digits to the default precision
     * and sign to positive */
    a->used  = 0;
-   a->alloc = MP_PREC;
+   a->alloc = MP_MIN_PREC;
    a->sign  = MP_ZPOS;
 
    return MP_OKAY;

--- a/bn_mp_init.c
+++ b/bn_mp_init.c
@@ -7,7 +7,7 @@
 int mp_init(mp_int *a)
 {
    /* allocate memory required and clear it */
-   a->dp = (mp_digit *) MP_CALLOC((size_t)MP_MIN_REC, sizeof(mp_digit));
+   a->dp = (mp_digit *) MP_CALLOC((size_t)MP_MIN_PREC, sizeof(mp_digit));
    if (a->dp == NULL) {
       return MP_MEM;
    }

--- a/bn_mp_init_size.c
+++ b/bn_mp_init_size.c
@@ -6,9 +6,12 @@
 /* init an mp_init for a given size */
 int mp_init_size(mp_int *a, int size)
 {
-   /* ensure there are always at least MP_PREC digits extra on top */
-   size += (MP_MIN_PREC + MP_PREC - 1) - ((size + (MP_PREC - 1)) % MP_PREC);
+   /* round up to a multiple of MP_PREC */
+   size += (MP_PREC - 1) - ((size + (MP_PREC - 1)) % MP_PREC);
 
+   if (size < MP_MIN_PREC) {
+      size = MP_MIN_PREC;
+   }
    /* alloc mem */
    a->dp = (mp_digit *) MP_CALLOC((size_t)size, sizeof(mp_digit));
    if (a->dp == NULL) {

--- a/bn_mp_init_size.c
+++ b/bn_mp_init_size.c
@@ -7,7 +7,7 @@
 int mp_init_size(mp_int *a, int size)
 {
    /* ensure there are always at least MP_PREC digits extra on top */
-   size += ((MP_PREC * 2) - 1) - ((size + (MP_PREC - 1)) % MP_PREC);
+   size += (MP_MIN_PREC + MP_PREC - 1) - ((size + (MP_PREC - 1)) % MP_PREC);
 
    /* alloc mem */
    a->dp = (mp_digit *) MP_CALLOC((size_t)size, sizeof(mp_digit));

--- a/bn_mp_init_size.c
+++ b/bn_mp_init_size.c
@@ -6,8 +6,8 @@
 /* init an mp_init for a given size */
 int mp_init_size(mp_int *a, int size)
 {
-   /* pad size so there are always extra digits */
-   size += (MP_PREC * 2) - (size % MP_PREC);
+   /* ensure there are always at least MP_PREC digits extra on top */
+   size += ((MP_PREC * 2) - 1) - ((size + (MP_PREC - 1)) % MP_PREC);
 
    /* alloc mem */
    a->dp = (mp_digit *) MP_CALLOC((size_t)size, sizeof(mp_digit));

--- a/bn_mp_shrink.c
+++ b/bn_mp_shrink.c
@@ -7,9 +7,9 @@
 int mp_shrink(mp_int *a)
 {
    mp_digit *tmp;
-   int alloc = MP_PREC;
+   int alloc = MP_MIN_PREC;
 
-   if (a->used > MP_PREC) {
+   if (a->used > MP_MIN_PREC) {
       alloc = a->used;
       alloc += (MP_PREC - 1) - ((alloc + (MP_PREC - 1)) % MP_PREC);
    }

--- a/bn_mp_shrink.c
+++ b/bn_mp_shrink.c
@@ -7,20 +7,21 @@
 int mp_shrink(mp_int *a)
 {
    mp_digit *tmp;
-   int used = 1;
+   int alloc = MP_PREC;
 
-   if (a->used > 0) {
-      used = a->used;
+   if (a->used > MP_PREC) {
+      alloc = a->used;
+      alloc += (MP_PREC - 1) - ((alloc + (MP_PREC - 1)) % MP_PREC);
    }
 
-   if (a->alloc != used) {
+   if (a->alloc != alloc) {
       if ((tmp = (mp_digit *) MP_REALLOC(a->dp,
                                          (size_t)a->alloc * sizeof(mp_digit),
-                                         (size_t)used * sizeof(mp_digit))) == NULL) {
+                                         (size_t)alloc * sizeof(mp_digit))) == NULL) {
          return MP_MEM;
       }
       a->dp    = tmp;
-      a->alloc = used;
+      a->alloc = alloc;
    }
    return MP_OKAY;
 }

--- a/tommath.h
+++ b/tommath.h
@@ -131,6 +131,8 @@ extern int KARATSUBA_MUL_CUTOFF,
 #ifndef MP_PREC
 #   ifndef MP_LOW_MEM
 #      define MP_PREC 32        /* default digits of precision */
+#   elif defined(MP_8BIT)
+#      define MP_PREC 16        /* default digits of precision */
 #   else
 #      define MP_PREC 8         /* default digits of precision */
 #   endif

--- a/tommath.h
+++ b/tommath.h
@@ -138,7 +138,7 @@ extern int KARATSUBA_MUL_CUTOFF,
 #   endif
 #endif
 
-#define MP_MIN_PREC ((((CHAR_BIT * sizeof(long long))/DIGIT_BIT) + MP_PREC - 1) / MP_PREC)
+#define MP_MIN_PREC ((((CHAR_BIT * (int)sizeof(long long))/DIGIT_BIT) + MP_PREC - 1) / MP_PREC)
 
 /* size of comba arrays, should be at least 2 * 2**(BITS_PER_WORD - BITS_PER_DIGIT*2) */
 #define MP_WARRAY               (1u << (((CHAR_BIT * sizeof(mp_word)) - (2 * DIGIT_BIT)) + 1))

--- a/tommath.h
+++ b/tommath.h
@@ -138,6 +138,8 @@ extern int KARATSUBA_MUL_CUTOFF,
 #   endif
 #endif
 
+#define MP_MIN_PREC ((((CHAR_BIT * sizeof(long long))/DIGIT_BIT) + MP_PREC - 1) / MP_PREC)
+
 /* size of comba arrays, should be at least 2 * 2**(BITS_PER_WORD - BITS_PER_DIGIT*2) */
 #define MP_WARRAY               (1u << (((CHAR_BIT * sizeof(mp_word)) - (2 * DIGIT_BIT)) + 1))
 

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -76,18 +76,14 @@ extern const size_t mp_s_rmap_reverse_sz;
 int func_name (mp_int * a, type b)                       \
 {                                                        \
    int x = 0;                                            \
-   int new_size = (((CHAR_BIT * sizeof(type)) + DIGIT_BIT) - 1) / DIGIT_BIT; \
-   int res = mp_grow(a, new_size);                       \
-   if (res == MP_OKAY) {                                 \
-     mp_zero(a);                                         \
-     while (b != 0u) {                                   \
-        a->dp[x++] = ((mp_digit)b & MP_MASK);            \
-        if ((CHAR_BIT * sizeof (b)) <= DIGIT_BIT) { break; } \
-        b >>= (((CHAR_BIT * sizeof (b)) <= DIGIT_BIT) ? 0 : DIGIT_BIT); \
-     }                                                   \
-     a->used = x;                                        \
+   mp_zero(a);                                           \
+   while (b != 0u) {                                     \
+      a->dp[x++] = ((mp_digit)b & MP_MASK);              \
+      if ((CHAR_BIT * sizeof (b)) <= DIGIT_BIT) { break; } \
+      b >>= (((CHAR_BIT * sizeof (b)) <= DIGIT_BIT) ? 0 : DIGIT_BIT); \
    }                                                     \
-   return res;                                           \
+   a->used = x;                                          \
+   return MP_OKAY;                                       \
 }
 
 /* deprecated functions */


### PR DESCRIPTION
In the mp_set_long_long (and related functions), an mp_grow() call is done, but that's only necessary if the already allocated room (MP_PREC) is so small that not even 64 bits fit. There is only one such a situation: -DMP_LOW_MEM in combination with -DMP_8BIT.

Therefore, I propose to increase the minimum MP_PREC from 8 to 16 in this case (allocating 8 bytes is ridicilously small anyway), then the mp_grow() is no longer necessesary in any mode.

This means that the minimum number of _bytes_ allocated are always minimum 16, which is always sufficient to store the 64 bits of a long long.