### PR TITLE
Allow setting tuning parameters via -D

### DIFF
--- a/tommath.h
+++ b/tommath.h
@@ -118,10 +118,18 @@ typedef uint64_t             mp_word;
 typedef int           mp_err;
 
 /* you'll have to tune these... */
-extern int KARATSUBA_MUL_CUTOFF,
-       KARATSUBA_SQR_CUTOFF,
-       TOOM_MUL_CUTOFF,
-       TOOM_SQR_CUTOFF;
+#ifndef KARATSUBA_SQR_CUTOFF
+extern int KARATSUBA_MUL_CUTOFF;
+#endif
+#ifndef KARATSUBA_SQR_CUTOFF
+extern int KARATSUBA_SQR_CUTOFF;
+#endif
+#ifndef TOOM_MUL_CUTOFF
+extern int TOOM_MUL_CUTOFF;
+#endif
+#ifndef TOOM_SQR_CUTOFF
+extern int TOOM_SQR_CUTOFF;
+#endif
 
 /* define this to use lower memory usage routines (exptmods mostly) */
 /* #define MP_LOW_MEM */


### PR DESCRIPTION
Depending on the environment, it might be nicer to be able to set the tuning parameters simply via `-D` than via a defining them in another file that is linked into the program.