### PR TITLE
removed obsolete check

### DIFF
--- a/bn_mp_prime_is_prime.c
+++ b/bn_mp_prime_is_prime.c
@@ -25,11 +25,6 @@ mp_err mp_prime_is_prime(const mp_int *a, int t, mp_bool *result)
    /* default to no */
    *result = MP_NO;
 
-   /* valid value of t? */
-   if (t > MP_PRIME_SIZE) {
-      return MP_VAL;
-   }
-
    /* Some shortcuts */
    /* N > 3 */
    if (a->used == 1) {


### PR DESCRIPTION
Removed the test that checks if the number of M-R rounds is smaller `MP_PRIME_MAX`
Should repair the test failure in #269