### PR TITLE
Restrict running Valgrind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,13 @@ matrix:
     # We have only one program and the variable $BUILDOPTIONS
     # has only the options to that program: testme.sh
 
+    # Run always with valgrind (no sanitizer, but debug info)
+    - env: COMPILE_DEBUG=1 BUILDOPTIONS='--with-cc=gcc-4.9 --with-m64 --with-valgrind'
+      addons:
+        apt:
+          packages:
+            - gcc-4.9
+
     # Check source code format
     - env: BUILDOPTIONS='--format'
       addons:
@@ -94,7 +101,7 @@ matrix:
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --with-travis-valgrind --make-option=tune'
 
     # clang for x86-64 architecture (64-bit longs and 64-bit pointers)
-    - env: COMPILE_DEBUG=1 SANITIZER=1 CONV_WARNINGS=relaxed BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-valgrind'
+    - env: SANITIZER=1 CONV_WARNINGS=relaxed BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind'
     - env: SANITIZER=1 CONV_WARNINGS=strict BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-6.0 --with-m64 --with-travis-valgrind'
       addons:
@@ -134,11 +141,6 @@ matrix:
         apt:
           packages:
             - gcc-4.8
-    - env: BUILDOPTIONS='--with-cc=gcc-4.9 --with-m64 --with-travis-valgrind'
-      addons:
-        apt:
-          packages:
-            - gcc-4.9
 
     # GCC for the x86-64 architecture with restricted limb sizes
     # formerly started with the option "--with-low-mp" to testme.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,35 @@ matrix:
             - libc6-dev-i386
             - gcc-multilib
 
+    # Test "autotuning", the automatic evaluation and setting of the Toom-Cook cut-offs.
+    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_8BIT  --with-travis-valgrind --make-option=tune'
+    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_16BIT --with-travis-valgrind --make-option=tune'
+    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_32BIT --with-travis-valgrind --make-option=tune'
+    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --with-travis-valgrind --make-option=tune'
+    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_8BIT  --with-travis-valgrind --make-option=tune'
+    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_16BIT --with-travis-valgrind --make-option=tune'
+    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-travis-valgrind --make-option=tune'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --with-travis-valgrind --make-option=tune'
+
+    # clang for x86-64 architecture (64-bit longs and 64-bit pointers)
+    - env: SANITIZER=1 CONV_WARNINGS=relaxed BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-valgrind'
+    - env: SANITIZER=1 CONV_WARNINGS=strict BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-6.0 --with-m64 --with-travis-valgrind'
+      addons:
+        apt:
+          packages:
+            - clang-6.0
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-5.0 --with-m64 --with-travis-valgrind'
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+    - env: BUILDOPTIONS='--with-cc=clang-4.0 --with-m64 --with-travis-valgrind'
+      addons:
+        apt:
+          packages:
+            - clang-4.0
+
     # GCC for the x64_32 architecture (32-bit longs and 32-bit pointers)
     # TODO: Probably not possible to run anything in x32 in Travis
     #       but needs to be checked to be sure.
@@ -111,25 +140,6 @@ matrix:
           packages:
             - gcc-4.9
 
-    # clang for x86-64 architecture (64-bit longs and 64-bit pointers)
-    - env: SANITIZER=1 CONV_WARNINGS=relaxed BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-valgrind'
-    - env: SANITIZER=1 CONV_WARNINGS=strict BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-6.0 --with-m64 --with-travis-valgrind'
-      addons:
-        apt:
-          packages:
-            - clang-6.0
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-5.0 --with-m64 --with-travis-valgrind'
-      addons:
-        apt:
-          packages:
-            - clang-5.0
-    - env: BUILDOPTIONS='--with-cc=clang-4.0 --with-m64 --with-travis-valgrind'
-      addons:
-        apt:
-          packages:
-            - clang-4.0
-
     # GCC for the x86-64 architecture with restricted limb sizes
     # formerly started with the option "--with-low-mp" to testme.sh
     # but testing all three in one run took to long and timed out.
