### PR TITLE
make mp_word private

### DIFF
--- a/demo/shared.h
+++ b/demo/shared.h
@@ -19,6 +19,6 @@
 #endif
 
 #define MP_WUR /* TODO: result checks disabled for now */
-#include "tommath.h"
+#include "tommath_private.h"
 
 extern void ndraw(mp_int* a, const char* name);

--- a/demo/test.c
+++ b/demo/test.c
@@ -1,5 +1,4 @@
 #include "shared.h"
-#include "tommath_private.h"
 
 static long rand_long(void)
 {

--- a/tommath.h
+++ b/tommath.h
@@ -55,14 +55,14 @@ extern "C" {
  */
 #ifdef MP_8BIT
 typedef uint8_t              mp_digit;
-typedef uint16_t             mp_word;
+typedef uint16_t             private_mp_word;
 #   define MP_SIZEOF_MP_DIGIT 1
 #   ifdef MP_DIGIT_BIT
 #      error You must not define MP_DIGIT_BIT when using MP_8BIT
 #   endif
 #elif defined(MP_16BIT)
 typedef uint16_t             mp_digit;
-typedef uint32_t             mp_word;
+typedef uint32_t             private_mp_word;
 #   define MP_SIZEOF_MP_DIGIT 2
 #   ifdef MP_DIGIT_BIT
 #      error You must not define MP_DIGIT_BIT when using MP_16BIT
@@ -70,14 +70,14 @@ typedef uint32_t             mp_word;
 #elif defined(MP_64BIT)
 /* for GCC only on supported platforms */
 typedef uint64_t mp_digit;
-typedef unsigned long        mp_word __attribute__((mode(TI)));
+typedef unsigned long        private_mp_word __attribute__((mode(TI)));
 #   define MP_DIGIT_BIT 60
 #else
 /* this is the default case, 28-bit digits */
 
 /* this is to make porting into LibTomCrypt easier :-) */
 typedef uint32_t             mp_digit;
-typedef uint64_t             mp_word;
+typedef uint64_t             private_mp_word;
 
 #   ifdef MP_31BIT
 /* this is an extension that uses 31-bit digits */
@@ -88,6 +88,9 @@ typedef uint64_t             mp_word;
 #      define MP_28BIT
 #   endif
 #endif
+
+/* mp_word is a private type */
+#define mp_word MP_DEPRECATED_PRAGMA("mp_word has been made private") private_mp_word
 
 /* otherwise the bits per digit is calculated automatically from the size of a mp_digit */
 #ifndef MP_DIGIT_BIT
@@ -172,7 +175,7 @@ TOOM_SQR_CUTOFF;
 #endif
 
 /* size of comba arrays, should be at least 2 * 2**(BITS_PER_WORD - BITS_PER_DIGIT*2) */
-#define PRIVATE_MP_WARRAY (1uLL << (((CHAR_BIT * sizeof(mp_word)) - (2 * MP_DIGIT_BIT)) + 1))
+#define PRIVATE_MP_WARRAY (1uLL << (((CHAR_BIT * sizeof(private_mp_word)) - (2 * MP_DIGIT_BIT)) + 1))
 #define MP_WARRAY (MP_DEPRECATED_PRAGMA("MP_WARRAY is an internal macro") PRIVATE_MP_WARRAY)
 
 #if defined(__GNUC__) && __GNUC__ >= 4

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -131,6 +131,10 @@ extern void MP_FREE(void *mem, size_t size);
 #undef MP_WARRAY
 #define MP_WARRAY PRIVATE_MP_WARRAY
 
+/* TODO: Remove private_mp_word as soon as deprecated mp_word is removed from tommath. */
+#undef mp_word
+typedef private_mp_word mp_word;
+
 #define MP_MIN(x, y) (((x) < (y)) ? (x) : (y))
 #define MP_MAX(x, y) (((x) > (y)) ? (x) : (y))
 


### PR DESCRIPTION
mp_word is an internal type and it is problematic if it is exposed
in the public api. See for example #216 - MSVC does not support 128 bit
mp_words. But it is perfectly ok to use those internally in the library,
as long as the library is compiled with GCC.

Ping @nijtmans - does it make sense to hide the mp_word type from the public api in general?