### PR TITLE
deprecate some macros in tommath.h

### DIFF
--- a/bn_deprecated.c
+++ b/bn_deprecated.c
@@ -6,6 +6,7 @@
 
 /* SPDX-License-Identifier: Unlicense */
 #include <tommath_private.h>
+#ifndef MP_NO_DEPRECATED
 #ifdef BN_FAST_MP_INVMOD_C
 int fast_mp_invmod(const mp_int *a, const mp_int *b, mp_int *c)
 {
@@ -83,5 +84,6 @@ void bn_reverse(unsigned char *s, int len)
 {
    s_mp_reverse(s, len);
 }
+#endif
 #endif
 #endif

--- a/bn_mp_2expt.c
+++ b/bn_mp_2expt.c
@@ -16,15 +16,15 @@ int mp_2expt(mp_int *a, int b)
    mp_zero(a);
 
    /* grow a to accomodate the single bit */
-   if ((res = mp_grow(a, (b / DIGIT_BIT) + 1)) != MP_OKAY) {
+   if ((res = mp_grow(a, (b / MP_DIGIT_BIT) + 1)) != MP_OKAY) {
       return res;
    }
 
    /* set the used count of where the bit will go */
-   a->used = (b / DIGIT_BIT) + 1;
+   a->used = (b / MP_DIGIT_BIT) + 1;
 
    /* put the single bit in its place */
-   a->dp[b / DIGIT_BIT] = (mp_digit)1 << (mp_digit)(b % DIGIT_BIT);
+   a->dp[b / MP_DIGIT_BIT] = (mp_digit)1 << (mp_digit)(b % MP_DIGIT_BIT);
 
    return MP_OKAY;
 }

--- a/bn_mp_add_d.c
+++ b/bn_mp_add_d.c
@@ -49,13 +49,13 @@ int mp_add_d(const mp_int *a, mp_digit b, mp_int *c)
        * the carry.
        */
       *tmpc   = *tmpa++ + b;
-      mu      = *tmpc >> DIGIT_BIT;
+      mu      = *tmpc >> MP_DIGIT_BIT;
       *tmpc++ &= MP_MASK;
 
       /* now handle rest of the digits */
       for (ix = 1; ix < a->used; ix++) {
          *tmpc   = *tmpa++ + mu;
-         mu      = *tmpc >> DIGIT_BIT;
+         mu      = *tmpc >> MP_DIGIT_BIT;
          *tmpc++ &= MP_MASK;
       }
       /* set final carry */

--- a/bn_mp_cnt_lsb.c
+++ b/bn_mp_cnt_lsb.c
@@ -21,7 +21,7 @@ int mp_cnt_lsb(const mp_int *a)
    /* scan lower digits until non-zero */
    for (x = 0; (x < a->used) && (a->dp[x] == 0u); x++) {}
    q = a->dp[x];
-   x *= DIGIT_BIT;
+   x *= MP_DIGIT_BIT;
 
    /* now scan this digit until a 1 is found */
    if ((q & 1u) == 0u) {

--- a/bn_mp_count_bits.c
+++ b/bn_mp_count_bits.c
@@ -15,7 +15,7 @@ int mp_count_bits(const mp_int *a)
    }
 
    /* get number of digits and add that */
-   r = (a->used - 1) * DIGIT_BIT;
+   r = (a->used - 1) * MP_DIGIT_BIT;
 
    /* take the last digit and count the bits in it */
    q = a->dp[a->used - 1];

--- a/bn_mp_div.c
+++ b/bn_mp_div.c
@@ -136,10 +136,10 @@ int mp_div(const mp_int *a, const mp_int *b, mp_int *c, mp_int *d)
    neg = (a->sign == b->sign) ? MP_ZPOS : MP_NEG;
    x.sign = y.sign = MP_ZPOS;
 
-   /* normalize both x and y, ensure that y >= b/2, [b == 2**DIGIT_BIT] */
-   norm = mp_count_bits(&y) % DIGIT_BIT;
-   if (norm < (DIGIT_BIT - 1)) {
-      norm = (DIGIT_BIT - 1) - norm;
+   /* normalize both x and y, ensure that y >= b/2, [b == 2**MP_DIGIT_BIT] */
+   norm = mp_count_bits(&y) % MP_DIGIT_BIT;
+   if (norm < (MP_DIGIT_BIT - 1)) {
+      norm = (MP_DIGIT_BIT - 1) - norm;
       if ((res = mp_mul_2d(&x, norm, &x)) != MP_OKAY) {
          goto LBL_Y;
       }
@@ -178,10 +178,10 @@ int mp_div(const mp_int *a, const mp_int *b, mp_int *c, mp_int *d)
       /* step 3.1 if xi == yt then set q{i-t-1} to b-1,
        * otherwise set q{i-t-1} to (xi*b + x{i-1})/yt */
       if (x.dp[i] == y.dp[t]) {
-         q.dp[(i - t) - 1] = ((mp_digit)1 << (mp_digit)DIGIT_BIT) - (mp_digit)1;
+         q.dp[(i - t) - 1] = ((mp_digit)1 << (mp_digit)MP_DIGIT_BIT) - (mp_digit)1;
       } else {
          mp_word tmp;
-         tmp = (mp_word)x.dp[i] << (mp_word)DIGIT_BIT;
+         tmp = (mp_word)x.dp[i] << (mp_word)MP_DIGIT_BIT;
          tmp |= (mp_word)x.dp[i - 1];
          tmp /= (mp_word)y.dp[t];
          if (tmp > (mp_word)MP_MASK) {

--- a/bn_mp_div_2.c
+++ b/bn_mp_div_2.c
@@ -33,7 +33,7 @@ int mp_div_2(const mp_int *a, mp_int *b)
          rr = *tmpa & 1u;
 
          /* shift the current digit, add in carry and store */
-         *tmpb-- = (*tmpa-- >> 1) | (r << (DIGIT_BIT - 1));
+         *tmpb-- = (*tmpa-- >> 1) | (r << (MP_DIGIT_BIT - 1));
 
          /* forward carry to next iteration */
          r = rr;

--- a/bn_mp_div_2d.c
+++ b/bn_mp_div_2d.c
@@ -32,12 +32,12 @@ int mp_div_2d(const mp_int *a, int b, mp_int *c, mp_int *d)
    }
 
    /* shift by as many digits in the bit count */
-   if (b >= DIGIT_BIT) {
-      mp_rshd(c, b / DIGIT_BIT);
+   if (b >= MP_DIGIT_BIT) {
+      mp_rshd(c, b / MP_DIGIT_BIT);
    }
 
-   /* shift any bit count < DIGIT_BIT */
-   D = (mp_digit)(b % DIGIT_BIT);
+   /* shift any bit count < MP_DIGIT_BIT */
+   D = (mp_digit)(b % MP_DIGIT_BIT);
    if (D != 0u) {
       mp_digit *tmpc, mask, shift;
 
@@ -45,7 +45,7 @@ int mp_div_2d(const mp_int *a, int b, mp_int *c, mp_int *d)
       mask = ((mp_digit)1 << D) - 1uL;
 
       /* shift for lsb */
-      shift = (mp_digit)DIGIT_BIT - D;
+      shift = (mp_digit)MP_DIGIT_BIT - D;
 
       /* alias */
       tmpc = c->dp + (c->used - 1);

--- a/bn_mp_div_3.c
+++ b/bn_mp_div_3.c
@@ -11,8 +11,8 @@ int mp_div_3(const mp_int *a, mp_int *c, mp_digit *d)
    mp_digit b;
    int      res, ix;
 
-   /* b = 2**DIGIT_BIT / 3 */
-   b = ((mp_word)1 << (mp_word)DIGIT_BIT) / (mp_word)3;
+   /* b = 2**MP_DIGIT_BIT / 3 */
+   b = ((mp_word)1 << (mp_word)MP_DIGIT_BIT) / (mp_word)3;
 
    if ((res = mp_init_size(&q, a->used)) != MP_OKAY) {
       return res;
@@ -22,11 +22,11 @@ int mp_div_3(const mp_int *a, mp_int *c, mp_digit *d)
    q.sign = a->sign;
    w = 0;
    for (ix = a->used - 1; ix >= 0; ix--) {
-      w = (w << (mp_word)DIGIT_BIT) | (mp_word)a->dp[ix];
+      w = (w << (mp_word)MP_DIGIT_BIT) | (mp_word)a->dp[ix];
 
       if (w >= 3u) {
          /* multiply w by [1/3] */
-         t = (w * (mp_word)b) >> (mp_word)DIGIT_BIT;
+         t = (w * (mp_word)b) >> (mp_word)MP_DIGIT_BIT;
 
          /* now subtract 3 * [w/3] from w, to get the remainder */
          w -= t+t+t;

--- a/bn_mp_div_d.c
+++ b/bn_mp_div_d.c
@@ -12,7 +12,7 @@ static int s_is_power_of_two(mp_digit b, int *p)
       return 0;
    }
 
-   for (x = 0; x < DIGIT_BIT; x++) {
+   for (x = 0; x < MP_DIGIT_BIT; x++) {
       if (b == ((mp_digit)1<<(mp_digit)x)) {
          *p = x;
          return 1;
@@ -72,7 +72,7 @@ int mp_div_d(const mp_int *a, mp_digit b, mp_int *c, mp_digit *d)
    q.sign = a->sign;
    w = 0;
    for (ix = a->used - 1; ix >= 0; ix--) {
-      w = (w << (mp_word)DIGIT_BIT) | (mp_word)a->dp[ix];
+      w = (w << (mp_word)MP_DIGIT_BIT) | (mp_word)a->dp[ix];
 
       if (w >= b) {
          t = (mp_digit)(w / b);

--- a/bn_mp_dr_reduce.c
+++ b/bn_mp_dr_reduce.c
@@ -51,7 +51,7 @@ top:
    for (i = 0; i < m; i++) {
       r         = ((mp_word)*tmpx2++ * (mp_word)k) + *tmpx1 + mu;
       *tmpx1++  = (mp_digit)(r & MP_MASK);
-      mu        = (mp_digit)(r >> ((mp_word)DIGIT_BIT));
+      mu        = (mp_digit)(r >> ((mp_word)MP_DIGIT_BIT));
    }
 
    /* set final carry */

--- a/bn_mp_dr_setup.c
+++ b/bn_mp_dr_setup.c
@@ -6,10 +6,10 @@
 /* determines the setup value */
 void mp_dr_setup(const mp_int *a, mp_digit *d)
 {
-   /* the casts are required if DIGIT_BIT is one less than
-    * the number of bits in a mp_digit [e.g. DIGIT_BIT==31]
+   /* the casts are required if MP_DIGIT_BIT is one less than
+    * the number of bits in a mp_digit [e.g. MP_DIGIT_BIT==31]
     */
-   *d = (mp_digit)(((mp_word)1 << (mp_word)DIGIT_BIT) - (mp_word)a->dp[0]);
+   *d = (mp_digit)(((mp_word)1 << (mp_word)MP_DIGIT_BIT) - (mp_word)a->dp[0]);
 }
 
 #endif

--- a/bn_mp_expt_d_ex.c
+++ b/bn_mp_expt_d_ex.c
@@ -40,7 +40,7 @@ int mp_expt_d_ex(const mp_int *a, mp_digit b, mp_int *c, int fast)
          b >>= 1;
       }
    } else {
-      for (x = 0; x < (unsigned)DIGIT_BIT; x++) {
+      for (x = 0; x < (unsigned)MP_DIGIT_BIT; x++) {
          /* square */
          if ((res = mp_sqr(c, c)) != MP_OKAY) {
             mp_clear(&g);
@@ -48,7 +48,7 @@ int mp_expt_d_ex(const mp_int *a, mp_digit b, mp_int *c, int fast)
          }
 
          /* if the bit is set multiply */
-         if ((b & ((mp_digit)1 << (DIGIT_BIT - 1))) != 0u) {
+         if ((b & ((mp_digit)1 << (MP_DIGIT_BIT - 1))) != 0u) {
             if ((res = mp_mul(c, &g, c)) != MP_OKAY) {
                mp_clear(&g);
                return res;

--- a/bn_mp_get_bit.c
+++ b/bn_mp_get_bit.c
@@ -16,13 +16,13 @@ int mp_get_bit(const mp_int *a, int b)
       return MP_VAL;
    }
 
-   limb = b / DIGIT_BIT;
+   limb = b / MP_DIGIT_BIT;
 
    if (limb >= a->used) {
       return MP_NO;
    }
 
-   bit = (mp_digit)(1) << (b % DIGIT_BIT);
+   bit = (mp_digit)(1) << (b % MP_DIGIT_BIT);
 
    isset = a->dp[limb] & bit;
    return (isset != 0u) ? MP_YES : MP_NO;

--- a/bn_mp_get_double.c
+++ b/bn_mp_get_double.c
@@ -7,7 +7,7 @@ double mp_get_double(const mp_int *a)
 {
    int i;
    double d = 0.0, fac = 1.0;
-   for (i = 0; i < DIGIT_BIT; ++i) {
+   for (i = 0; i < MP_DIGIT_BIT; ++i) {
       fac *= 2.0;
    }
    for (i = a->used; i --> 0;) {

--- a/bn_mp_get_long.c
+++ b/bn_mp_get_long.c
@@ -14,14 +14,14 @@ unsigned long mp_get_long(const mp_int *a)
    }
 
    /* get number of digits of the lsb we have to read */
-   i = MP_MIN(a->used, (((CHAR_BIT * (int)sizeof(unsigned long)) + DIGIT_BIT - 1) / DIGIT_BIT)) - 1;
+   i = MP_MIN(a->used, (((CHAR_BIT * (int)sizeof(unsigned long)) + MP_DIGIT_BIT - 1) / MP_DIGIT_BIT)) - 1;
 
    /* get most significant digit of result */
    res = (unsigned long)a->dp[i];
 
-#if (ULONG_MAX != 0xFFFFFFFFUL) || (DIGIT_BIT < 32)
+#if (ULONG_MAX != 0xFFFFFFFFUL) || (MP_DIGIT_BIT < 32)
    while (--i >= 0) {
-      res = (res << DIGIT_BIT) | (unsigned long)a->dp[i];
+      res = (res << MP_DIGIT_BIT) | (unsigned long)a->dp[i];
    }
 #endif
    return res;

--- a/bn_mp_get_long_long.c
+++ b/bn_mp_get_long_long.c
@@ -14,14 +14,14 @@ unsigned long long mp_get_long_long(const mp_int *a)
    }
 
    /* get number of digits of the lsb we have to read */
-   i = MP_MIN(a->used, (((CHAR_BIT * (int)sizeof(unsigned long long)) + DIGIT_BIT - 1) / DIGIT_BIT)) - 1;
+   i = MP_MIN(a->used, (((CHAR_BIT * (int)sizeof(unsigned long long)) + MP_DIGIT_BIT - 1) / MP_DIGIT_BIT)) - 1;
 
    /* get most significant digit of result */
    res = (unsigned long long)a->dp[i];
 
-#if DIGIT_BIT < 64
+#if MP_DIGIT_BIT < 64
    while (--i >= 0) {
-      res = (res << DIGIT_BIT) | (unsigned long long)a->dp[i];
+      res = (res << MP_DIGIT_BIT) | (unsigned long long)a->dp[i];
    }
 #endif
    return res;

--- a/bn_mp_is_square.c
+++ b/bn_mp_is_square.c
@@ -44,7 +44,7 @@ int mp_is_square(const mp_int *arg, int *ret)
       return MP_OKAY;
    }
 
-   /* First check mod 128 (suppose that DIGIT_BIT is at least 7) */
+   /* First check mod 128 (suppose that MP_DIGIT_BIT is at least 7) */
    if (rem_128[127u & arg->dp[0]] == (char)1) {
       return MP_OKAY;
    }

--- a/bn_mp_mod_2d.c
+++ b/bn_mp_mod_2d.c
@@ -15,7 +15,7 @@ int mp_mod_2d(const mp_int *a, int b, mp_int *c)
    }
 
    /* if the modulus is larger than the value than return */
-   if (b >= (a->used * DIGIT_BIT)) {
+   if (b >= (a->used * MP_DIGIT_BIT)) {
       res = mp_copy(a, c);
       return res;
    }
@@ -26,12 +26,12 @@ int mp_mod_2d(const mp_int *a, int b, mp_int *c)
    }
 
    /* zero digits above the last digit of the modulus */
-   for (x = (b / DIGIT_BIT) + (((b % DIGIT_BIT) == 0) ? 0 : 1); x < c->used; x++) {
+   for (x = (b / MP_DIGIT_BIT) + (((b % MP_DIGIT_BIT) == 0) ? 0 : 1); x < c->used; x++) {
       c->dp[x] = 0;
    }
    /* clear the digit that is not completely outside/inside the modulus */
-   c->dp[b / DIGIT_BIT] &=
-      ((mp_digit)1 << (mp_digit)(b % DIGIT_BIT)) - (mp_digit)1;
+   c->dp[b / MP_DIGIT_BIT] &=
+      ((mp_digit)1 << (mp_digit)(b % MP_DIGIT_BIT)) - (mp_digit)1;
    mp_clamp(c);
    return MP_OKAY;
 }

--- a/bn_mp_montgomery_calc_normalization.c
+++ b/bn_mp_montgomery_calc_normalization.c
@@ -14,10 +14,10 @@ int mp_montgomery_calc_normalization(mp_int *a, const mp_int *b)
    int     x, bits, res;
 
    /* how many bits of last digit does b use */
-   bits = mp_count_bits(b) % DIGIT_BIT;
+   bits = mp_count_bits(b) % MP_DIGIT_BIT;
 
    if (b->used > 1) {
-      if ((res = mp_2expt(a, ((b->used - 1) * DIGIT_BIT) + bits - 1)) != MP_OKAY) {
+      if ((res = mp_2expt(a, ((b->used - 1) * MP_DIGIT_BIT) + bits - 1)) != MP_OKAY) {
          return res;
       }
    } else {
@@ -27,7 +27,7 @@ int mp_montgomery_calc_normalization(mp_int *a, const mp_int *b)
 
 
    /* now compute C = A * B mod b */
-   for (x = bits - 1; x < (int)DIGIT_BIT; x++) {
+   for (x = bits - 1; x < (int)MP_DIGIT_BIT; x++) {
       if ((res = mp_mul_2(a, a)) != MP_OKAY) {
          return res;
       }

--- a/bn_mp_montgomery_reduce.c
+++ b/bn_mp_montgomery_reduce.c
@@ -19,7 +19,7 @@ int mp_montgomery_reduce(mp_int *x, const mp_int *n, mp_digit rho)
    if ((digs < (int)MP_WARRAY) &&
        (x->used <= (int)MP_WARRAY) &&
        (n->used <
-        (int)(1u << ((CHAR_BIT * sizeof(mp_word)) - (2u * (size_t)DIGIT_BIT))))) {
+        (int)(1u << ((CHAR_BIT * sizeof(mp_word)) - (2u * (size_t)MP_DIGIT_BIT))))) {
       return s_mp_montgomery_reduce_fast(x, n, rho);
    }
 
@@ -64,7 +64,7 @@ int mp_montgomery_reduce(mp_int *x, const mp_int *n, mp_digit rho)
                       (mp_word)u + (mp_word)*tmpx;
 
             /* get carry */
-            u       = (mp_digit)(r >> (mp_word)DIGIT_BIT);
+            u       = (mp_digit)(r >> (mp_word)MP_DIGIT_BIT);
 
             /* fix digit */
             *tmpx++ = (mp_digit)(r & (mp_word)MP_MASK);
@@ -75,7 +75,7 @@ int mp_montgomery_reduce(mp_int *x, const mp_int *n, mp_digit rho)
          /* propagate carries upwards as required*/
          while (u != 0u) {
             *tmpx   += u;
-            u        = *tmpx >> DIGIT_BIT;
+            u        = *tmpx >> MP_DIGIT_BIT;
             *tmpx++ &= MP_MASK;
          }
       }

--- a/bn_mp_montgomery_setup.c
+++ b/bn_mp_montgomery_setup.c
@@ -35,7 +35,7 @@ int mp_montgomery_setup(const mp_int *n, mp_digit *rho)
 #endif
 
    /* rho = -1/m mod b */
-   *rho = (mp_digit)(((mp_word)1 << (mp_word)DIGIT_BIT) - x) & MP_MASK;
+   *rho = (mp_digit)(((mp_word)1 << (mp_word)MP_DIGIT_BIT) - x) & MP_MASK;
 
    return MP_OKAY;
 }

--- a/bn_mp_mul.c
+++ b/bn_mp_mul.c
@@ -67,7 +67,7 @@ GO_ON:
 #ifdef BN_S_MP_MUL_DIGS_FAST_C
          if ((digs < (int)MP_WARRAY) &&
              (MP_MIN(a->used, b->used) <=
-              (int)(1u << ((CHAR_BIT * sizeof(mp_word)) - (2u * (size_t)DIGIT_BIT))))) {
+              (int)(1u << ((CHAR_BIT * sizeof(mp_word)) - (2u * (size_t)MP_DIGIT_BIT))))) {
             res = s_mp_mul_digs_fast(a, b, c, digs);
          } else
 #endif

--- a/bn_mp_mul_2.c
+++ b/bn_mp_mul_2.c
@@ -34,7 +34,7 @@ int mp_mul_2(const mp_int *a, mp_int *b)
          /* get what will be the *next* carry bit from the
           * MSB of the current digit
           */
-         rr = *tmpa >> (mp_digit)(DIGIT_BIT - 1);
+         rr = *tmpa >> (mp_digit)(MP_DIGIT_BIT - 1);
 
          /* now shift up this digit, add in the carry [from the previous] */
          *tmpb++ = ((*tmpa++ << 1uL) | r) & MP_MASK;

--- a/bn_mp_mul_2d.c
+++ b/bn_mp_mul_2d.c
@@ -16,21 +16,21 @@ int mp_mul_2d(const mp_int *a, int b, mp_int *c)
       }
    }
 
-   if (c->alloc < (c->used + (b / DIGIT_BIT) + 1)) {
-      if ((res = mp_grow(c, c->used + (b / DIGIT_BIT) + 1)) != MP_OKAY) {
+   if (c->alloc < (c->used + (b / MP_DIGIT_BIT) + 1)) {
+      if ((res = mp_grow(c, c->used + (b / MP_DIGIT_BIT) + 1)) != MP_OKAY) {
          return res;
       }
    }
 
    /* shift by as many digits in the bit count */
-   if (b >= DIGIT_BIT) {
-      if ((res = mp_lshd(c, b / DIGIT_BIT)) != MP_OKAY) {
+   if (b >= MP_DIGIT_BIT) {
+      if ((res = mp_lshd(c, b / MP_DIGIT_BIT)) != MP_OKAY) {
          return res;
       }
    }
 
-   /* shift any bit count < DIGIT_BIT */
-   d = (mp_digit)(b % DIGIT_BIT);
+   /* shift any bit count < MP_DIGIT_BIT */
+   d = (mp_digit)(b % MP_DIGIT_BIT);
    if (d != 0u) {
       mp_digit *tmpc, shift, mask, r, rr;
       int x;
@@ -39,7 +39,7 @@ int mp_mul_2d(const mp_int *a, int b, mp_int *c)
       mask = ((mp_digit)1 << d) - (mp_digit)1;
 
       /* shift for msbs */
-      shift = (mp_digit)DIGIT_BIT - d;
+      shift = (mp_digit)MP_DIGIT_BIT - d;
 
       /* alias */
       tmpc = c->dp;

--- a/bn_mp_mul_d.c
+++ b/bn_mp_mul_d.c
@@ -41,7 +41,7 @@ int mp_mul_d(const mp_int *a, mp_digit b, mp_int *c)
       *tmpc++ = (mp_digit)(r & (mp_word)MP_MASK);
 
       /* send carry into next iteration */
-      u       = (mp_digit)(r >> (mp_word)DIGIT_BIT);
+      u       = (mp_digit)(r >> (mp_word)MP_DIGIT_BIT);
    }
 
    /* store final carry [if any] and increment ix offset  */

--- a/bn_mp_prime_is_prime.c
+++ b/bn_mp_prime_is_prime.c
@@ -296,10 +296,10 @@ int mp_prime_is_prime(const mp_int *a, int t, int *result)
             fips_rand &= mask;
          }
 #endif
-         if (fips_rand > (unsigned int)(INT_MAX - DIGIT_BIT)) {
-            len = INT_MAX / DIGIT_BIT;
+         if (fips_rand > (unsigned int)(INT_MAX - MP_DIGIT_BIT)) {
+            len = INT_MAX / MP_DIGIT_BIT;
          } else {
-            len = (((int)fips_rand + DIGIT_BIT) / DIGIT_BIT);
+            len = (((int)fips_rand + MP_DIGIT_BIT) / MP_DIGIT_BIT);
          }
          /*  Unlikely. */
          if (len < 0) {

--- a/bn_mp_prime_next_prime.c
+++ b/bn_mp_prime_next_prime.c
@@ -114,7 +114,7 @@ int mp_prime_next_prime(mp_int *a, int t, int bbs_style)
                y = 1;
             }
          }
-      } while ((y == 1) && (step < (((mp_digit)1 << DIGIT_BIT) - kstep)));
+      } while ((y == 1) && (step < (((mp_digit)1 << MP_DIGIT_BIT) - kstep)));
 
       /* add the step */
       if ((err = mp_add_d(a, step, a)) != MP_OKAY) {
@@ -122,7 +122,7 @@ int mp_prime_next_prime(mp_int *a, int t, int bbs_style)
       }
 
       /* if didn't pass sieve and step == MP_MAX then skip test */
-      if ((y == 1) && (step >= (((mp_digit)1 << DIGIT_BIT) - kstep))) {
+      if ((y == 1) && (step >= (((mp_digit)1 << MP_DIGIT_BIT) - kstep))) {
          continue;
       }
 

--- a/bn_mp_reduce.c
+++ b/bn_mp_reduce.c
@@ -21,7 +21,7 @@ int mp_reduce(mp_int *x, const mp_int *m, const mp_int *mu)
    mp_rshd(&q, um - 1);
 
    /* according to HAC this optimization is ok */
-   if ((mp_digit)um > ((mp_digit)1 << (DIGIT_BIT - 1))) {
+   if ((mp_digit)um > ((mp_digit)1 << (MP_DIGIT_BIT - 1))) {
       if ((res = mp_mul(&q, mu, &q)) != MP_OKAY) {
          goto CLEANUP;
       }
@@ -46,7 +46,7 @@ int mp_reduce(mp_int *x, const mp_int *m, const mp_int *mu)
    mp_rshd(&q, um + 1);
 
    /* x = x mod b**(k+1), quick (no division) */
-   if ((res = mp_mod_2d(x, DIGIT_BIT * (um + 1), x)) != MP_OKAY) {
+   if ((res = mp_mod_2d(x, MP_DIGIT_BIT * (um + 1), x)) != MP_OKAY) {
       goto CLEANUP;
    }
 

--- a/bn_mp_reduce_is_2k.c
+++ b/bn_mp_reduce_is_2k.c
@@ -19,7 +19,7 @@ int mp_reduce_is_2k(const mp_int *a)
       iw = 1;
 
       /* Test every bit from the second digit up, must be 1 */
-      for (ix = DIGIT_BIT; ix < iy; ix++) {
+      for (ix = MP_DIGIT_BIT; ix < iy; ix++) {
          if ((a->dp[iw] & iz) == 0u) {
             return MP_NO;
          }

--- a/bn_mp_reduce_setup.c
+++ b/bn_mp_reduce_setup.c
@@ -10,7 +10,7 @@ int mp_reduce_setup(mp_int *a, const mp_int *b)
 {
    int     res;
 
-   if ((res = mp_2expt(a, b->used * 2 * DIGIT_BIT)) != MP_OKAY) {
+   if ((res = mp_2expt(a, b->used * 2 * MP_DIGIT_BIT)) != MP_OKAY) {
       return res;
    }
    return mp_div(a, b, a, NULL);

--- a/bn_mp_sqr.c
+++ b/bn_mp_sqr.c
@@ -25,7 +25,7 @@ int mp_sqr(const mp_int *a, mp_int *b)
          /* can we use the fast comba multiplier? */
          if ((((a->used * 2) + 1) < (int)MP_WARRAY) &&
              (a->used <
-              (int)(1u << (((CHAR_BIT * sizeof(mp_word)) - (2u * (size_t)DIGIT_BIT)) - 1u)))) {
+              (int)(1u << (((CHAR_BIT * sizeof(mp_word)) - (2u * (size_t)MP_DIGIT_BIT)) - 1u)))) {
             res = s_mp_sqr_fast(a, b);
          } else
 #endif

--- a/bn_s_mp_add.c
+++ b/bn_s_mp_add.c
@@ -55,7 +55,7 @@ int s_mp_add(const mp_int *a, const mp_int *b, mp_int *c)
          *tmpc = *tmpa++ + *tmpb++ + u;
 
          /* U = carry bit of T[i] */
-         u = *tmpc >> (mp_digit)DIGIT_BIT;
+         u = *tmpc >> (mp_digit)MP_DIGIT_BIT;
 
          /* take away carry bit from T[i] */
          *tmpc++ &= MP_MASK;
@@ -70,7 +70,7 @@ int s_mp_add(const mp_int *a, const mp_int *b, mp_int *c)
             *tmpc = x->dp[i] + u;
 
             /* U = carry bit of T[i] */
-            u = *tmpc >> (mp_digit)DIGIT_BIT;
+            u = *tmpc >> (mp_digit)MP_DIGIT_BIT;
 
             /* take away carry bit from T[i] */
             *tmpc++ &= MP_MASK;

--- a/bn_s_mp_exptmod.c
+++ b/bn_s_mp_exptmod.c
@@ -141,11 +141,11 @@ int s_mp_exptmod(const mp_int *G, const mp_int *X, const mp_int *P, mp_int *Y, i
          }
          /* read next digit and reset the bitcnt */
          buf    = X->dp[digidx--];
-         bitcnt = (int)DIGIT_BIT;
+         bitcnt = (int)MP_DIGIT_BIT;
       }
 
       /* grab the next msb from the exponent */
-      y     = (buf >> (mp_digit)(DIGIT_BIT - 1)) & 1;
+      y     = (buf >> (mp_digit)(MP_DIGIT_BIT - 1)) & 1;
       buf <<= (mp_digit)1;
 
       /* if the bit is zero and mode == 0 then we ignore it

--- a/bn_s_mp_exptmod_fast.c
+++ b/bn_s_mp_exptmod_fast.c
@@ -85,7 +85,7 @@ int s_mp_exptmod_fast(const mp_int *G, const mp_int *X, const mp_int *P, mp_int 
       /* automatically pick the comba one if available (saves quite a few calls/ifs) */
 #ifdef BN_S_MP_MONTGOMERY_REDUCE_FAST_C
       if ((((P->used * 2) + 1) < (int)MP_WARRAY) &&
-          (P->used < (1 << ((CHAR_BIT * sizeof(mp_word)) - (2 * DIGIT_BIT))))) {
+          (P->used < (1 << ((CHAR_BIT * sizeof(mp_word)) - (2 * MP_DIGIT_BIT))))) {
          redux = s_mp_montgomery_reduce_fast;
       } else
 #endif
@@ -195,11 +195,11 @@ int s_mp_exptmod_fast(const mp_int *G, const mp_int *X, const mp_int *P, mp_int 
          }
          /* read next digit and reset bitcnt */
          buf    = X->dp[digidx--];
-         bitcnt = (int)DIGIT_BIT;
+         bitcnt = (int)MP_DIGIT_BIT;
       }
 
       /* grab the next msb from the exponent */
-      y     = (mp_digit)(buf >> (DIGIT_BIT - 1)) & 1;
+      y     = (mp_digit)(buf >> (MP_DIGIT_BIT - 1)) & 1;
       buf <<= (mp_digit)1;
 
       /* if the bit is zero and mode == 0 then we ignore it

--- a/bn_s_mp_karatsuba_mul.c
+++ b/bn_s_mp_karatsuba_mul.c
@@ -6,7 +6,7 @@
 /* c = |a| * |b| using Karatsuba Multiplication using
  * three half size multiplications
  *
- * Let B represent the radix [e.g. 2**DIGIT_BIT] and
+ * Let B represent the radix [e.g. 2**MP_DIGIT_BIT] and
  * let n represent half of the number of digits in
  * the min(a,b)
  *

--- a/bn_s_mp_montgomery_reduce_fast.c
+++ b/bn_s_mp_montgomery_reduce_fast.c
@@ -99,7 +99,7 @@ int s_mp_montgomery_reduce_fast(mp_int *x, const mp_int *n, mp_digit rho)
       }
 
       /* now fix carry for next digit, W[ix+1] */
-      W[ix + 1] += W[ix] >> (mp_word)DIGIT_BIT;
+      W[ix + 1] += W[ix] >> (mp_word)MP_DIGIT_BIT;
    }
 
    /* now we have to propagate the carries and
@@ -119,7 +119,7 @@ int s_mp_montgomery_reduce_fast(mp_int *x, const mp_int *n, mp_digit rho)
       _W = W + ++ix;
 
       for (; ix <= ((n->used * 2) + 1); ix++) {
-         *_W++ += *_W1++ >> (mp_word)DIGIT_BIT;
+         *_W++ += *_W1++ >> (mp_word)MP_DIGIT_BIT;
       }
 
       /* copy out, A = A/b**n

--- a/bn_s_mp_mul_digs.c
+++ b/bn_s_mp_mul_digs.c
@@ -18,7 +18,7 @@ int s_mp_mul_digs(const mp_int *a, const mp_int *b, mp_int *c, int digs)
    /* can we use the fast multiplier? */
    if ((digs < (int)MP_WARRAY) &&
        (MP_MIN(a->used, b->used) <
-        (int)(1u << ((CHAR_BIT * sizeof(mp_word)) - (2u * (size_t)DIGIT_BIT))))) {
+        (int)(1u << ((CHAR_BIT * sizeof(mp_word)) - (2u * (size_t)MP_DIGIT_BIT))))) {
       return s_mp_mul_digs_fast(a, b, c, digs);
    }
 
@@ -57,7 +57,7 @@ int s_mp_mul_digs(const mp_int *a, const mp_int *b, mp_int *c, int digs)
          *tmpt++ = (mp_digit)(r & (mp_word)MP_MASK);
 
          /* get the carry word from the result */
-         u       = (mp_digit)(r >> (mp_word)DIGIT_BIT);
+         u       = (mp_digit)(r >> (mp_word)MP_DIGIT_BIT);
       }
       /* set carry if it is placed below digs */
       if ((ix + iy) < digs) {

--- a/bn_s_mp_mul_digs_fast.c
+++ b/bn_s_mp_mul_digs_fast.c
@@ -65,7 +65,7 @@ int s_mp_mul_digs_fast(const mp_int *a, const mp_int *b, mp_int *c, int digs)
       W[ix] = (mp_digit)_W & MP_MASK;
 
       /* make next carry */
-      _W = _W >> (mp_word)DIGIT_BIT;
+      _W = _W >> (mp_word)MP_DIGIT_BIT;
    }
 
    /* setup dest */

--- a/bn_s_mp_mul_high_digs.c
+++ b/bn_s_mp_mul_high_digs.c
@@ -17,7 +17,7 @@ int s_mp_mul_high_digs(const mp_int *a, const mp_int *b, mp_int *c, int digs)
    /* can we use the fast multiplier? */
 #ifdef BN_S_MP_MUL_HIGH_DIGS_FAST_C
    if (((a->used + b->used + 1) < (int)MP_WARRAY)
-       && (MP_MIN(a->used, b->used) < (int)(1u << ((CHAR_BIT * sizeof(mp_word)) - (2u * (size_t)DIGIT_BIT))))) {
+       && (MP_MIN(a->used, b->used) < (int)(1u << ((CHAR_BIT * sizeof(mp_word)) - (2u * (size_t)MP_DIGIT_BIT))))) {
       return s_mp_mul_high_digs_fast(a, b, c, digs);
    }
 #endif
@@ -52,7 +52,7 @@ int s_mp_mul_high_digs(const mp_int *a, const mp_int *b, mp_int *c, int digs)
          *tmpt++ = (mp_digit)(r & (mp_word)MP_MASK);
 
          /* carry the carry */
-         u       = (mp_digit)(r >> (mp_word)DIGIT_BIT);
+         u       = (mp_digit)(r >> (mp_word)MP_DIGIT_BIT);
       }
       *tmpt = u;
    }

--- a/bn_s_mp_mul_high_digs_fast.c
+++ b/bn_s_mp_mul_high_digs_fast.c
@@ -55,7 +55,7 @@ int s_mp_mul_high_digs_fast(const mp_int *a, const mp_int *b, mp_int *c, int dig
       W[ix] = (mp_digit)_W & MP_MASK;
 
       /* make next carry */
-      _W = _W >> (mp_word)DIGIT_BIT;
+      _W = _W >> (mp_word)MP_DIGIT_BIT;
    }
 
    /* setup dest */

--- a/bn_s_mp_sqr.c
+++ b/bn_s_mp_sqr.c
@@ -29,7 +29,7 @@ int s_mp_sqr(const mp_int *a, mp_int *b)
       t.dp[ix+ix] = (mp_digit)(r & (mp_word)MP_MASK);
 
       /* get the carry */
-      u           = (mp_digit)(r >> (mp_word)DIGIT_BIT);
+      u           = (mp_digit)(r >> (mp_word)MP_DIGIT_BIT);
 
       /* left hand side of A[ix] * A[iy] */
       tmpx        = a->dp[ix];
@@ -50,13 +50,13 @@ int s_mp_sqr(const mp_int *a, mp_int *b)
          *tmpt++ = (mp_digit)(r & (mp_word)MP_MASK);
 
          /* get carry */
-         u       = (mp_digit)(r >> (mp_word)DIGIT_BIT);
+         u       = (mp_digit)(r >> (mp_word)MP_DIGIT_BIT);
       }
       /* propagate upwards */
       while (u != 0uL) {
          r       = (mp_word)*tmpt + (mp_word)u;
          *tmpt++ = (mp_digit)(r & (mp_word)MP_MASK);
-         u       = (mp_digit)(r >> (mp_word)DIGIT_BIT);
+         u       = (mp_digit)(r >> (mp_word)MP_DIGIT_BIT);
       }
    }
 

--- a/bn_s_mp_sqr_fast.c
+++ b/bn_s_mp_sqr_fast.c
@@ -73,7 +73,7 @@ int s_mp_sqr_fast(const mp_int *a, mp_int *b)
       W[ix] = (mp_digit)_W & MP_MASK;
 
       /* make next carry */
-      W1 = _W >> (mp_word)DIGIT_BIT;
+      W1 = _W >> (mp_word)MP_DIGIT_BIT;
    }
 
    /* setup dest */

--- a/bn_s_mp_toom_mul.c
+++ b/bn_s_mp_toom_mul.c
@@ -26,7 +26,7 @@ int s_mp_toom_mul(const mp_int *a, const mp_int *b, mp_int *c)
    B = MP_MIN(a->used, b->used) / 3;
 
    /* a = a2 * B**2 + a1 * B + a0 */
-   if ((res = mp_mod_2d(a, DIGIT_BIT * B, &a0)) != MP_OKAY) {
+   if ((res = mp_mod_2d(a, MP_DIGIT_BIT * B, &a0)) != MP_OKAY) {
       goto LBL_ERR;
    }
 
@@ -34,7 +34,7 @@ int s_mp_toom_mul(const mp_int *a, const mp_int *b, mp_int *c)
       goto LBL_ERR;
    }
    mp_rshd(&a1, B);
-   if ((res = mp_mod_2d(&a1, DIGIT_BIT * B, &a1)) != MP_OKAY) {
+   if ((res = mp_mod_2d(&a1, MP_DIGIT_BIT * B, &a1)) != MP_OKAY) {
       goto LBL_ERR;
    }
 
@@ -44,7 +44,7 @@ int s_mp_toom_mul(const mp_int *a, const mp_int *b, mp_int *c)
    mp_rshd(&a2, B*2);
 
    /* b = b2 * B**2 + b1 * B + b0 */
-   if ((res = mp_mod_2d(b, DIGIT_BIT * B, &b0)) != MP_OKAY) {
+   if ((res = mp_mod_2d(b, MP_DIGIT_BIT * B, &b0)) != MP_OKAY) {
       goto LBL_ERR;
    }
 
@@ -52,7 +52,7 @@ int s_mp_toom_mul(const mp_int *a, const mp_int *b, mp_int *c)
       goto LBL_ERR;
    }
    mp_rshd(&b1, B);
-   (void)mp_mod_2d(&b1, DIGIT_BIT * B, &b1);
+   (void)mp_mod_2d(&b1, MP_DIGIT_BIT * B, &b1);
 
    if ((res = mp_copy(b, &b2)) != MP_OKAY) {
       goto LBL_ERR;

--- a/bn_s_mp_toom_sqr.c
+++ b/bn_s_mp_toom_sqr.c
@@ -18,7 +18,7 @@ int s_mp_toom_sqr(const mp_int *a, mp_int *b)
    B = a->used / 3;
 
    /* a = a2 * B**2 + a1 * B + a0 */
-   if ((res = mp_mod_2d(a, DIGIT_BIT * B, &a0)) != MP_OKAY) {
+   if ((res = mp_mod_2d(a, MP_DIGIT_BIT * B, &a0)) != MP_OKAY) {
       goto LBL_ERR;
    }
 
@@ -26,7 +26,7 @@ int s_mp_toom_sqr(const mp_int *a, mp_int *b)
       goto LBL_ERR;
    }
    mp_rshd(&a1, B);
-   if ((res = mp_mod_2d(&a1, DIGIT_BIT * B, &a1)) != MP_OKAY) {
+   if ((res = mp_mod_2d(&a1, MP_DIGIT_BIT * B, &a1)) != MP_OKAY) {
       goto LBL_ERR;
    }
 

--- a/demo/main.c
+++ b/demo/main.c
@@ -42,7 +42,7 @@ int main(void)
 #endif
    printf("Size of mp_digit: %u\n", (unsigned int)sizeof(mp_digit));
    printf("Size of mp_word: %u\n", (unsigned int)sizeof(mp_word));
-   printf("DIGIT_BIT: %d\n", DIGIT_BIT);
+   printf("MP_DIGIT_BIT: %d\n", MP_DIGIT_BIT);
    printf("MP_PREC: %d\n", MP_PREC);
 
    if (LTM_DEMO_TEST_VS_MTEST) {

--- a/demo/test.c
+++ b/demo/test.c
@@ -1056,7 +1056,7 @@ static int test_mp_reduce_2k(void)
             printf(".");
             fflush(stdout);
          }
-         mp_rand(&b, (cnt / DIGIT_BIT + 1) * 2);
+         mp_rand(&b, (cnt / MP_DIGIT_BIT + 1) * 2);
          mp_copy(&c, &b);
          mp_mod(&c, &a, &c);
          mp_reduce_2k(&b, &a, 2uL);

--- a/demo/timing.c
+++ b/demo/timing.c
@@ -177,7 +177,7 @@ int main(void)
       } while (++rr < 100000u);
       printf("Adding\t\t%4d-bit => %9" PRIu64 "/sec, %9" PRIu64 " cycles\n",
              mp_count_bits(&a), CLK_PER_SEC / tt, tt);
-      FPRINTF(log, "%6d %9" PRIu64 "\n", cnt * DIGIT_BIT, tt);
+      FPRINTF(log, "%6d %9" PRIu64 "\n", cnt * MP_DIGIT_BIT, tt);
       FFLUSH(log);
    }
    FCLOSE(log);
@@ -199,7 +199,7 @@ int main(void)
 
       printf("Subtracting\t\t%4d-bit => %9" PRIu64 "/sec, %9" PRIu64 " cycles\n",
              mp_count_bits(&a), CLK_PER_SEC / tt, tt);
-      FPRINTF(log, "%6d %9" PRIu64 "\n", cnt * DIGIT_BIT, tt);
+      FPRINTF(log, "%6d %9" PRIu64 "\n", cnt * MP_DIGIT_BIT, tt);
       FFLUSH(log);
    }
    FCLOSE(log);
@@ -219,7 +219,7 @@ int main(void)
       TOOM_SQR_CUTOFF = (ix == 2) ? old_toom_s : 9999;
 
       log = FOPEN((ix == 0) ? "logs/mult.log" : (ix == 1) ? "logs/mult_kara.log" : "logs/mult_toom.log", "w");
-      for (cnt = 4; cnt <= (10240 / DIGIT_BIT); cnt += 2) {
+      for (cnt = 4; cnt <= (10240 / MP_DIGIT_BIT); cnt += 2) {
          SLEEP;
          mp_rand(&a, cnt);
          mp_rand(&b, cnt);
@@ -240,7 +240,7 @@ int main(void)
       FCLOSE(log);
 
       log = FOPEN((ix == 0) ? "logs/sqr.log" : (ix == 1) ? "logs/sqr_kara.log" : "logs/sqr_toom.log", "w");
-      for (cnt = 4; cnt <= (10240 / DIGIT_BIT); cnt += 2) {
+      for (cnt = 4; cnt <= (10240 / MP_DIGIT_BIT); cnt += 2) {
          SLEEP;
          mp_rand(&a, cnt);
          rr = 0u;
@@ -366,7 +366,7 @@ int main(void)
       }
       printf("Inverting mod\t%4d-bit => %9" PRIu64 "/sec, %9" PRIu64 " cycles\n",
              mp_count_bits(&a), CLK_PER_SEC / tt, tt);
-      FPRINTF(log, "%6d %9" PRIu64 "\n", cnt * DIGIT_BIT, tt);
+      FPRINTF(log, "%6d %9" PRIu64 "\n", cnt * MP_DIGIT_BIT, tt);
    }
    FCLOSE(log);
 

--- a/etc/drprime.c
+++ b/etc/drprime.c
@@ -1,7 +1,7 @@
 /* Makes safe primes of a DR nature */
 #include <tommath.h>
 
-static int sizes[] = { 1+256/DIGIT_BIT, 1+512/DIGIT_BIT, 1+768/DIGIT_BIT, 1+1024/DIGIT_BIT, 1+2048/DIGIT_BIT, 1+4096/DIGIT_BIT };
+static int sizes[] = { 1+256/MP_DIGIT_BIT, 1+512/MP_DIGIT_BIT, 1+768/MP_DIGIT_BIT, 1+1024/MP_DIGIT_BIT, 1+2048/MP_DIGIT_BIT, 1+4096/MP_DIGIT_BIT };
 
 int main(void)
 {
@@ -17,7 +17,7 @@ int main(void)
    if (out != NULL) {
       for (x = 0; x < (int)(sizeof(sizes)/sizeof(sizes[0])); x++) {
 top:
-         printf("Seeking a %d-bit safe prime\n", sizes[x] * DIGIT_BIT);
+         printf("Seeking a %d-bit safe prime\n", sizes[x] * MP_DIGIT_BIT);
          mp_grow(&a, sizes[x]);
          mp_zero(&a);
          for (y = 1; y < sizes[x]; y++) {

--- a/etc/pprime.c
+++ b/etc/pprime.c
@@ -185,7 +185,7 @@ static int pprime(int k, int li, mp_int *p, mp_int *q)
    static const mp_digit bases[] = { 2, 3, 5, 7, 11, 13, 17, 19 };
 
    /* single digit ? */
-   if (k <= (int) DIGIT_BIT) {
+   if (k <= (int) MP_DIGIT_BIT) {
       mp_set(p, prime_digit());
       return MP_OKAY;
    }

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -49,6 +49,8 @@ endif
 
 CFLAGS += -I./ -Wall -Wsign-compare -Wextra -Wshadow
 
+CFLAGS += -D_MP_NO_DEPRECATED_WARNING
+
 ifndef NO_ADDTL_WARNINGS
 # additional warnings
 CFLAGS += -Wdeclaration-after-statement -Wbad-function-cast -Wcast-align

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -49,7 +49,7 @@ endif
 
 CFLAGS += -I./ -Wall -Wsign-compare -Wextra -Wshadow
 
-CFLAGS += -D_MP_NO_DEPRECATED_WARNING
+CFLAGS += -DPRIVATE_MP_NO_DEPRECATED_WARNING
 
 ifndef NO_ADDTL_WARNINGS
 # additional warnings

--- a/tommath.h
+++ b/tommath.h
@@ -165,7 +165,9 @@ typedef int ltm_prime_callback(unsigned char *dst, int len, void *dat);
 #    define MP_DEPRECATED_PRAGMA(s)
 #  endif
 
-#  define DIGIT_BIT   MP_DIGIT_BIT
+/* DIGIT_BIT is used in #ifdefs, therefore we cannot use MP_DEPRECATED_PRAGMA */
+#  define DIGIT_BIT   /* DIGIT_BIT macro is deprecated, use MP_DIGIT_BIT instead */ MP_DIGIT_BIT
+
 #  define USED(m)     (MP_DEPRECATED_PRAGMA("USED macro is deprecated, use z->used instead") (m)->used)
 #  define DIGIT(m, k) (MP_DEPRECATED_PRAGMA("DIGIT macro is deprecated, use z->dp instead") (m)->dp[(k)])
 #  define SIGN(m)     (MP_DEPRECATED_PRAGMA("SIGN macro is deprecated, use z->sign instead") (m)->sign)

--- a/tommath.h
+++ b/tommath.h
@@ -148,10 +148,21 @@ typedef struct  {
 /* callback for mp_prime_random, should fill dst with random bytes and return how many read [upto len] */
 typedef int ltm_prime_callback(unsigned char *dst, int len, void *dat);
 
+#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 301)
+#  define MP_DEPRECATED(x) __attribute__((deprecated("replaced by " #x)))
+#  define _MP_DEPRECATED_PRAGMA(s) _Pragma(#s)
+#  define MP_DEPRECATED_PRAGMA(s) _MP_DEPRECATED_PRAGMA(GCC warning s)
+#elif defined(_MSC_VER) && _MSC_VER >= 1500
+#  define MP_DEPRECATED(x) __declspec(deprecated("replaced by " #x))
+#  define MP_DEPRECATED_PRAGMA(s) __pragma(message(s))
+#else
+#  define MP_DEPRECATED
+#  define MP_DEPRECATED_PRAGMA(s)
+#endif
 
-#define USED(m)     ((m)->used)
-#define DIGIT(m, k) ((m)->dp[(k)])
-#define SIGN(m)     ((m)->sign)
+#define USED(m)     (MP_DEPRECATED_PRAGMA("USED macro is deprecated, use z->used instead") (m)->used)
+#define DIGIT(m, k) (MP_DEPRECATED_PRAGMA("DIGIT macro is deprecated, use z->dp instead") (m)->dp[(k)])
+#define SIGN(m)     (MP_DEPRECATED_PRAGMA("SIGN macro is deprecated, use z->sign instead") (m)->sign)
 
 /* error code to char* string */
 const char *mp_error_to_string(int code);

--- a/tommath.h
+++ b/tommath.h
@@ -136,7 +136,7 @@ extern int KARATSUBA_MUL_CUTOFF,
 #endif
 
 /* size of comba arrays, should be at least 2 * 2**(BITS_PER_WORD - BITS_PER_DIGIT*2) */
-#define _MP_WARRAY_PRIVATE (1u << (((CHAR_BIT * sizeof(mp_word)) - (2 * MP_DIGIT_BIT)) + 1))
+#define PRIVATE_MP_WARRAY (1u << (((CHAR_BIT * sizeof(mp_word)) - (2 * MP_DIGIT_BIT)) + 1))
 
 /* the infamous mp_int structure */
 typedef struct  {
@@ -149,14 +149,14 @@ typedef int ltm_prime_callback(unsigned char *dst, int len, void *dat);
 
 #ifndef MP_NO_DEPRECATED
 
-#  ifndef _MP_NO_DEPRECATED_WARNING
+#  ifndef PRIVATE_MP_NO_DEPRECATED_WARNING
 #    warning Deprecated functions are enabled, define MP_NO_DEPRECATED!
 #  endif
 
 #  if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 301)
 #    define MP_DEPRECATED(x) __attribute__((deprecated("replaced by " #x)))
-#    define _MP_DEPRECATED_PRAGMA(s) _Pragma(#s)
-#    define MP_DEPRECATED_PRAGMA(s) _MP_DEPRECATED_PRAGMA(GCC warning s)
+#    define PRIVATE_MP_DEPRECATED_PRAGMA(s) _Pragma(#s)
+#    define MP_DEPRECATED_PRAGMA(s) PRIVATE_MP_DEPRECATED_PRAGMA(GCC warning s)
 #  elif defined(_MSC_VER) && _MSC_VER >= 1500
 #    define MP_DEPRECATED(x) __declspec(deprecated("replaced by " #x))
 #    define MP_DEPRECATED_PRAGMA(s) __pragma(message(s))
@@ -171,7 +171,7 @@ typedef int ltm_prime_callback(unsigned char *dst, int len, void *dat);
 #  define USED(m)     (MP_DEPRECATED_PRAGMA("USED macro is deprecated, use z->used instead") (m)->used)
 #  define DIGIT(m, k) (MP_DEPRECATED_PRAGMA("DIGIT macro is deprecated, use z->dp instead") (m)->dp[(k)])
 #  define SIGN(m)     (MP_DEPRECATED_PRAGMA("SIGN macro is deprecated, use z->sign instead") (m)->sign)
-#  define MP_WARRAY   (MP_DEPRECATED_PRAGMA("MP_WARRAY is an internal macro") _MP_WARRAY_PRIVATE)
+#  define MP_WARRAY   (MP_DEPRECATED_PRAGMA("MP_WARRAY is an internal macro") PRIVATE_MP_WARRAY)
 #endif
 
 /* error code to char* string */

--- a/tommath.h
+++ b/tommath.h
@@ -43,8 +43,8 @@ extern "C" {
 
 /* some default configurations.
  *
- * A "mp_digit" must be able to hold DIGIT_BIT + 1 bits
- * A "mp_word" must be able to hold 2*DIGIT_BIT + 1 bits
+ * A "mp_digit" must be able to hold MP_DIGIT_BIT + 1 bits
+ * A "mp_word" must be able to hold 2*MP_DIGIT_BIT + 1 bits
  *
  * At the very least a mp_digit must be able to hold 7 bits
  * [any size beyond that is ok provided it doesn't overflow the data type]
@@ -53,21 +53,21 @@ extern "C" {
 typedef uint8_t              mp_digit;
 typedef uint16_t             mp_word;
 #   define MP_SIZEOF_MP_DIGIT 1
-#   ifdef DIGIT_BIT
-#      error You must not define DIGIT_BIT when using MP_8BIT
+#   ifdef MP_DIGIT_BIT
+#      error You must not define MP_DIGIT_BIT when using MP_8BIT
 #   endif
 #elif defined(MP_16BIT)
 typedef uint16_t             mp_digit;
 typedef uint32_t             mp_word;
 #   define MP_SIZEOF_MP_DIGIT 2
-#   ifdef DIGIT_BIT
-#      error You must not define DIGIT_BIT when using MP_16BIT
+#   ifdef MP_DIGIT_BIT
+#      error You must not define MP_DIGIT_BIT when using MP_16BIT
 #   endif
 #elif defined(MP_64BIT)
 /* for GCC only on supported platforms */
 typedef uint64_t mp_digit;
 typedef unsigned long        mp_word __attribute__((mode(TI)));
-#   define DIGIT_BIT 60
+#   define MP_DIGIT_BIT 60
 #else
 /* this is the default case, 28-bit digits */
 
@@ -77,21 +77,20 @@ typedef uint64_t             mp_word;
 
 #   ifdef MP_31BIT
 /* this is an extension that uses 31-bit digits */
-#      define DIGIT_BIT 31
+#      define MP_DIGIT_BIT 31
 #   else
 /* default case is 28-bit digits, defines MP_28BIT as a handy macro to test */
-#      define DIGIT_BIT 28
+#      define MP_DIGIT_BIT 28
 #      define MP_28BIT
 #   endif
 #endif
 
 /* otherwise the bits per digit is calculated automatically from the size of a mp_digit */
-#ifndef DIGIT_BIT
-#   define DIGIT_BIT (((CHAR_BIT * MP_SIZEOF_MP_DIGIT) - 1))  /* bits per digit */
+#ifndef MP_DIGIT_BIT
+#   define MP_DIGIT_BIT (((CHAR_BIT * MP_SIZEOF_MP_DIGIT) - 1))  /* bits per digit */
 #endif
 
-#define MP_DIGIT_BIT     DIGIT_BIT
-#define MP_MASK          ((((mp_digit)1)<<((mp_digit)DIGIT_BIT))-((mp_digit)1))
+#define MP_MASK          ((((mp_digit)1)<<((mp_digit)MP_DIGIT_BIT))-((mp_digit)1))
 #define MP_DIGIT_MAX     MP_MASK
 
 /* equalities */
@@ -137,7 +136,7 @@ extern int KARATSUBA_MUL_CUTOFF,
 #endif
 
 /* size of comba arrays, should be at least 2 * 2**(BITS_PER_WORD - BITS_PER_DIGIT*2) */
-#define MP_WARRAY               (1u << (((CHAR_BIT * sizeof(mp_word)) - (2 * DIGIT_BIT)) + 1))
+#define MP_WARRAY               (1u << (((CHAR_BIT * sizeof(mp_word)) - (2 * MP_DIGIT_BIT)) + 1))
 
 /* the infamous mp_int structure */
 typedef struct  {
@@ -160,6 +159,7 @@ typedef int ltm_prime_callback(unsigned char *dst, int len, void *dat);
 #  define MP_DEPRECATED_PRAGMA(s)
 #endif
 
+#define DIGIT_BIT   (MP_DEPRECATED_PRAGMA("DIGIT_BIT macro is deprecated, MP_DIGIT_BIT instead") MP_DIGIT_BIT)
 #define USED(m)     (MP_DEPRECATED_PRAGMA("USED macro is deprecated, use z->used instead") (m)->used)
 #define DIGIT(m, k) (MP_DEPRECATED_PRAGMA("DIGIT macro is deprecated, use z->dp instead") (m)->dp[(k)])
 #define SIGN(m)     (MP_DEPRECATED_PRAGMA("SIGN macro is deprecated, use z->sign instead") (m)->sign)

--- a/tommath.h
+++ b/tommath.h
@@ -137,7 +137,6 @@ extern int KARATSUBA_MUL_CUTOFF,
 
 /* size of comba arrays, should be at least 2 * 2**(BITS_PER_WORD - BITS_PER_DIGIT*2) */
 #define _MP_WARRAY_PRIVATE (1u << (((CHAR_BIT * sizeof(mp_word)) - (2 * MP_DIGIT_BIT)) + 1))
-#define MP_WARRAY (MP_DEPRECATED_PRAGMA("MP_WARRAY is an internal macro") _MP_WARRAY_PRIVATE)
 
 /* the infamous mp_int structure */
 typedef struct  {
@@ -148,22 +147,30 @@ typedef struct  {
 /* callback for mp_prime_random, should fill dst with random bytes and return how many read [upto len] */
 typedef int ltm_prime_callback(unsigned char *dst, int len, void *dat);
 
-#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 301)
-#  define MP_DEPRECATED(x) __attribute__((deprecated("replaced by " #x)))
-#  define _MP_DEPRECATED_PRAGMA(s) _Pragma(#s)
-#  define MP_DEPRECATED_PRAGMA(s) _MP_DEPRECATED_PRAGMA(GCC warning s)
-#elif defined(_MSC_VER) && _MSC_VER >= 1500
-#  define MP_DEPRECATED(x) __declspec(deprecated("replaced by " #x))
-#  define MP_DEPRECATED_PRAGMA(s) __pragma(message(s))
-#else
-#  define MP_DEPRECATED
-#  define MP_DEPRECATED_PRAGMA(s)
-#endif
+#ifndef MP_NO_DEPRECATED
 
-#define DIGIT_BIT   (MP_DEPRECATED_PRAGMA("DIGIT_BIT macro is deprecated, MP_DIGIT_BIT instead") MP_DIGIT_BIT)
-#define USED(m)     (MP_DEPRECATED_PRAGMA("USED macro is deprecated, use z->used instead") (m)->used)
-#define DIGIT(m, k) (MP_DEPRECATED_PRAGMA("DIGIT macro is deprecated, use z->dp instead") (m)->dp[(k)])
-#define SIGN(m)     (MP_DEPRECATED_PRAGMA("SIGN macro is deprecated, use z->sign instead") (m)->sign)
+#  ifndef _MP_NO_DEPRECATED_WARNING
+#    warning Deprecated functions are enabled, define MP_NO_DEPRECATED!
+#  endif
+
+#  if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 301)
+#    define MP_DEPRECATED(x) __attribute__((deprecated("replaced by " #x)))
+#    define _MP_DEPRECATED_PRAGMA(s) _Pragma(#s)
+#    define MP_DEPRECATED_PRAGMA(s) _MP_DEPRECATED_PRAGMA(GCC warning s)
+#  elif defined(_MSC_VER) && _MSC_VER >= 1500
+#    define MP_DEPRECATED(x) __declspec(deprecated("replaced by " #x))
+#    define MP_DEPRECATED_PRAGMA(s) __pragma(message(s))
+#  else
+#    define MP_DEPRECATED
+#    define MP_DEPRECATED_PRAGMA(s)
+#  endif
+
+#  define DIGIT_BIT   MP_DIGIT_BIT
+#  define USED(m)     (MP_DEPRECATED_PRAGMA("USED macro is deprecated, use z->used instead") (m)->used)
+#  define DIGIT(m, k) (MP_DEPRECATED_PRAGMA("DIGIT macro is deprecated, use z->dp instead") (m)->dp[(k)])
+#  define SIGN(m)     (MP_DEPRECATED_PRAGMA("SIGN macro is deprecated, use z->sign instead") (m)->sign)
+#  define MP_WARRAY   (MP_DEPRECATED_PRAGMA("MP_WARRAY is an internal macro") _MP_WARRAY_PRIVATE)
+#endif
 
 /* error code to char* string */
 const char *mp_error_to_string(int code);

--- a/tommath.h
+++ b/tommath.h
@@ -136,7 +136,8 @@ extern int KARATSUBA_MUL_CUTOFF,
 #endif
 
 /* size of comba arrays, should be at least 2 * 2**(BITS_PER_WORD - BITS_PER_DIGIT*2) */
-#define MP_WARRAY               (1u << (((CHAR_BIT * sizeof(mp_word)) - (2 * MP_DIGIT_BIT)) + 1))
+#define _MP_WARRAY_PRIVATE (1u << (((CHAR_BIT * sizeof(mp_word)) - (2 * MP_DIGIT_BIT)) + 1))
+#define MP_WARRAY (MP_DEPRECATED_PRAGMA("MP_WARRAY is an internal macro") _MP_WARRAY_PRIVATE)
 
 /* the infamous mp_int structure */
 typedef struct  {

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -89,6 +89,7 @@ int func_name (mp_int * a, type b)                       \
 }
 
 /* deprecated functions */
+#ifndef MP_NO_DEPRECATED
 MP_DEPRECATED(s_mp_invmod_fast) int fast_mp_invmod(const mp_int *a, const mp_int *b, mp_int *c);
 MP_DEPRECATED(s_mp_montgomery_reduce_fast) int fast_mp_montgomery_reduce(mp_int *x, const mp_int *n, mp_digit rho);
 MP_DEPRECATED(s_mp_mul_digs_fast) int fast_s_mp_mul_digs(const mp_int *a, const mp_int *b, mp_int *c, int digs);
@@ -104,6 +105,7 @@ MP_DEPRECATED(s_mp_karatsuba_sqr) int mp_karatsuba_sqr(const mp_int *a, mp_int *
 MP_DEPRECATED(s_mp_toom_mul) int mp_toom_mul(const mp_int *a, const mp_int *b, mp_int *c);
 MP_DEPRECATED(s_mp_toom_sqr) int mp_toom_sqr(const mp_int *a, mp_int *b);
 MP_DEPRECATED(s_mp_reverse) void bn_reverse(unsigned char *s, int len);
+#endif
 
 #ifdef __cplusplus
 }

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -25,6 +25,12 @@ extern void *MP_CALLOC(size_t nmemb, size_t size);
 extern void MP_FREE(void *mem, size_t size);
 #endif
 
+/* TODO: Remove _MP_WARRAY_PRIVATE as soon as deprecated
+ * MP_WARRAY is removed from tommath.h
+*/
+#undef MP_WARRAY
+#define MP_WARRAY _MP_WARRAY_PRIVATE
+
 #define MP_MIN(x, y) (((x) < (y)) ? (x) : (y))
 #define MP_MAX(x, y) (((x) > (y)) ? (x) : (y))
 

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -25,11 +25,9 @@ extern void *MP_CALLOC(size_t nmemb, size_t size);
 extern void MP_FREE(void *mem, size_t size);
 #endif
 
-/* TODO: Remove _MP_WARRAY_PRIVATE as soon as deprecated
- * MP_WARRAY is removed from tommath.h
-*/
+/* TODO: Remove PRIVATE_MP_WARRAY as soon as deprecated MP_WARRAY is removed from tommath.h */
 #undef MP_WARRAY
-#define MP_WARRAY _MP_WARRAY_PRIVATE
+#define MP_WARRAY PRIVATE_MP_WARRAY
 
 #define MP_MIN(x, y) (((x) < (y)) ? (x) : (y))
 #define MP_MAX(x, y) (((x) > (y)) ? (x) : (y))

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -68,14 +68,14 @@ extern const size_t mp_s_rmap_reverse_sz;
 int func_name (mp_int * a, type b)                       \
 {                                                        \
    int x = 0;                                            \
-   int new_size = (((CHAR_BIT * sizeof(type)) + DIGIT_BIT) - 1) / DIGIT_BIT; \
+   int new_size = (((CHAR_BIT * sizeof(type)) + MP_DIGIT_BIT) - 1) / MP_DIGIT_BIT; \
    int res = mp_grow(a, new_size);                       \
    if (res == MP_OKAY) {                                 \
      mp_zero(a);                                         \
      while (b != 0u) {                                   \
         a->dp[x++] = ((mp_digit)b & MP_MASK);            \
-        if ((CHAR_BIT * sizeof (b)) <= DIGIT_BIT) { break; } \
-        b >>= (((CHAR_BIT * sizeof (b)) <= DIGIT_BIT) ? 0 : DIGIT_BIT); \
+        if ((CHAR_BIT * sizeof (b)) <= MP_DIGIT_BIT) { break; } \
+        b >>= (((CHAR_BIT * sizeof (b)) <= MP_DIGIT_BIT) ? 0 : MP_DIGIT_BIT); \
      }                                                   \
      a->used = x;                                        \
    }                                                     \

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -10,14 +10,6 @@
 extern "C" {
 #endif
 
-#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 301)
-#  define MP_DEPRECATED(x) __attribute__((deprecated("replaced by " #x)))
-#elif defined(_MSC_VER) && _MSC_VER >= 1500
-#  define MP_DEPRECATED(x) __declspec(deprecated("replaced by " #x))
-#else
-#  define MP_DEPRECATED
-#endif
-
 /* define heap macros */
 #ifndef MP_MALLOC
 /* default to libc stuff */


### PR DESCRIPTION
@sjaeckel Does it make sense to cleanup the public api a bit? This will only give warnings in gcc and probably clang. But I don't see a way to do this more generally.

**Edit**: I moved the MP_DEPRECATED to the public header since we might need it later. Furthermore I added MP_DEPRECATED_PRAGMA which can be used in macro situations.