@@ -141,16 +151,6 @@ matrix:
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_8BIT  --with-travis-valgrind'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_16BIT --with-travis-valgrind'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-travis-valgrind'
-
-    # Test "autotuning", the automatic evaluation and setting of the Toom-Cook cut-offs.
-    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_8BIT  --with-travis-valgrind --make-option=tune'
-    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_16BIT --with-travis-valgrind --make-option=tune'
-    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_32BIT --with-travis-valgrind --make-option=tune'
-    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --with-travis-valgrind --make-option=tune'
-    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_8BIT  --with-travis-valgrind --make-option=tune'
-    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_16BIT --with-travis-valgrind --make-option=tune'
-    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-travis-valgrind --make-option=tune'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --with-travis-valgrind --make-option=tune'
 
     # GCC for the x86-64 architecture testing against a different Bigint-implementation
     # with 333333 different inputs.

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,12 +157,12 @@ matrix:
     # GCC for the x86-64 architecture testing against a different Bigint-implementation
     # with 333333 different inputs.
     #- env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --with-travis-valgrind'
-    #- env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
+    - env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
 
     # clang for the x86-64 architecture testing against a different Bigint-implementation
     # with a better random source.
     - env: BUILDOPTIONS='--with-cc=clang-7 --test-vs-mtest=333333 --with-travis-valgrind'
-    - env: BUILDOPTIONS='--with-cc=clang-7 --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
+    #- env: BUILDOPTIONS='--with-cc=clang-7 --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
 
 
 # Notifications go to

--- a/.travis.yml
+++ b/.travis.yml
@@ -154,12 +154,12 @@ matrix:
 
     # GCC for the x86-64 architecture testing against a different Bigint-implementation
     # with 333333 different inputs.
-    - env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --with-travis-valgrind'
-    - env: BUILDOPTIONS='--with-cc=clang-7 --test-vs-mtest=333333 --with-travis-valgrind'
+    #- env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --with-travis-valgrind'
+    #- env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
 
     # clang for the x86-64 architecture testing against a different Bigint-implementation
     # with a better random source.
-    - env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
+    - env: BUILDOPTIONS='--with-cc=clang-7 --test-vs-mtest=333333 --with-travis-valgrind'
     - env: BUILDOPTIONS='--with-cc=clang-7 --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ matrix:
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --with-travis-valgrind --make-option=tune'
 
     # clang for x86-64 architecture (64-bit longs and 64-bit pointers)
-    - env: SANITIZER=1 CONV_WARNINGS=relaxed BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-valgrind'
+    - env: COMPILE_DEBUG=1 SANITIZER=1 CONV_WARNINGS=relaxed BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-valgrind'
     - env: SANITIZER=1 CONV_WARNINGS=strict BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-6.0 --with-m64 --with-travis-valgrind'
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,18 @@ matrix:
     #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-travis-valgrind --make-option=tune'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --with-travis-valgrind --make-option=tune'
 
+    # GCC for the x86-64 architecture testing against a different Bigint-implementation
+    # with 333333 different inputs.
+    #- env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --with-travis-valgrind'
+    # ...  and a better random source.
+    - env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
+
+    # clang for the x86-64 architecture testing against a different Bigint-implementation
+    # with 333333 different inputs
+    - env: BUILDOPTIONS='--with-cc=clang-7 --test-vs-mtest=333333 --with-travis-valgrind'
+    # ...  and a better random source.
+    #- env: BUILDOPTIONS='--with-cc=clang-7 --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
+
     # GCC for the x64_32 architecture (32-bit longs and 32-bit pointers)
     # TODO: Probably not possible to run anything in x32 in Travis
     #       but needs to be checked to be sure.
@@ -153,17 +165,6 @@ matrix:
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_8BIT  --with-travis-valgrind'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_16BIT --with-travis-valgrind'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-travis-valgrind'
-
-    # GCC for the x86-64 architecture testing against a different Bigint-implementation
-    # with 333333 different inputs.
-    #- env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --with-travis-valgrind'
-    - env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
-
-    # clang for the x86-64 architecture testing against a different Bigint-implementation
-    # with a better random source.
-    - env: BUILDOPTIONS='--with-cc=clang-7 --test-vs-mtest=333333 --with-travis-valgrind'
-    #- env: BUILDOPTIONS='--with-cc=clang-7 --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
-
 
 # Notifications go to
 # An email address is also possible.

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,13 +60,6 @@ matrix:
     # We have only one program and the variable $BUILDOPTIONS
     # has only the options to that program: testme.sh
 
