### PR TITLE
make tommath_class.h and tommath_superclass.h private

### DIFF
--- a/makefile.mingw
+++ b/makefile.mingw
@@ -58,9 +58,8 @@ bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o bn_s_mp_mul_digs_fast.o bn_s
 bn_s_mp_mul_high_digs_fast.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
 bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
 
-HEADERS_PUB=tommath.h tommath_class.h tommath_superclass.h
-
-HEADERS=tommath_private.h $(HEADERS_PUB)
+HEADERS_PUB=tommath.h
+HEADERS=tommath_private.h tommath_class.h tommath_superclass.h $(HEADERS_PUB)
 
 #The default rule for make builds the libtommath.a library (static)
 default: $(LIBMAIN_S)

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -50,9 +50,8 @@ bn_s_mp_montgomery_reduce_fast.obj bn_s_mp_mul_digs.obj bn_s_mp_mul_digs_fast.ob
 bn_s_mp_mul_high_digs_fast.obj bn_s_mp_rand_jenkins.obj bn_s_mp_rand_platform.obj bn_s_mp_reverse.obj \
 bn_s_mp_sqr.obj bn_s_mp_sqr_fast.obj bn_s_mp_sub.obj bn_s_mp_toom_mul.obj bn_s_mp_toom_sqr.obj
 
-HEADERS_PUB=tommath.h tommath_class.h tommath_superclass.h
-
-HEADERS=tommath_private.h $(HEADERS_PUB)
+HEADERS_PUB=tommath.h
+HEADERS=tommath_private.h tommath_class.h tommath_superclass.h $(HEADERS_PUB)
 
 #The default rule for make builds the tommath.lib library (static)
 default: $(LIBMAIN_S)

--- a/makefile.unix
+++ b/makefile.unix
@@ -59,9 +59,8 @@ bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o bn_s_mp_mul_digs_fast.o bn_s
 bn_s_mp_mul_high_digs_fast.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
 bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
 
-HEADERS_PUB=tommath.h tommath_class.h tommath_superclass.h
-
-HEADERS=tommath_private.h $(HEADERS_PUB)
+HEADERS_PUB=tommath.h
+HEADERS=tommath_private.h tommath_class.h tommath_superclass.h $(HEADERS_PUB)
 
 #The default rule for make builds the libtommath.a library (static)
 default: $(LIBMAIN_S)

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -116,8 +116,8 @@ else
    COVERAGE_APP = ./test
 endif
 
-HEADERS_PUB=tommath.h tommath_class.h tommath_superclass.h
-HEADERS=tommath_private.h $(HEADERS_PUB)
+HEADERS_PUB=tommath.h
+HEADERS=tommath_private.h tommath_class.h tommath_superclass.h $(HEADERS_PUB)
 
 test_standalone: CFLAGS+=-DLTM_DEMO_TEST_VS_MTEST=0
 

--- a/tommath.h
+++ b/tommath.h
@@ -16,8 +16,6 @@
 #  include <stdio.h>
 #endif
 
-#include "tommath_class.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -5,6 +5,7 @@
 #define TOMMATH_PRIV_H_
 
 #include "tommath.h"
+#include "tommath_class.h"
 
 /* Hardening libtommath
  * --------------------


### PR DESCRIPTION
These headers are used for configuration during build time.
Therefore they shouldn't be exposed as part of the public API.