### PR TITLE
Formatting strange definitions of pointers to functions returning mp_err

### DIFF
--- a/bn_mp_rand.c
+++ b/bn_mp_rand.c
@@ -3,9 +3,9 @@
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
-mp_err(*s_mp_rand_source)(void *out, size_t size) = s_mp_rand_platform;
+mp_err (*s_mp_rand_source)(void *out, size_t size) = s_mp_rand_platform;
 
-void mp_rand_source(mp_err(*source)(void *out, size_t size))
+void mp_rand_source(mp_err (*source)(void *out, size_t size))
 {
    s_mp_rand_source = (source == NULL) ? s_mp_rand_platform : source;
 }

--- a/bn_s_mp_exptmod.c
+++ b/bn_s_mp_exptmod.c
@@ -15,7 +15,7 @@ mp_err s_mp_exptmod(const mp_int *G, const mp_int *X, const mp_int *P, mp_int *Y
    mp_digit buf;
    mp_err   err;
    int      bitbuf, bitcpy, bitcnt, mode, digidx, x, y, winsize;
-   mp_err(*redux)(mp_int *x, const mp_int *m, const mp_int *mu);
+   mp_err (*redux)(mp_int *x, const mp_int *m, const mp_int *mu);
 
    /* find window size */
    x = mp_count_bits(X);

--- a/bn_s_mp_exptmod_fast.c
+++ b/bn_s_mp_exptmod_fast.c
@@ -28,7 +28,7 @@ mp_err s_mp_exptmod_fast(const mp_int *G, const mp_int *X, const mp_int *P, mp_i
     * one of many reduction algorithms without modding the guts of
     * the code with if statements everywhere.
     */
-   mp_err(*redux)(mp_int *x, const mp_int *n, mp_digit rho);
+   mp_err (*redux)(mp_int *x, const mp_int *n, mp_digit rho);
 
    /* find window size */
    x = mp_count_bits(X);

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -174,7 +174,7 @@ typedef private_mp_word mp_word;
 MP_STATIC_ASSERT(prec_geq_min_prec, MP_PREC >= MP_MIN_PREC)
 
 /* random number source */
-extern MP_PRIVATE mp_err(*s_mp_rand_source)(void *out, size_t size);
+extern MP_PRIVATE mp_err (*s_mp_rand_source)(void *out, size_t size);
 
 /* lowlevel functions, do not call! */
 MP_PRIVATE mp_bool s_mp_get_bit(const mp_int *a, unsigned int b);


### PR DESCRIPTION
Noting that function pointer definitions, where the function returns mp_err, are strangely formatted: They look like function calls. If the function returns int or long, formatting is OK.

This commit fixes this strange formatting.