### PR TITLE
deprecate mp_prime_is_divisible and ltm_prime_tab

### DIFF
--- a/bn_deprecated.c
+++ b/bn_deprecated.c
@@ -12,8 +12,8 @@ int mp_get_bit(const mp_int *a, int b)
    return (s_mp_get_bit(a, (unsigned int)b) == MP_YES) ? MP_YES : MP_NO;
 }
 #endif
-#ifdef BN_S_MP_JACOBI_C
-mp_err s_mp_jacobi(const mp_int *a, const mp_int *n, int *c)
+#ifdef BN_MP_JACOBI_C
+mp_err mp_jacobi(const mp_int *a, const mp_int *n, int *c)
 {
    if (a->sign == MP_NEG) {
       return MP_VAL;
@@ -22,12 +22,6 @@ mp_err s_mp_jacobi(const mp_int *a, const mp_int *n, int *c)
       return MP_VAL;
    }
    return mp_kronecker(a, n, c);
-}
-#endif
-#ifdef BN_MP_JACOBI_C
-mp_err mp_jacobi(const mp_int *a, const mp_int *n, int *c)
-{
-   return s_mp_jacobi(a, n, c);
 }
 #endif
 #ifdef BN_MP_PRIME_RANDOM_EX_C
@@ -189,6 +183,12 @@ unsigned long mp_get_long(const mp_int *a)
 unsigned long long mp_get_long_long(const mp_int *a)
 {
    return (unsigned long long)mp_get_mag64(a);
+}
+#endif
+#ifdef BN_MP_PRIME_IS_DIVISIBLE_C
+mp_err mp_prime_is_divisible(const mp_int *a, mp_bool *result)
+{
+   return s_mp_prime_is_divisible(a, result);
 }
 #endif
 #endif

--- a/bn_mp_prime_is_prime.c
+++ b/bn_mp_prime_is_prime.c
@@ -51,21 +51,21 @@ mp_err mp_prime_is_prime(const mp_int *a, int t, mp_bool *result)
    }
 
    /* is the input equal to one of the primes in the table? */
