### PR TITLE
Fix MSVC warning

### DIFF
--- a/tommath.h
+++ b/tommath.h
@@ -369,7 +369,7 @@ mp_err mp_rand(mp_int *a, int digits) MP_WUR;
 /* makes a pseudo-random small int of a given size */
 MP_DEPRECATED(mp_rand) mp_err mp_rand_digit(mp_digit *r) MP_WUR;
 /* use custom random data source instead of source provided the platform */
-void mp_rand_source(mp_err source(void *out, size_t size));
+void mp_rand_source(mp_err(*source)(void *out, size_t size));
 
 #ifdef MP_PRNG_ENABLE_LTM_RNG
 #  warning MP_PRNG_ENABLE_LTM_RNG has been deprecated, use mp_rand_source instead.


### PR DESCRIPTION
Compilation of "development" with Visual Studio 2017 gave:

bn_mp_rand.c
bn_mp_rand.c(9): warning C4028: formal parameter 1 different from declaration

This commit fixes this warning