-    # Run always with valgrind (no sanitizer, but debug info)
-    - env: COMPILE_DEBUG=1 BUILDOPTIONS='--with-cc=gcc-4.9 --with-m64 --with-valgrind'
-      addons:
-        apt:
-          packages:
-            - gcc-4.9
-
     # Check source code format
     - env: BUILDOPTIONS='--format'
       addons:
@@ -74,7 +67,14 @@ matrix:
           packages:
             - astyle
 
-    # GCC for the 32-bit architecture (no valgrind yet)
+    # Run always with valgrind (no sanitizer, but debug info)
+    - env: COMPILE_DEBUG=1 BUILDOPTIONS='--with-cc=gcc-4.9 --with-m64 --with-valgrind'
+      addons:
+        apt:
+          packages:
+            - gcc-4.9
+
+    # GCC for the 32-bit architecture (no valgrind)
     - env: BUILDOPTIONS='--with-cc=gcc-5 --with-m32'
       addons:
         apt:
@@ -82,7 +82,7 @@ matrix:
             - libc6-dev-i386
             - gcc-multilib
 
-    # clang for the 32-bit architecture (no valgrind yet)
+    # clang for the 32-bit architecture (no valgrind)
     - env: BUILDOPTIONS='--with-cc=clang-7 --with-m32'
       addons:
         apt:
@@ -99,25 +99,6 @@ matrix:
     #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_16BIT --with-travis-valgrind --make-option=tune'
     #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-travis-valgrind --make-option=tune'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --with-travis-valgrind --make-option=tune'
-
-    # clang for x86-64 architecture (64-bit longs and 64-bit pointers)
-    - env: SANITIZER=1 CONV_WARNINGS=relaxed BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind'
-    - env: SANITIZER=1 CONV_WARNINGS=strict BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-6.0 --with-m64 --with-travis-valgrind'
-      addons:
-        apt:
-          packages:
-            - clang-6.0
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-5.0 --with-m64 --with-travis-valgrind'
-      addons:
-        apt:
-          packages:
-            - clang-5.0
-    - env: BUILDOPTIONS='--with-cc=clang-4.0 --with-m64 --with-travis-valgrind'
-      addons:
-        apt:
-          packages:
-            - clang-4.0
 
     # GCC for the x64_32 architecture (32-bit longs and 32-bit pointers)
     # TODO: Probably not possible to run anything in x32 in Travis
@@ -141,6 +122,25 @@ matrix:
         apt:
           packages:
             - gcc-4.8
+
+    # clang for x86-64 architecture (64-bit longs and 64-bit pointers)
+    - env: SANITIZER=1 CONV_WARNINGS=relaxed BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind'
+    - env: SANITIZER=1 CONV_WARNINGS=strict BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-6.0 --with-m64 --with-travis-valgrind'
+      addons:
+        apt:
+          packages:
+            - clang-6.0
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-5.0 --with-m64 --with-travis-valgrind'
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+    - env: BUILDOPTIONS='--with-cc=clang-4.0 --with-m64 --with-travis-valgrind'
+      addons:
+        apt:
+          packages:
+            - clang-4.0
 
     # GCC for the x86-64 architecture with restricted limb sizes
     # formerly started with the option "--with-low-mp" to testme.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,13 +143,13 @@ matrix:
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-travis-valgrind'
 
     # Test "autotuning", the automatic evaluation and setting of the Toom-Cook cut-offs.
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_8BIT  --with-travis-valgrind --make-option=tune'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_16BIT --with-travis-valgrind --make-option=tune'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_32BIT --with-travis-valgrind --make-option=tune'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --with-travis-valgrind --make-option=tune'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_8BIT  --with-travis-valgrind --make-option=tune'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_16BIT --with-travis-valgrind --make-option=tune'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-travis-valgrind --make-option=tune'
+    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_8BIT  --with-travis-valgrind --make-option=tune'
+    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_16BIT --with-travis-valgrind --make-option=tune'
+    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_32BIT --with-travis-valgrind --make-option=tune'
+    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --with-travis-valgrind --make-option=tune'
+    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_8BIT  --with-travis-valgrind --make-option=tune'
+    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_16BIT --with-travis-valgrind --make-option=tune'
+    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-travis-valgrind --make-option=tune'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --with-travis-valgrind --make-option=tune'
 
     # GCC for the x86-64 architecture testing against a different Bigint-implementation

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,37 +94,37 @@ matrix:
             - gcc-multilib
 
     # GCC for the x86-64 architecture (64-bit longs and 64-bit pointers)
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --with-m64 --with-valgrind'
-    - env: BUILDOPTIONS='--with-cc=gcc-4.7 --with-m64 --with-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --with-m64 --with-travis-valgrind'
+    - env: BUILDOPTIONS='--with-cc=gcc-4.7 --with-m64 --with-travis-valgrind'
       addons:
         apt:
           packages:
             - gcc-4.7
