### PR TITLE
MSVC compile:  higher warning-level -Wall, but warning-free

### DIFF
--- a/demo/test.c
+++ b/demo/test.c
@@ -622,6 +622,7 @@ LBL_ERR:
 
 }
 
+#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559)
 static int test_mp_set_double(void)
 {
    int i;
@@ -632,7 +633,6 @@ static int test_mp_set_double(void)
    }
 
    /* test mp_get_double/mp_set_double */
-#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559)
    if (mp_set_double(&a, +1.0/0.0) != MP_VAL) {
       printf("\nmp_set_double should return MP_VAL for +inf");
       goto LBL_ERR;
@@ -670,7 +670,6 @@ static int test_mp_set_double(void)
          goto LBL_ERR;
       }
    }
-#endif
 
    mp_clear_multi(&a, &b, NULL);
    return EXIT_SUCCESS;
@@ -679,6 +678,7 @@ LBL_ERR:
    return EXIT_FAILURE;
 
 }
+#endif
 
 static int test_mp_get_u32(void)
 {
@@ -2112,7 +2112,9 @@ int unit_tests(int argc, char **argv)
       T(mp_read_radix),
       T(mp_reduce_2k),
       T(mp_reduce_2k_l),
+#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559)
       T(mp_set_double),
+#endif
       T(mp_signed_rsh),
       T(mp_sqrt),
       T(mp_sqrtmod_prime),

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -14,7 +14,7 @@ PREFIX    = c:\devel
 CFLAGS    = /Ox
 
 #Compilation flags
-LTM_CFLAGS  = /nologo /I./ /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /Wall /wd4146 /wd4127 /wd4710 /wd4711 /wd4820 $(CFLAGS)
+LTM_CFLAGS  = /nologo /I./ /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D__STDC_WANT_SECURE_LIB__=0 /Wall /wd4146 /wd4127 /wd4710 /wd4711 /wd4820 $(CFLAGS)
 LTM_LDFLAGS = advapi32.lib
 
 #Libraries to be created (this makefile builds only static libraries)

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -14,7 +14,7 @@ PREFIX    = c:\devel
 CFLAGS    = /Ox
 
 #Compilation flags
-LTM_CFLAGS  = /nologo /I./ /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /W3 $(CFLAGS)
+LTM_CFLAGS  = /nologo /I./ /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /Wall /wd4146 /wd4127 /wd4710 /wd4711 /wd4820 $(CFLAGS)
 LTM_LDFLAGS = advapi32.lib
 
 #Libraries to be created (this makefile builds only static libraries)
@@ -60,7 +60,7 @@ $(OBJECTS): $(HEADERS)
 .c.obj:
 	$(CC) $(LTM_CFLAGS) /c $< /Fo$@
 
-#Create tomcrypt.lib
+#Create tommath.lib
 $(LIBMAIN_S): $(OBJECTS)
 	lib /out:$(LIBMAIN_S) $(OBJECTS)
 


### PR DESCRIPTION
This updates the warning level for MSVC compiles to -Wall (from -W3).   At the same time, it removes 5 specific MSVC warnings, which are simply wrong and used legitimitely in libtommath:

C4146: unary minus operator applied to unsigned type, result still unsigned
C4127: conditional expression is constant
C4710: 'function' : function not inlined
C4711: function 'function' selected for inline expansion
C4820: 'bytes' bytes padding added after construct 'member_name'