### PR TITLE
Removed obsolete code

### DIFF
--- a/bn_mp_prime_is_prime.c
+++ b/bn_mp_prime_is_prime.c
@@ -145,7 +145,6 @@ mp_err mp_prime_is_prime(const mp_int *a, int t, mp_bool *result)
       TODO: can be made a bit finer grained but comparing is not free.
    */
    if (t < 0) {
-      t = -t;
       /*
           Sorenson, Jonathan; Webster, Jonathan (2015).
            "Strong Pseudoprimes to Twelve Prime Bases".

--- a/bn_mp_prime_strong_lucas_selfridge.c
+++ b/bn_mp_prime_strong_lucas_selfridge.c
@@ -177,26 +177,12 @@ mp_err mp_prime_strong_lucas_selfridge(const mp_int *a, mp_bool *result)
    mp_set(&U2mz, 1uL);  /* U_1 */
    mp_set(&V2mz, (mp_digit)P);  /* V_1 */
 
-   if (Q < 0) {
-      Q = -Q;
-      mp_set_u32(&Qmz, (uint32_t)Q);
-      if ((err = mp_mul_2(&Qmz, &Q2mz)) != MP_OKAY) {
-         goto LBL_LS_ERR;
-      }
-      /* Initializes calculation of Q^d */
-      mp_set_u32(&Qkdz, (uint32_t)Q);
-      Qmz.sign = MP_NEG;
-      Q2mz.sign = MP_NEG;
-      Qkdz.sign = MP_NEG;
-      Q = -Q;
-   } else {
-      mp_set_u32(&Qmz, (uint32_t)Q);
-      if ((err = mp_mul_2(&Qmz, &Q2mz)) != MP_OKAY) {
-         goto LBL_LS_ERR;
-      }
-      /* Initializes calculation of Q^d */
-      mp_set_u32(&Qkdz, (uint32_t)Q);
+   mp_set_i32(&Qmz, Q);
+   if ((err = mp_mul_2(&Qmz, &Q2mz)) != MP_OKAY) {
+      goto LBL_LS_ERR;
    }
+   /* Initializes calculation of Q^d */
+   mp_set_i32(&Qkdz, Q);
 
    Nbits = mp_count_bits(&Dz);
 


### PR DESCRIPTION
@karel-m  run `clang-tidy` and found several things (vid.: #317 ). Two of them are actually obsolete code and this PR removes them.

That code was in cryptographically sensitive parts of LTM, so a second (or more) opinion about the correctness would be highly appreciated!