-    - env: BUILDOPTIONS='--with-cc=gcc-4.8 --with-m64 --with-valgrind'
+    - env: BUILDOPTIONS='--with-cc=gcc-4.8 --with-m64 --with-travis-valgrind'
       addons:
         apt:
           packages:
             - gcc-4.8
-    - env: BUILDOPTIONS='--with-cc=gcc-4.9 --with-m64 --with-valgrind'
+    - env: BUILDOPTIONS='--with-cc=gcc-4.9 --with-m64 --with-travis-valgrind'
       addons:
         apt:
           packages:
             - gcc-4.9
 
     # clang for x86-64 architecture (64-bit longs and 64-bit pointers)
-    - env: SANITIZER=1 CONV_WARNINGS=strict BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-valgrind'
     - env: SANITIZER=1 CONV_WARNINGS=relaxed BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-valgrind'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-6.0 --with-m64 --with-valgrind'
+    - env: SANITIZER=1 CONV_WARNINGS=strict BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-6.0 --with-m64 --with-travis-valgrind'
       addons:
         apt:
           packages:
             - clang-6.0
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-5.0 --with-m64 --with-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-5.0 --with-m64 --with-travis-valgrind'
       addons:
         apt:
           packages:
             - clang-5.0
-    - env: BUILDOPTIONS='--with-cc=clang-4.0 --with-m64 --with-valgrind'
+    - env: BUILDOPTIONS='--with-cc=clang-4.0 --with-m64 --with-travis-valgrind'
       addons:
         apt:
           packages:
@@ -133,34 +133,34 @@ matrix:
     # GCC for the x86-64 architecture with restricted limb sizes
     # formerly started with the option "--with-low-mp" to testme.sh
     # but testing all three in one run took to long and timed out.
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_8BIT  --with-valgrind'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_16BIT --with-valgrind'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_32BIT --with-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_8BIT  --with-travis-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_16BIT --with-travis-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_32BIT --with-travis-valgrind'
 
     # clang for the x86-64 architecture with restricted limb sizes
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_8BIT  --with-valgrind'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_16BIT --with-valgrind'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_8BIT  --with-travis-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_16BIT --with-travis-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-travis-valgrind'
 
     # Test "autotuning", the automatic evaluation and setting of the Toom-Cook cut-offs.
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_8BIT  --with-valgrind --make-option=tune'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_16BIT --with-valgrind --make-option=tune'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_32BIT --with-valgrind --make-option=tune'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --with-valgrind --make-option=tune'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_8BIT  --with-valgrind --make-option=tune'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_16BIT --with-valgrind --make-option=tune'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-valgrind --make-option=tune'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --with-valgrind --make-option=tune'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_8BIT  --with-travis-valgrind --make-option=tune'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_16BIT --with-travis-valgrind --make-option=tune'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_32BIT --with-travis-valgrind --make-option=tune'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --with-travis-valgrind --make-option=tune'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_8BIT  --with-travis-valgrind --make-option=tune'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_16BIT --with-travis-valgrind --make-option=tune'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-travis-valgrind --make-option=tune'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --with-travis-valgrind --make-option=tune'
 
     # GCC for the x86-64 architecture testing against a different Bigint-implementation
     # with 333333 different inputs.
-    - env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --with-valgrind'
-    - env: BUILDOPTIONS='--with-cc=clang-7 --test-vs-mtest=333333 --with-valgrind'
+    - env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --with-travis-valgrind'
+    - env: BUILDOPTIONS='--with-cc=clang-7 --test-vs-mtest=333333 --with-travis-valgrind'
 
     # clang for the x86-64 architecture testing against a different Bigint-implementation
     # with a better random source.
-    - env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --mtest-real-rand --with-valgrind'
-    - env: BUILDOPTIONS='--with-cc=clang-7 --test-vs-mtest=333333 --mtest-real-rand --with-valgrind'
+    - env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
+    - env: BUILDOPTIONS='--with-cc=clang-7 --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
 
 
 # Notifications go to

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -71,7 +71,7 @@ endif
 ifdef COMPILE_DEBUG
 #debug
 CFLAGS += -g3