-   for (ix = 0; ix < MP_PRIME_SIZE; ix++) {
-      if (mp_cmp_d(a, ltm_prime_tab[ix]) == MP_EQ) {
+   for (ix = 0; ix < PRIVATE_MP_PRIME_TAB_SIZE; ix++) {
+      if (mp_cmp_d(a, s_mp_prime_tab[ix]) == MP_EQ) {
          *result = MP_YES;
          return MP_OKAY;
       }
    }
 #ifdef MP_8BIT
    /* The search in the loop above was exhaustive in this case */
-   if ((a->used == 1) && (MP_PRIME_SIZE >= 31)) {
+   if ((a->used == 1) && (PRIVATE_MP_PRIME_TAB_SIZE >= 31)) {
       return MP_OKAY;
    }
 #endif
 
    /* first perform trial division */
-   if ((err = mp_prime_is_divisible(a, &res)) != MP_OKAY) {
+   if ((err = s_mp_prime_is_divisible(a, &res)) != MP_OKAY) {
       return err;
    }
 
@@ -173,7 +173,7 @@ mp_err mp_prime_is_prime(const mp_int *a, int t, mp_bool *result)
 
       /* we did bases 2 and 3  already, skip them */
       for (ix = 2; ix < p_max; ix++) {
-         mp_set(&b, ltm_prime_tab[ix]);
+         mp_set(&b, s_mp_prime_tab[ix]);
          if ((err = mp_prime_miller_rabin(a, &b, &res)) != MP_OKAY) {
             goto LBL_B;
          }

--- a/bn_mp_prime_next_prime.c
+++ b/bn_mp_prime_next_prime.c
@@ -13,17 +13,17 @@ mp_err mp_prime_next_prime(mp_int *a, int t, int bbs_style)
    int      x, y;
    mp_err  err;
    mp_bool res = MP_NO;
-   mp_digit res_tab[MP_PRIME_SIZE], step, kstep;
+   mp_digit res_tab[PRIVATE_MP_PRIME_TAB_SIZE], step, kstep;
    mp_int   b;
 
    /* force positive */
    a->sign = MP_ZPOS;
 
    /* simple algo if a is less than the largest prime in the table */
-   if (mp_cmp_d(a, ltm_prime_tab[MP_PRIME_SIZE-1]) == MP_LT) {
+   if (mp_cmp_d(a, s_mp_prime_tab[PRIVATE_MP_PRIME_TAB_SIZE-1]) == MP_LT) {
       /* find which prime it is bigger than */
-      for (x = MP_PRIME_SIZE - 2; x >= 0; x--) {
-         if (mp_cmp_d(a, ltm_prime_tab[x]) != MP_LT) {
+      for (x = PRIVATE_MP_PRIME_TAB_SIZE - 2; x >= 0; x--) {
+         if (mp_cmp_d(a, s_mp_prime_tab[x]) != MP_LT) {
             if (bbs_style == 1) {
                /* ok we found a prime smaller or
                 * equal [so the next is larger]
@@ -31,17 +31,17 @@ mp_err mp_prime_next_prime(mp_int *a, int t, int bbs_style)
                 * however, the prime must be
                 * congruent to 3 mod 4
                 */
-               if ((ltm_prime_tab[x + 1] & 3u) != 3u) {
+               if ((s_mp_prime_tab[x + 1] & 3u) != 3u) {
                   /* scan upwards for a prime congruent to 3 mod 4 */
-                  for (y = x + 1; y < MP_PRIME_SIZE; y++) {
-                     if ((ltm_prime_tab[y] & 3u) == 3u) {
-                        mp_set(a, ltm_prime_tab[y]);
+                  for (y = x + 1; y < PRIVATE_MP_PRIME_TAB_SIZE; y++) {
+                     if ((s_mp_prime_tab[y] & 3u) == 3u) {
+                        mp_set(a, s_mp_prime_tab[y]);
                         return MP_OKAY;
                      }
                   }
                }
             } else {
-               mp_set(a, ltm_prime_tab[x + 1]);
+               mp_set(a, s_mp_prime_tab[x + 1]);
                return MP_OKAY;
             }
          }
@@ -80,8 +80,8 @@ mp_err mp_prime_next_prime(mp_int *a, int t, int bbs_style)
    }
 
    /* generate the restable */
-   for (x = 1; x < MP_PRIME_SIZE; x++) {
-      if ((err = mp_mod_d(a, ltm_prime_tab[x], res_tab + x)) != MP_OKAY) {
+   for (x = 1; x < PRIVATE_MP_PRIME_TAB_SIZE; x++) {
+      if ((err = mp_mod_d(a, s_mp_prime_tab[x], res_tab + x)) != MP_OKAY) {
          return err;
       }
    }
@@ -102,13 +102,13 @@ mp_err mp_prime_next_prime(mp_int *a, int t, int bbs_style)
          step += kstep;
 
          /* compute the new residue without using division */
-         for (x = 1; x < MP_PRIME_SIZE; x++) {
+         for (x = 1; x < PRIVATE_MP_PRIME_TAB_SIZE; x++) {
             /* add the step to each residue */
             res_tab[x] += kstep;
 
             /* subtract the modulus [instead of using division] */
-            if (res_tab[x] >= ltm_prime_tab[x]) {
-               res_tab[x]  -= ltm_prime_tab[x];
+            if (res_tab[x] >= s_mp_prime_tab[x]) {
+               res_tab[x]  -= s_mp_prime_tab[x];
             }
 
             /* set flag if zero */

--- a/bn_prime_tab.c
+++ b/bn_prime_tab.c
@@ -43,4 +43,19 @@ const mp_digit ltm_prime_tab[] = {
    0x062B, 0x062F, 0x063D, 0x0641, 0x0647, 0x0649, 0x064D, 0x0653
 #endif
 };
+
+#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 301)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+const mp_digit *s_mp_prime_tab = ltm_prime_tab;
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER) && _MSC_VER >= 1500
+#pragma warning(push)
+#pragma warning(disable: 4996)
+const mp_digit *s_mp_prime_tab = ltm_prime_tab;
+#pragma warning(pop)
+#else
+const mp_digit *s_mp_prime_tab = ltm_prime_tab;
+#endif
+
 #endif

--- a/bn_s_mp_prime_is_divisible.c
+++ b/bn_s_mp_prime_is_divisible.c
@@ -1,14 +1,14 @@
 #include "tommath_private.h"
-#ifdef BN_MP_PRIME_IS_DIVISIBLE_C
+#ifdef BN_S_MP_PRIME_IS_DIVISIBLE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
 /* determines if an integers is divisible by one
- * of the first MP_PRIME_SIZE primes or not
+ * of the first PRIME_SIZE primes or not
  *
  * sets result to 0 if not, 1 if yes
  */
-mp_err mp_prime_is_divisible(const mp_int *a, mp_bool *result)
+mp_err s_mp_prime_is_divisible(const mp_int *a, mp_bool *result)
 {
    int      ix;
    mp_err   err;
@@ -17,9 +17,9 @@ mp_err mp_prime_is_divisible(const mp_int *a, mp_bool *result)
    /* default to not */
    *result = MP_NO;
 
-   for (ix = 0; ix < MP_PRIME_SIZE; ix++) {
+   for (ix = 0; ix < PRIVATE_MP_PRIME_TAB_SIZE; ix++) {
       /* what is a mod LBL_prime_tab[ix] */
-      if ((err = mp_mod_d(a, ltm_prime_tab[ix], &res)) != MP_OKAY) {
+      if ((err = mp_mod_d(a, s_mp_prime_tab[ix], &res)) != MP_OKAY) {
          return err;
       }
 

--- a/demo/test.c
+++ b/demo/test.c
@@ -292,66 +292,6 @@ static int test_mp_rand(void)
    return err == MP_OKAY ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
-static int test_s_mp_jacobi(void)
-{
-   struct s_mp_jacobi_st {
-      unsigned long n;
-      int c[16];
-   };
-
-   static struct s_mp_jacobi_st jacobi[] = {
-      { 3, {  1, -1,  0,  1, -1,  0,  1, -1,  0,  1, -1,  0,  1, -1,  0,  1 } },
-      { 5, {  0,  1, -1, -1,  1,  0,  1, -1, -1,  1,  0,  1, -1, -1,  1,  0 } },
-      { 7, {  1, -1,  1, -1, -1,  0,  1,  1, -1,  1, -1, -1,  0,  1,  1, -1 } },
-      { 9, { -1,  1,  0,  1,  1,  0,  1,  1,  0,  1,  1,  0,  1,  1,  0,  1 } },
-   };
-
-   int i, n, cnt;
-   mp_err err, should;
-   mp_int a, b;
-   if (mp_init_multi(&a, &b, NULL)!= MP_OKAY) {
-      return EXIT_FAILURE;
-   }
-
-   mp_set_ul(&a, 0uL);
-   mp_set_ul(&b, 1uL);
-   if ((err = s_mp_jacobi(&a, &b, &i)) != MP_OKAY) {
-      printf("Failed executing s_mp_jacobi(0 | 1) %s.\n", mp_error_to_string(err));
-      goto LBL_ERR;
-   }
-   if (i != 1) {
-      printf("Failed trivial s_mp_jacobi(0 | 1) %d != 1\n", i);
-      goto LBL_ERR;
-   }
-   for (cnt = 0; cnt < (int)(sizeof(jacobi)/sizeof(jacobi[0])); ++cnt) {
-      mp_set_ul(&b, jacobi[cnt].n);
-      /* only test positive values of a */
-      for (n = -5; n <= 10; ++n) {
-         mp_set_ul(&a, (unsigned int)abs(n));
-         should = MP_OKAY;
-         if (n < 0) {
-            mp_neg(&a, &a);
-            /* Until #44 is fixed the negative a's must fail */
-            should = MP_VAL;
-         }
-         if ((err = s_mp_jacobi(&a, &b, &i)) != should) {
-            printf("Failed executing s_mp_jacobi(%d | %lu) %s.\n", n, jacobi[cnt].n, mp_error_to_string(err));
-            goto LBL_ERR;
-         }
-         if ((err == MP_OKAY) && (i != jacobi[cnt].c[n + 5])) {
-            printf("Failed trivial s_mp_jacobi(%d | %lu) %d != %d\n", n, jacobi[cnt].n, i, jacobi[cnt].c[n + 5]);
-            goto LBL_ERR;
-         }
-      }
-   }
-
-   mp_clear_multi(&a, &b, NULL);
-   return EXIT_SUCCESS;
-LBL_ERR:
-   mp_clear_multi(&a, &b, NULL);
-   return EXIT_FAILURE;
-}
-
 static int test_mp_kronecker(void)
 {
    struct mp_kronecker_st {
@@ -2175,7 +2115,6 @@ int unit_tests(int argc, char **argv)
       T(mp_sqrtmod_prime),
       T(mp_xor),
       T(s_mp_balance_mul),
-      T(s_mp_jacobi),
       T(s_mp_karatsuba_mul),
       T(s_mp_karatsuba_sqr),
       T(s_mp_toom_mul),

--- a/libtommath_VS2008.vcproj
+++ b/libtommath_VS2008.vcproj
@@ -601,10 +601,6 @@
 			>
 		</File>
 		<File
-			RelativePath="bn_mp_prime_is_divisible.c"
-			>
-		</File>
-		<File
 			RelativePath="bn_mp_prime_is_prime.c"
 			>
 		</File>
@@ -830,6 +826,10 @@
 		</File>
 		<File
 			RelativePath="bn_s_mp_mul_high_digs_fast.c"
+			>
+		</File>
+		<File
+			RelativePath="bn_s_mp_prime_is_divisible.c"
 			>
 		</File>
 		<File

--- a/makefile
+++ b/makefile
@@ -37,20 +37,20 @@ bn_mp_init_multi.o bn_mp_init_set.o bn_mp_init_size.o bn_mp_invmod.o bn_mp_is_sq
 bn_mp_isodd.o bn_mp_kronecker.o bn_mp_lcm.o bn_mp_lshd.o bn_mp_mod.o bn_mp_mod_2d.o bn_mp_mod_d.o \
 bn_mp_montgomery_calc_normalization.o bn_mp_montgomery_reduce.o bn_mp_montgomery_setup.o bn_mp_mul.o \
 bn_mp_mul_2.o bn_mp_mul_2d.o bn_mp_mul_d.o bn_mp_mulmod.o bn_mp_n_root.o bn_mp_n_root_ex.o bn_mp_neg.o \
-bn_mp_or.o bn_mp_prime_fermat.o bn_mp_prime_frobenius_underwood.o bn_mp_prime_is_divisible.o \
-bn_mp_prime_is_prime.o bn_mp_prime_miller_rabin.o bn_mp_prime_next_prime.o \
-bn_mp_prime_rabin_miller_trials.o bn_mp_prime_rand.o bn_mp_prime_strong_lucas_selfridge.o \
-bn_mp_radix_size.o bn_mp_radix_smap.o bn_mp_rand.o bn_mp_read_radix.o bn_mp_read_signed_bin.o \
-bn_mp_read_unsigned_bin.o bn_mp_reduce.o bn_mp_reduce_2k.o bn_mp_reduce_2k_l.o bn_mp_reduce_2k_setup.o \
-bn_mp_reduce_2k_setup_l.o bn_mp_reduce_is_2k.o bn_mp_reduce_is_2k_l.o bn_mp_reduce_setup.o bn_mp_rshd.o \
-bn_mp_set.o bn_mp_set_double.o bn_mp_shrink.o bn_mp_signed_bin_size.o bn_mp_signed_rsh.o bn_mp_sqr.o \
-bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o bn_mp_submod.o \
-bn_mp_to_signed_bin.o bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o bn_mp_to_unsigned_bin_n.o \
-bn_mp_toradix.o bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o \
-bn_s_mp_add.o bn_s_mp_balance_mul.o bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o \
-bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o \
-bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o \
-bn_s_mp_mul_high_digs_fast.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
+bn_mp_or.o bn_mp_prime_fermat.o bn_mp_prime_frobenius_underwood.o bn_mp_prime_is_prime.o \
+bn_mp_prime_miller_rabin.o bn_mp_prime_next_prime.o bn_mp_prime_rabin_miller_trials.o \
+bn_mp_prime_rand.o bn_mp_prime_strong_lucas_selfridge.o bn_mp_radix_size.o bn_mp_radix_smap.o \
+bn_mp_rand.o bn_mp_read_radix.o bn_mp_read_signed_bin.o bn_mp_read_unsigned_bin.o bn_mp_reduce.o \
+bn_mp_reduce_2k.o bn_mp_reduce_2k_l.o bn_mp_reduce_2k_setup.o bn_mp_reduce_2k_setup_l.o \
+bn_mp_reduce_is_2k.o bn_mp_reduce_is_2k_l.o bn_mp_reduce_setup.o bn_mp_rshd.o bn_mp_set.o \
+bn_mp_set_double.o bn_mp_shrink.o bn_mp_signed_bin_size.o bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o \
+bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o bn_mp_submod.o bn_mp_to_signed_bin.o \
+bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o bn_mp_to_unsigned_bin_n.o bn_mp_toradix.o \
+bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o \
+bn_s_mp_balance_mul.o bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o \
+bn_s_mp_invmod_slow.o bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o \
+bn_s_mp_mul_digs.o bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o \
+bn_s_mp_prime_is_divisible.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
 bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
 
 #END_INS

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -40,20 +40,20 @@ bn_mp_init_multi.o bn_mp_init_set.o bn_mp_init_size.o bn_mp_invmod.o bn_mp_is_sq
 bn_mp_isodd.o bn_mp_kronecker.o bn_mp_lcm.o bn_mp_lshd.o bn_mp_mod.o bn_mp_mod_2d.o bn_mp_mod_d.o \
 bn_mp_montgomery_calc_normalization.o bn_mp_montgomery_reduce.o bn_mp_montgomery_setup.o bn_mp_mul.o \
 bn_mp_mul_2.o bn_mp_mul_2d.o bn_mp_mul_d.o bn_mp_mulmod.o bn_mp_n_root.o bn_mp_n_root_ex.o bn_mp_neg.o \
-bn_mp_or.o bn_mp_prime_fermat.o bn_mp_prime_frobenius_underwood.o bn_mp_prime_is_divisible.o \
-bn_mp_prime_is_prime.o bn_mp_prime_miller_rabin.o bn_mp_prime_next_prime.o \
-bn_mp_prime_rabin_miller_trials.o bn_mp_prime_rand.o bn_mp_prime_strong_lucas_selfridge.o \
-bn_mp_radix_size.o bn_mp_radix_smap.o bn_mp_rand.o bn_mp_read_radix.o bn_mp_read_signed_bin.o \
-bn_mp_read_unsigned_bin.o bn_mp_reduce.o bn_mp_reduce_2k.o bn_mp_reduce_2k_l.o bn_mp_reduce_2k_setup.o \
-bn_mp_reduce_2k_setup_l.o bn_mp_reduce_is_2k.o bn_mp_reduce_is_2k_l.o bn_mp_reduce_setup.o bn_mp_rshd.o \
-bn_mp_set.o bn_mp_set_double.o bn_mp_shrink.o bn_mp_signed_bin_size.o bn_mp_signed_rsh.o bn_mp_sqr.o \
-bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o bn_mp_submod.o \
-bn_mp_to_signed_bin.o bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o bn_mp_to_unsigned_bin_n.o \
-bn_mp_toradix.o bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o \
-bn_s_mp_add.o bn_s_mp_balance_mul.o bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o \
-bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o \
-bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o \
-bn_s_mp_mul_high_digs_fast.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
+bn_mp_or.o bn_mp_prime_fermat.o bn_mp_prime_frobenius_underwood.o bn_mp_prime_is_prime.o \
+bn_mp_prime_miller_rabin.o bn_mp_prime_next_prime.o bn_mp_prime_rabin_miller_trials.o \
+bn_mp_prime_rand.o bn_mp_prime_strong_lucas_selfridge.o bn_mp_radix_size.o bn_mp_radix_smap.o \
+bn_mp_rand.o bn_mp_read_radix.o bn_mp_read_signed_bin.o bn_mp_read_unsigned_bin.o bn_mp_reduce.o \
+bn_mp_reduce_2k.o bn_mp_reduce_2k_l.o bn_mp_reduce_2k_setup.o bn_mp_reduce_2k_setup_l.o \
+bn_mp_reduce_is_2k.o bn_mp_reduce_is_2k_l.o bn_mp_reduce_setup.o bn_mp_rshd.o bn_mp_set.o \
+bn_mp_set_double.o bn_mp_shrink.o bn_mp_signed_bin_size.o bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o \
+bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o bn_mp_submod.o bn_mp_to_signed_bin.o \
+bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o bn_mp_to_unsigned_bin_n.o bn_mp_toradix.o \
+bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o \
+bn_s_mp_balance_mul.o bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o \
+bn_s_mp_invmod_slow.o bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o \
+bn_s_mp_mul_digs.o bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o \
+bn_s_mp_prime_is_divisible.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
 bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
 bn_mp_set_double.o bn_mp_set_int.o bn_mp_set_long.o bn_mp_set_long_long.o bn_mp_shrink.o \
 bn_mp_signed_bin_size.o bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o \

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -32,20 +32,20 @@ bn_mp_init_multi.obj bn_mp_init_set.obj bn_mp_init_size.obj bn_mp_invmod.obj bn_
 bn_mp_isodd.obj bn_mp_kronecker.obj bn_mp_lcm.obj bn_mp_lshd.obj bn_mp_mod.obj bn_mp_mod_2d.obj bn_mp_mod_d.obj \
 bn_mp_montgomery_calc_normalization.obj bn_mp_montgomery_reduce.obj bn_mp_montgomery_setup.obj bn_mp_mul.obj \
 bn_mp_mul_2.obj bn_mp_mul_2d.obj bn_mp_mul_d.obj bn_mp_mulmod.obj bn_mp_n_root.obj bn_mp_n_root_ex.obj bn_mp_neg.obj \
-bn_mp_or.obj bn_mp_prime_fermat.obj bn_mp_prime_frobenius_underwood.obj bn_mp_prime_is_divisible.obj \
-bn_mp_prime_is_prime.obj bn_mp_prime_miller_rabin.obj bn_mp_prime_next_prime.obj \
-bn_mp_prime_rabin_miller_trials.obj bn_mp_prime_rand.obj bn_mp_prime_strong_lucas_selfridge.obj \
-bn_mp_radix_size.obj bn_mp_radix_smap.obj bn_mp_rand.obj bn_mp_read_radix.obj bn_mp_read_signed_bin.obj \
-bn_mp_read_unsigned_bin.obj bn_mp_reduce.obj bn_mp_reduce_2k.obj bn_mp_reduce_2k_l.obj bn_mp_reduce_2k_setup.obj \
-bn_mp_reduce_2k_setup_l.obj bn_mp_reduce_is_2k.obj bn_mp_reduce_is_2k_l.obj bn_mp_reduce_setup.obj bn_mp_rshd.obj \
-bn_mp_set.obj bn_mp_set_double.obj bn_mp_shrink.obj bn_mp_signed_bin_size.obj bn_mp_signed_rsh.obj bn_mp_sqr.obj \
-bn_mp_sqrmod.obj bn_mp_sqrt.obj bn_mp_sqrtmod_prime.obj bn_mp_sub.obj bn_mp_sub_d.obj bn_mp_submod.obj \
-bn_mp_to_signed_bin.obj bn_mp_to_signed_bin_n.obj bn_mp_to_unsigned_bin.obj bn_mp_to_unsigned_bin_n.obj \
-bn_mp_toradix.obj bn_mp_toradix_n.obj bn_mp_unsigned_bin_size.obj bn_mp_xor.obj bn_mp_zero.obj bn_prime_tab.obj \
-bn_s_mp_add.obj bn_s_mp_balance_mul.obj bn_s_mp_exptmod.obj bn_s_mp_exptmod_fast.obj bn_s_mp_get_bit.obj \
-bn_s_mp_invmod_fast.obj bn_s_mp_invmod_slow.obj bn_s_mp_karatsuba_mul.obj bn_s_mp_karatsuba_sqr.obj \
-bn_s_mp_montgomery_reduce_fast.obj bn_s_mp_mul_digs.obj bn_s_mp_mul_digs_fast.obj bn_s_mp_mul_high_digs.obj \
-bn_s_mp_mul_high_digs_fast.obj bn_s_mp_rand_jenkins.obj bn_s_mp_rand_platform.obj bn_s_mp_reverse.obj \
+bn_mp_or.obj bn_mp_prime_fermat.obj bn_mp_prime_frobenius_underwood.obj bn_mp_prime_is_prime.obj \
+bn_mp_prime_miller_rabin.obj bn_mp_prime_next_prime.obj bn_mp_prime_rabin_miller_trials.obj \
+bn_mp_prime_rand.obj bn_mp_prime_strong_lucas_selfridge.obj bn_mp_radix_size.obj bn_mp_radix_smap.obj \
+bn_mp_rand.obj bn_mp_read_radix.obj bn_mp_read_signed_bin.obj bn_mp_read_unsigned_bin.obj bn_mp_reduce.obj \
+bn_mp_reduce_2k.obj bn_mp_reduce_2k_l.obj bn_mp_reduce_2k_setup.obj bn_mp_reduce_2k_setup_l.obj \
+bn_mp_reduce_is_2k.obj bn_mp_reduce_is_2k_l.obj bn_mp_reduce_setup.obj bn_mp_rshd.obj bn_mp_set.obj \
+bn_mp_set_double.obj bn_mp_shrink.obj bn_mp_signed_bin_size.obj bn_mp_signed_rsh.obj bn_mp_sqr.obj bn_mp_sqrmod.obj \
+bn_mp_sqrt.obj bn_mp_sqrtmod_prime.obj bn_mp_sub.obj bn_mp_sub_d.obj bn_mp_submod.obj bn_mp_to_signed_bin.obj \
+bn_mp_to_signed_bin_n.obj bn_mp_to_unsigned_bin.obj bn_mp_to_unsigned_bin_n.obj bn_mp_toradix.obj \
+bn_mp_toradix_n.obj bn_mp_unsigned_bin_size.obj bn_mp_xor.obj bn_mp_zero.obj bn_prime_tab.obj bn_s_mp_add.obj \
+bn_s_mp_balance_mul.obj bn_s_mp_exptmod.obj bn_s_mp_exptmod_fast.obj bn_s_mp_get_bit.obj bn_s_mp_invmod_fast.obj \
+bn_s_mp_invmod_slow.obj bn_s_mp_karatsuba_mul.obj bn_s_mp_karatsuba_sqr.obj bn_s_mp_montgomery_reduce_fast.obj \
+bn_s_mp_mul_digs.obj bn_s_mp_mul_digs_fast.obj bn_s_mp_mul_high_digs.obj bn_s_mp_mul_high_digs_fast.obj \
+bn_s_mp_prime_is_divisible.obj bn_s_mp_rand_jenkins.obj bn_s_mp_rand_platform.obj bn_s_mp_reverse.obj \
 bn_s_mp_sqr.obj bn_s_mp_sqr_fast.obj bn_s_mp_sub.obj bn_s_mp_toom_mul.obj bn_s_mp_toom_sqr.obj
 bn_mp_set_double.obj bn_mp_set_int.obj bn_mp_set_long.obj bn_mp_set_long_long.obj bn_mp_shrink.obj \
 bn_mp_signed_bin_size.obj bn_mp_signed_rsh.obj bn_mp_sqr.obj bn_mp_sqrmod.obj bn_mp_sqrt.obj bn_mp_sqrtmod_prime.obj \

--- a/makefile.shared
+++ b/makefile.shared
@@ -34,20 +34,20 @@ bn_mp_init_multi.o bn_mp_init_set.o bn_mp_init_size.o bn_mp_invmod.o bn_mp_is_sq
 bn_mp_isodd.o bn_mp_kronecker.o bn_mp_lcm.o bn_mp_lshd.o bn_mp_mod.o bn_mp_mod_2d.o bn_mp_mod_d.o \
 bn_mp_montgomery_calc_normalization.o bn_mp_montgomery_reduce.o bn_mp_montgomery_setup.o bn_mp_mul.o \
 bn_mp_mul_2.o bn_mp_mul_2d.o bn_mp_mul_d.o bn_mp_mulmod.o bn_mp_n_root.o bn_mp_n_root_ex.o bn_mp_neg.o \
-bn_mp_or.o bn_mp_prime_fermat.o bn_mp_prime_frobenius_underwood.o bn_mp_prime_is_divisible.o \
-bn_mp_prime_is_prime.o bn_mp_prime_miller_rabin.o bn_mp_prime_next_prime.o \
-bn_mp_prime_rabin_miller_trials.o bn_mp_prime_rand.o bn_mp_prime_strong_lucas_selfridge.o \
-bn_mp_radix_size.o bn_mp_radix_smap.o bn_mp_rand.o bn_mp_read_radix.o bn_mp_read_signed_bin.o \
-bn_mp_read_unsigned_bin.o bn_mp_reduce.o bn_mp_reduce_2k.o bn_mp_reduce_2k_l.o bn_mp_reduce_2k_setup.o \
-bn_mp_reduce_2k_setup_l.o bn_mp_reduce_is_2k.o bn_mp_reduce_is_2k_l.o bn_mp_reduce_setup.o bn_mp_rshd.o \
-bn_mp_set.o bn_mp_set_double.o bn_mp_shrink.o bn_mp_signed_bin_size.o bn_mp_signed_rsh.o bn_mp_sqr.o \
-bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o bn_mp_submod.o \
-bn_mp_to_signed_bin.o bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o bn_mp_to_unsigned_bin_n.o \
-bn_mp_toradix.o bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o \
-bn_s_mp_add.o bn_s_mp_balance_mul.o bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o \
-bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o \
-bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o \
-bn_s_mp_mul_high_digs_fast.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
+bn_mp_or.o bn_mp_prime_fermat.o bn_mp_prime_frobenius_underwood.o bn_mp_prime_is_prime.o \
+bn_mp_prime_miller_rabin.o bn_mp_prime_next_prime.o bn_mp_prime_rabin_miller_trials.o \
+bn_mp_prime_rand.o bn_mp_prime_strong_lucas_selfridge.o bn_mp_radix_size.o bn_mp_radix_smap.o \
+bn_mp_rand.o bn_mp_read_radix.o bn_mp_read_signed_bin.o bn_mp_read_unsigned_bin.o bn_mp_reduce.o \
+bn_mp_reduce_2k.o bn_mp_reduce_2k_l.o bn_mp_reduce_2k_setup.o bn_mp_reduce_2k_setup_l.o \
+bn_mp_reduce_is_2k.o bn_mp_reduce_is_2k_l.o bn_mp_reduce_setup.o bn_mp_rshd.o bn_mp_set.o \
+bn_mp_set_double.o bn_mp_shrink.o bn_mp_signed_bin_size.o bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o \
+bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o bn_mp_submod.o bn_mp_to_signed_bin.o \
+bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o bn_mp_to_unsigned_bin_n.o bn_mp_toradix.o \
+bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o \
+bn_s_mp_balance_mul.o bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o \
+bn_s_mp_invmod_slow.o bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o \
+bn_s_mp_mul_digs.o bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o \
+bn_s_mp_prime_is_divisible.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
 bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
 bn_mp_set_double.o bn_mp_set_int.o bn_mp_set_long.o bn_mp_set_long_long.o bn_mp_shrink.o \
 bn_mp_signed_bin_size.o bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o \

--- a/makefile.unix
+++ b/makefile.unix
@@ -41,20 +41,20 @@ bn_mp_init_multi.o bn_mp_init_set.o bn_mp_init_size.o bn_mp_invmod.o bn_mp_is_sq
 bn_mp_isodd.o bn_mp_kronecker.o bn_mp_lcm.o bn_mp_lshd.o bn_mp_mod.o bn_mp_mod_2d.o bn_mp_mod_d.o \
 bn_mp_montgomery_calc_normalization.o bn_mp_montgomery_reduce.o bn_mp_montgomery_setup.o bn_mp_mul.o \
 bn_mp_mul_2.o bn_mp_mul_2d.o bn_mp_mul_d.o bn_mp_mulmod.o bn_mp_n_root.o bn_mp_n_root_ex.o bn_mp_neg.o \
-bn_mp_or.o bn_mp_prime_fermat.o bn_mp_prime_frobenius_underwood.o bn_mp_prime_is_divisible.o \
-bn_mp_prime_is_prime.o bn_mp_prime_miller_rabin.o bn_mp_prime_next_prime.o \
-bn_mp_prime_rabin_miller_trials.o bn_mp_prime_rand.o bn_mp_prime_strong_lucas_selfridge.o \
-bn_mp_radix_size.o bn_mp_radix_smap.o bn_mp_rand.o bn_mp_read_radix.o bn_mp_read_signed_bin.o \
-bn_mp_read_unsigned_bin.o bn_mp_reduce.o bn_mp_reduce_2k.o bn_mp_reduce_2k_l.o bn_mp_reduce_2k_setup.o \
-bn_mp_reduce_2k_setup_l.o bn_mp_reduce_is_2k.o bn_mp_reduce_is_2k_l.o bn_mp_reduce_setup.o bn_mp_rshd.o \
-bn_mp_set.o bn_mp_set_double.o bn_mp_shrink.o bn_mp_signed_bin_size.o bn_mp_signed_rsh.o bn_mp_sqr.o \
-bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o bn_mp_submod.o \
-bn_mp_to_signed_bin.o bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o bn_mp_to_unsigned_bin_n.o \
-bn_mp_toradix.o bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o \
-bn_s_mp_add.o bn_s_mp_balance_mul.o bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o \
-bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o \
-bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o \
-bn_s_mp_mul_high_digs_fast.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
+bn_mp_or.o bn_mp_prime_fermat.o bn_mp_prime_frobenius_underwood.o bn_mp_prime_is_prime.o \
+bn_mp_prime_miller_rabin.o bn_mp_prime_next_prime.o bn_mp_prime_rabin_miller_trials.o \
+bn_mp_prime_rand.o bn_mp_prime_strong_lucas_selfridge.o bn_mp_radix_size.o bn_mp_radix_smap.o \
+bn_mp_rand.o bn_mp_read_radix.o bn_mp_read_signed_bin.o bn_mp_read_unsigned_bin.o bn_mp_reduce.o \
+bn_mp_reduce_2k.o bn_mp_reduce_2k_l.o bn_mp_reduce_2k_setup.o bn_mp_reduce_2k_setup_l.o \
+bn_mp_reduce_is_2k.o bn_mp_reduce_is_2k_l.o bn_mp_reduce_setup.o bn_mp_rshd.o bn_mp_set.o \
+bn_mp_set_double.o bn_mp_shrink.o bn_mp_signed_bin_size.o bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o \
+bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o bn_mp_submod.o bn_mp_to_signed_bin.o \
+bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o bn_mp_to_unsigned_bin_n.o bn_mp_toradix.o \
+bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o \
+bn_s_mp_balance_mul.o bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o \
+bn_s_mp_invmod_slow.o bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o \
+bn_s_mp_mul_digs.o bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o \
+bn_s_mp_prime_is_divisible.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
 bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
 bn_mp_set_double.o bn_mp_set_int.o bn_mp_set_long.o bn_mp_set_long_long.o bn_mp_shrink.o \
 bn_mp_signed_bin_size.o bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o \

--- a/tommath.h
+++ b/tommath.h
@@ -576,17 +576,17 @@ mp_err mp_exptmod(const mp_int *G, const mp_int *X, const mp_int *P, mp_int *Y) 
 
 /* number of primes */
 #ifdef MP_8BIT
-#  define MP_PRIME_SIZE 31
+#  define PRIVATE_MP_PRIME_TAB_SIZE 31
 #else
-#  define MP_PRIME_SIZE 256
+#  define PRIVATE_MP_PRIME_TAB_SIZE 256
 #endif
-#define PRIME_SIZE (MP_DEPRECATED_PRAGMA("PRIME_SIZE has been deprecated, use MP_PRIME_SIZE") MP_PRIME_SIZE)
+#define PRIME_SIZE (MP_DEPRECATED_PRAGMA("PRIME_SIZE has been made internal") PRIVATE_MP_PRIME_TAB_SIZE)
 
-/* table of first MP_PRIME_SIZE primes */
-extern const mp_digit ltm_prime_tab[MP_PRIME_SIZE];
+/* table of first PRIME_SIZE primes */
+MP_DEPRECATED(internal) extern const mp_digit ltm_prime_tab[PRIVATE_MP_PRIME_TAB_SIZE];
 
-/* result=1 if a is divisible by one of the first MP_PRIME_SIZE primes */
-mp_err mp_prime_is_divisible(const mp_int *a, mp_bool *result) MP_WUR;
+/* result=1 if a is divisible by one of the first PRIME_SIZE primes */
+MP_DEPRECATED(mp_prime_is_prime) mp_err mp_prime_is_divisible(const mp_int *a, mp_bool *result) MP_WUR;
 
 /* performs one Fermat test of "a" using base "b".
  * Sets result to 0 if composite or 1 if probable prime

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -82,7 +82,6 @@
 #   define BN_MP_OR_C
 #   define BN_MP_PRIME_FERMAT_C
 #   define BN_MP_PRIME_FROBENIUS_UNDERWOOD_C
-#   define BN_MP_PRIME_IS_DIVISIBLE_C
 #   define BN_MP_PRIME_IS_PRIME_C
 #   define BN_MP_PRIME_MILLER_RABIN_C
 #   define BN_MP_PRIME_NEXT_PRIME_C
@@ -140,6 +139,7 @@
 #   define BN_S_MP_MUL_DIGS_FAST_C
 #   define BN_S_MP_MUL_HIGH_DIGS_C
 #   define BN_S_MP_MUL_HIGH_DIGS_FAST_C
+#   define BN_S_MP_PRIME_IS_DIVISIBLE_C
 #   define BN_S_MP_RAND_JENKINS_C
 #   define BN_S_MP_RAND_PLATFORM_C
 #   define BN_S_MP_REVERSE_C
@@ -171,10 +171,9 @@
 #if defined(BN_DEPRECATED_C)
 #   define BN_MP_GET_BIT_C
 #   define BN_S_MP_GET_BIT_C
-#   define BN_S_MP_JACOBI_C
+#   define BN_MP_JACOBI_C
 #   define BN_MP_CMP_D_C
 #   define BN_MP_KRONECKER_C
-#   define BN_MP_JACOBI_C
 #   define BN_MP_PRIME_RANDOM_EX_C
 #   define BN_S_MP_PRIME_RANDOM_EX_C
 #   define BN_MP_RAND_DIGIT_C
@@ -224,6 +223,8 @@
 #   define BN_MP_GET_LONG_C
 #   define BN_MP_GET_MAG64_C
 #   define BN_MP_GET_LONG_LONG_C
+#   define BN_MP_PRIME_IS_DIVISIBLE_C
+#   define BN_S_MP_PRIME_IS_DIVISIBLE_C
 #endif
 
 #if defined(BN_MP_2EXPT_C)
@@ -675,14 +676,10 @@
 #   define BN_MP_CLEAR_MULTI_C
 #endif
 
-#if defined(BN_MP_PRIME_IS_DIVISIBLE_C)
-#   define BN_MP_MOD_D_C
-#endif
-
 #if defined(BN_MP_PRIME_IS_PRIME_C)
 #   define BN_MP_IS_SQUARE_C
 #   define BN_MP_CMP_D_C
-#   define BN_MP_PRIME_IS_DIVISIBLE_C
+#   define BN_S_MP_PRIME_IS_DIVISIBLE_C
 #   define BN_MP_INIT_SET_C
 #   define BN_MP_PRIME_MILLER_RABIN_C
 #   define BN_MP_PRIME_FROBENIUS_UNDERWOOD_C
@@ -1136,6 +1133,10 @@
 #if defined(BN_S_MP_MUL_HIGH_DIGS_FAST_C)
 #   define BN_MP_GROW_C
 #   define BN_MP_CLAMP_C
+#endif
+
+#if defined(BN_S_MP_PRIME_IS_DIVISIBLE_C)
+#   define BN_MP_MOD_D_C
 #endif
 
 #if defined(BN_S_MP_RAND_JENKINS_C)

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -198,8 +198,8 @@ MP_PRIVATE mp_err s_mp_exptmod_fast(const mp_int *G, const mp_int *X, const mp_i
 MP_PRIVATE mp_err s_mp_exptmod(const mp_int *G, const mp_int *X, const mp_int *P, mp_int *Y, int redmode) MP_WUR;
 MP_PRIVATE mp_err s_mp_rand_platform(void *p, size_t n) MP_WUR;
 MP_PRIVATE mp_err s_mp_prime_random_ex(mp_int *a, int t, int size, int flags, private_mp_prime_callback cb, void *dat);
-MP_PRIVATE mp_err s_mp_jacobi(const mp_int *a, const mp_int *n, int *c);
 MP_PRIVATE void s_mp_reverse(unsigned char *s, int len);
+MP_PRIVATE mp_err s_mp_prime_is_divisible(const mp_int *a, mp_bool *result);
 
 /* TODO: jenkins prng is not thread safe as of now */
 MP_PRIVATE mp_err s_mp_rand_jenkins(void *p, size_t n) MP_WUR;
@@ -208,6 +208,7 @@ MP_PRIVATE void s_mp_rand_jenkins_init(uint64_t seed);
 extern MP_PRIVATE const char *const mp_s_rmap;
 extern MP_PRIVATE const uint8_t mp_s_rmap_reverse[];
 extern MP_PRIVATE const size_t mp_s_rmap_reverse_sz;
+extern MP_PRIVATE const mp_digit *s_mp_prime_tab;
 
 /* deprecated functions */
 MP_DEPRECATED(s_mp_invmod_fast) mp_err fast_mp_invmod(const mp_int *a, const mp_int *b, mp_int *c);


### PR DESCRIPTION
* it is an implementation detail used for prime testing
* there is upcoming work by @czurnieden regarding a generalised prime sieve
* furthermore remove jacobi test (replaced by kronecker)