### PR TITLE
minor improvements&fixes

### DIFF
--- a/demo/test.c
+++ b/demo/test.c
@@ -137,7 +137,11 @@ LBL_ERR:
 
 static int check_get_set_i32(mp_int *a, int32_t b)
 {
+   mp_clear(a);
+   if (mp_shrink(a) != MP_OKAY) return EXIT_FAILURE;
+
    mp_set_i32(a, b);
+   if (mp_shrink(a) != MP_OKAY) return EXIT_FAILURE;
    if (mp_get_i32(a) != b) return EXIT_FAILURE;
    if (mp_get_u32(a) != (uint32_t)b) return EXIT_FAILURE;
    if (mp_get_mag32(a) != uabs32(b)) return EXIT_FAILURE;
@@ -180,7 +184,11 @@ LBL_ERR:
 
 static int check_get_set_i64(mp_int *a, int64_t b)
 {
+   mp_clear(a);
+   if (mp_shrink(a) != MP_OKAY) return EXIT_FAILURE;
+
    mp_set_i64(a, b);
+   if (mp_shrink(a) != MP_OKAY) return EXIT_FAILURE;
    if (mp_get_i64(a) != b) return EXIT_FAILURE;
    if (mp_get_u64(a) != (uint64_t)b) return EXIT_FAILURE;
    if (mp_get_mag64(a) != uabs64(b)) return EXIT_FAILURE;

--- a/etc/tune_it.sh
+++ b/etc/tune_it.sh
@@ -35,11 +35,12 @@ median() {
   echo $median
 }
 
-MPWD=$(pwd)
+MPWD=$(dirname $(readlink -f "$0"))
 FILE_NAME="tuning_list"
-TOMMATH_CUTOFFS_H="../tommath_cutoffs.h"
+TOMMATH_CUTOFFS_H="$MPWD/../tommath_cutoffs.h"
 BACKUP_SUFFIX=".orig"
-RNUM=0;
+RNUM=0
+
 #############################################################################
 # It would be a good idea to isolate these processes (with e.g.: cpuset)    #
 #                                                                           #

--- a/testme.sh
+++ b/testme.sh
@@ -126,9 +126,9 @@ _runtest()
   then
     # "make tune" will run "tune_it.sh" automatically, hence "autotune", but it cannot
     # get switched off without some effort, so we just let it run twice for testing purposes
-    _make "$1" "$2" ""
     echo -e "\rRun autotune $1 $2"
-    $_timeout $TUNE_CMD > ../test_${suffix}.log || _die "running autotune" $?
+    _make "$1" "$2" ""
+    $_timeout $TUNE_CMD > test_${suffix}.log || _die "running autotune" $?
   else
     _make "$1" "$2" "test_standalone"
     echo -e "\rRun test $1 $2"


### PR DESCRIPTION
The path to the output of the tuner `test_*.log` was wrong, it pointed to the parent directory.

[Edit] 
* Tests of `mp_shrink()` are added
* The path of `etc/tune_it.sh` is correctly determined, so you can also run e.g `./etc/tune_it.sh` from the project root