-else
+endif
 
 ifdef COMPILE_SIZE
 #for size
@@ -87,7 +87,6 @@ CFLAGS  += -fomit-frame-pointer
 endif
 
 endif # COMPILE_SIZE
-endif # COMPILE_DEBUG
 
 ifneq ($(findstring clang,$(CC)),)
 CFLAGS += -Wno-typedef-redefinition -Wno-tautological-compare -Wno-builtin-requires-header

--- a/testme.sh
+++ b/testme.sh
@@ -128,7 +128,7 @@ _runtest()
     # get switched off without some effort, so we just let it run twice for testing purposes
     _make "$1" "$2" ""
     echo -e "\rRun autotune $1 $2"
-    $_timeout ./etc/tune_it.sh > test_${suffix}.log || _die "running autotune" $?
+    $_timeout $TUNE_CMD > ../test_${suffix}.log || _die "running autotune" $?
   else
     _make "$1" "$2" "test_standalone"
     echo -e "\rRun test $1 $2"
@@ -154,7 +154,7 @@ echo "autotune branch"
     # The shell used for /bin/sh is DASH 0.5.7-4ubuntu1 on the author's machine which fails valgrind, so
     # we just run on instance of etc/tune with the same options as in etc/tune_it.sh
     echo -e "\rRun etc/tune $1 $2 once inside valgrind"
-    $_timeout $VALGRIND_BIN $VALGRIND_OPTS ./etc/tune -t -r 10 -L 3 > test_${suffix}.log || _die "running etc/tune" $?
+    $_timeout $VALGRIND_BIN $VALGRIND_OPTS $TUNE_CMD > test_${suffix}.log || _die "running etc/tune" $?
   else
     _make "$1" "$2" "test_standalone"
     echo -e "\rRun test $1 $2 inside valgrind"
@@ -195,6 +195,7 @@ VALGRIND_OPTS=" --leak-check=full --show-leak-kinds=all --error-exitcode=1 "
 #VALGRIND_OPTS=""
 VALGRIND_BIN=""
 CHECK_FORMAT=""
+TUNE_CMD="./etc/tune -t -r 10 -L 3"
 
 alive_pid=0
 

--- a/testme.sh
+++ b/testme.sh
@@ -61,11 +61,13 @@ _help()
   echo "    --with-valgrind"
   echo "    --with-valgrind=*       Run in valgrind (slow!)."
   echo
-  echo "    --valgrind-options       Additional Valgrind options"
-  echo "                             Some of the options like e.g.:"
-  echo "                             --track-origins=yes add a lot of extra"
-  echo "                             runtime and may trigger the 30 minutes"
-  echo "                             timeout."
+  echo "    --with-travis-valgrind  Run with valgrind on Travis on specific branches."
+  echo
+  echo "    --valgrind-options      Additional Valgrind options"
+  echo "                            Some of the options like e.g.:"
+  echo "                            --track-origins=yes add a lot of extra"
+  echo "                            runtime and may trigger the 30 minutes"
+  echo "                            timeout."
   echo
   echo "Godmode:"
   echo
@@ -231,6 +233,18 @@ do
         VALGRIND_BIN="valgrind"
       fi
       start_alive_printing
+    ;;
+    --with-travis-valgrind*)
+      if [[ ("$TRAVIS_BRANCH" == "develop" && "$TRAVIS_PULL_REQUEST" == "false") || "$TRAVIS_BRANCH" == *"valgrind"* || "$TRAVIS_COMMIT_MESSAGE" == *"valgrind"* ]]
+      then
+        if [[ ${1#*d} != "" ]]
+        then
+          VALGRIND_BIN="${1#*=}"
+        else
+          VALGRIND_BIN="valgrind"
+        fi
+        start_alive_printing
+      fi
     ;;
     --make-option=*)
       MAKE_OPTIONS="$MAKE_OPTIONS ${1#*=}"


### PR DESCRIPTION
* Activate on the develop branch
* Activate on branches containing the word v-algrind (without hyphen)
* Activate if the commit message contains v-algrind (without hyphen)

With valgrind the tests take about 15 minutes, without valgrind about 1 minute. We should not do that. I think it is bad for us and it is kind of abusive towards travis.
