### PR TITLE
Rename bn_get_magxx -> bn_get_mag_uxx.  Documentation updated too

### DIFF
--- a/bn_deprecated.c
+++ b/bn_deprecated.c
@@ -170,19 +170,19 @@ mp_err mp_set_long_long(mp_int *a, unsigned long long b)
 #ifdef BN_MP_GET_INT_C
 unsigned long mp_get_int(const mp_int *a)
 {
-   return mp_get_mag32(a);
+   return (unsigned long)mp_get_mag_u32(a);
 }
 #endif
 #ifdef BN_MP_GET_LONG_C
 unsigned long mp_get_long(const mp_int *a)
 {
-   return (sizeof(long) > sizeof(int32_t)) ? (unsigned long)mp_get_mag64(a) : (unsigned long)mp_get_mag32(a);
+   return (unsigned long)mp_get_mag_ul(a);
 }
 #endif
 #ifdef BN_MP_GET_LONG_LONG_C
 unsigned long long mp_get_long_long(const mp_int *a)
 {
-   return (unsigned long long)mp_get_mag64(a);
+   return mp_get_mag_ull(a);
 }
 #endif
 #ifdef BN_MP_PRIME_IS_DIVISIBLE_C

--- a/bn_mp_get_i32.c
+++ b/bn_mp_get_i32.c
@@ -3,5 +3,5 @@
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
-MP_GET_SIGNED(mp_get_i32, mp_get_mag32, int32_t, uint32_t)
+MP_GET_SIGNED(mp_get_i32, mp_get_mag_u32, int32_t, uint32_t)
 #endif

--- a/bn_mp_get_i64.c
+++ b/bn_mp_get_i64.c
@@ -3,5 +3,5 @@
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
-MP_GET_SIGNED(mp_get_i64, mp_get_mag64, int64_t, uint64_t)
+MP_GET_SIGNED(mp_get_i64, mp_get_mag_u64, int64_t, uint64_t)
 #endif

--- a/bn_mp_get_l.c
+++ b/bn_mp_get_l.c
@@ -3,5 +3,5 @@
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
-MP_GET_SIGNED(mp_get_l, mp_get_magl, long, unsigned long)
+MP_GET_SIGNED(mp_get_l, mp_get_mag_ul, long, unsigned long)
 #endif

--- a/bn_mp_get_ll.c
+++ b/bn_mp_get_ll.c
@@ -3,5 +3,5 @@
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
-MP_GET_SIGNED(mp_get_ll, mp_get_magll, long long, unsigned long long)
+MP_GET_SIGNED(mp_get_ll, mp_get_mag_ull, long long, unsigned long long)
 #endif

--- a/bn_mp_get_mag_u32.c
+++ b/bn_mp_get_mag_u32.c
@@ -1,7 +1,7 @@
 #include "tommath_private.h"
-#ifdef BN_MP_GET_MAGL_C
+#ifdef BN_MP_GET_MAG_U32_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
-MP_GET_MAG(mp_get_magl, unsigned long)
+MP_GET_MAG(mp_get_mag_u32, uint32_t)
 #endif

--- a/bn_mp_get_mag_u64.c
+++ b/bn_mp_get_mag_u64.c
@@ -1,7 +1,7 @@
 #include "tommath_private.h"
-#ifdef BN_MP_GET_MAG32_C
+#ifdef BN_MP_GET_MAG_U64_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
-MP_GET_MAG(mp_get_mag32, uint32_t)
+MP_GET_MAG(mp_get_mag_u64, uint64_t)
 #endif

--- a/bn_mp_get_mag_ul.c
+++ b/bn_mp_get_mag_ul.c
@@ -1,7 +1,7 @@
 #include "tommath_private.h"
-#ifdef BN_MP_GET_MAG64_C
+#ifdef BN_MP_GET_MAG_UL_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
-MP_GET_MAG(mp_get_mag64, uint64_t)
+MP_GET_MAG(mp_get_mag_ul, unsigned long)
 #endif

--- a/bn_mp_get_mag_ull.c
+++ b/bn_mp_get_mag_ull.c
@@ -1,7 +1,7 @@
 #include "tommath_private.h"
-#ifdef BN_MP_GET_MAGLL_C
+#ifdef BN_MP_GET_MAG_ULL_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
-MP_GET_MAG(mp_get_magll, unsigned long long)
+MP_GET_MAG(mp_get_mag_ull, unsigned long long)
 #endif

--- a/demo/test.c
+++ b/demo/test.c
@@ -90,7 +90,7 @@ static int test_trivial_stuff(void)
    if (mp_get_u32(&b) != (uint32_t)-4) {
       goto LBL_ERR;
    }
-   if (mp_get_mag32(&b) != 4) {
+   if (mp_get_mag_u32(&b) != 4) {
       goto LBL_ERR;
    }
    /* a: -5-> b: 1 */
@@ -139,7 +139,7 @@ static int check_get_set_i32(mp_int *a, int32_t b)
    if (mp_shrink(a) != MP_OKAY) return EXIT_FAILURE;
    if (mp_get_i32(a) != b) return EXIT_FAILURE;
    if (mp_get_u32(a) != (uint32_t)b) return EXIT_FAILURE;
-   if (mp_get_mag32(a) != uabs32(b)) return EXIT_FAILURE;
+   if (mp_get_mag_u32(a) != uabs32(b)) return EXIT_FAILURE;
 
    mp_set_u32(a, (uint32_t)b);
    if (mp_get_u32(a) != (uint32_t)b) return EXIT_FAILURE;
@@ -186,7 +186,7 @@ static int check_get_set_i64(mp_int *a, int64_t b)
    if (mp_shrink(a) != MP_OKAY) return EXIT_FAILURE;
    if (mp_get_i64(a) != b) return EXIT_FAILURE;
    if (mp_get_u64(a) != (uint64_t)b) return EXIT_FAILURE;
-   if (mp_get_mag64(a) != uabs64(b)) return EXIT_FAILURE;
+   if (mp_get_mag_u64(a) != uabs64(b)) return EXIT_FAILURE;
 
    mp_set_u64(a, (uint64_t)b);
    if (mp_get_u64(a) != (uint64_t)b) return EXIT_FAILURE;

--- a/doc/bn.tex
+++ b/doc/bn.tex
@@ -839,10 +839,10 @@ The value can be obtained again by calling the following functions.
 \begin{alltt}
 int32_t mp_get_i32 (mp_int * a);
 uint32_t mp_get_u32 (mp_int * a);
-uint32_t mp_get_mag32 (mp_int * a);
+uint32_t mp_get_mag_u32 (mp_int * a);
 int64_t mp_get_i64 (mp_int * a);
 uint64_t mp_get_u64 (mp_int * a);
-uint64_t mp_get_mag64 (mp_int * a);
+uint64_t mp_get_mag_u64 (mp_int * a);
 \end{alltt}
 
 These functions return the 32 or 64 least significant bits of $a$ respectively. The unsigned functions
@@ -894,7 +894,7 @@ To retrieve the value, the following functions can be used.
 \begin{alltt}
 long mp_get_l (mp_int * a);
 unsigned long mp_get_ul (mp_int * a);
-unsigned long mp_get_magl (mp_int * a);
+unsigned long mp_get_mag_ul (mp_int * a);
 \end{alltt}
 
 This will return the least significant bits of the mp\_int $a$ that fit into a ``long''.
@@ -915,7 +915,7 @@ To retrieve the value, the following functions can be used.
 \begin{alltt}
 long long mp_get_ll (mp_int * a);
 unsigned long long mp_get_ull (mp_int * a);
-unsigned long long mp_get_magll (mp_int * a);
+unsigned long long mp_get_mag_ull (mp_int * a);
 \end{alltt}
 
 This will return the least significant bits of the mp\_int $a$ that fit into a ``long long''.

--- a/libtommath_VS2008.vcproj
+++ b/libtommath_VS2008.vcproj
@@ -477,19 +477,19 @@
 			>
 		</File>
 		<File
-			RelativePath="bn_mp_get_mag32.c"
+			RelativePath="bn_mp_get_mag_u32.c"
 			>
 		</File>
 		<File
-			RelativePath="bn_mp_get_mag64.c"
+			RelativePath="bn_mp_get_mag_u64.c"
 			>
 		</File>
 		<File
-			RelativePath="bn_mp_get_magl.c"
+			RelativePath="bn_mp_get_mag_ul.c"
 			>
 		</File>
 		<File
-			RelativePath="bn_mp_get_magll.c"
+			RelativePath="bn_mp_get_mag_ull.c"
 			>
 		</File>
 		<File

--- a/makefile
+++ b/makefile
@@ -32,13 +32,13 @@ bn_mp_cnt_lsb.o bn_mp_complement.o bn_mp_copy.o bn_mp_count_bits.o bn_mp_decr.o 
 bn_mp_div_2d.o bn_mp_div_3.o bn_mp_div_d.o bn_mp_dr_is_modulus.o bn_mp_dr_reduce.o bn_mp_dr_setup.o \
 bn_mp_error_to_string.o bn_mp_exch.o bn_mp_export.o bn_mp_expt_d.o bn_mp_exptmod.o bn_mp_exteuclid.o \
 bn_mp_fread.o bn_mp_fwrite.o bn_mp_gcd.o bn_mp_get_double.o bn_mp_get_i32.o bn_mp_get_i64.o bn_mp_get_l.o \
-bn_mp_get_ll.o bn_mp_get_mag32.o bn_mp_get_mag64.o bn_mp_get_magl.o bn_mp_get_magll.o bn_mp_grow.o \
-bn_mp_ilogb.o bn_mp_import.o bn_mp_incr.o bn_mp_init.o bn_mp_init_copy.o bn_mp_init_i32.o bn_mp_init_i64.o \
-bn_mp_init_l.o bn_mp_init_ll.o bn_mp_init_multi.o bn_mp_init_set.o bn_mp_init_size.o bn_mp_init_u32.o \
-bn_mp_init_u64.o bn_mp_init_ul.o bn_mp_init_ull.o bn_mp_invmod.o bn_mp_is_square.o bn_mp_iseven.o \
-bn_mp_isodd.o bn_mp_kronecker.o bn_mp_lcm.o bn_mp_lshd.o bn_mp_mod.o bn_mp_mod_2d.o bn_mp_mod_d.o \
-bn_mp_montgomery_calc_normalization.o bn_mp_montgomery_reduce.o bn_mp_montgomery_setup.o bn_mp_mul.o \
-bn_mp_mul_2.o bn_mp_mul_2d.o bn_mp_mul_d.o bn_mp_mulmod.o bn_mp_n_root.o bn_mp_neg.o bn_mp_or.o \
+bn_mp_get_ll.o bn_mp_get_mag_u32.o bn_mp_get_mag_u64.o bn_mp_get_mag_ul.o bn_mp_get_mag_ull.o \
+bn_mp_grow.o bn_mp_ilogb.o bn_mp_import.o bn_mp_incr.o bn_mp_init.o bn_mp_init_copy.o bn_mp_init_i32.o \
+bn_mp_init_i64.o bn_mp_init_l.o bn_mp_init_ll.o bn_mp_init_multi.o bn_mp_init_set.o bn_mp_init_size.o \
+bn_mp_init_u32.o bn_mp_init_u64.o bn_mp_init_ul.o bn_mp_init_ull.o bn_mp_invmod.o bn_mp_is_square.o \
+bn_mp_iseven.o bn_mp_isodd.o bn_mp_kronecker.o bn_mp_lcm.o bn_mp_lshd.o bn_mp_mod.o bn_mp_mod_2d.o \
+bn_mp_mod_d.o bn_mp_montgomery_calc_normalization.o bn_mp_montgomery_reduce.o bn_mp_montgomery_setup.o \
+bn_mp_mul.o bn_mp_mul_2.o bn_mp_mul_2d.o bn_mp_mul_d.o bn_mp_mulmod.o bn_mp_n_root.o bn_mp_neg.o bn_mp_or.o \
 bn_mp_prime_fermat.o bn_mp_prime_frobenius_underwood.o bn_mp_prime_is_prime.o \
 bn_mp_prime_miller_rabin.o bn_mp_prime_next_prime.o bn_mp_prime_rabin_miller_trials.o \
 bn_mp_prime_rand.o bn_mp_prime_strong_lucas_selfridge.o bn_mp_radix_size.o bn_mp_radix_smap.o \

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -35,13 +35,13 @@ bn_mp_cnt_lsb.o bn_mp_complement.o bn_mp_copy.o bn_mp_count_bits.o bn_mp_decr.o 
 bn_mp_div_2d.o bn_mp_div_3.o bn_mp_div_d.o bn_mp_dr_is_modulus.o bn_mp_dr_reduce.o bn_mp_dr_setup.o \
 bn_mp_error_to_string.o bn_mp_exch.o bn_mp_export.o bn_mp_expt_d.o bn_mp_exptmod.o bn_mp_exteuclid.o \
 bn_mp_fread.o bn_mp_fwrite.o bn_mp_gcd.o bn_mp_get_double.o bn_mp_get_i32.o bn_mp_get_i64.o bn_mp_get_l.o \
-bn_mp_get_ll.o bn_mp_get_mag32.o bn_mp_get_mag64.o bn_mp_get_magl.o bn_mp_get_magll.o bn_mp_grow.o \
-bn_mp_ilogb.o bn_mp_import.o bn_mp_incr.o bn_mp_init.o bn_mp_init_copy.o bn_mp_init_i32.o bn_mp_init_i64.o \
-bn_mp_init_l.o bn_mp_init_ll.o bn_mp_init_multi.o bn_mp_init_set.o bn_mp_init_size.o bn_mp_init_u32.o \
-bn_mp_init_u64.o bn_mp_init_ul.o bn_mp_init_ull.o bn_mp_invmod.o bn_mp_is_square.o bn_mp_iseven.o \
-bn_mp_isodd.o bn_mp_kronecker.o bn_mp_lcm.o bn_mp_lshd.o bn_mp_mod.o bn_mp_mod_2d.o bn_mp_mod_d.o \
-bn_mp_montgomery_calc_normalization.o bn_mp_montgomery_reduce.o bn_mp_montgomery_setup.o bn_mp_mul.o \
-bn_mp_mul_2.o bn_mp_mul_2d.o bn_mp_mul_d.o bn_mp_mulmod.o bn_mp_n_root.o bn_mp_neg.o bn_mp_or.o \
+bn_mp_get_ll.o bn_mp_get_mag_u32.o bn_mp_get_mag_u64.o bn_mp_get_mag_ul.o bn_mp_get_mag_ull.o \
+bn_mp_grow.o bn_mp_ilogb.o bn_mp_import.o bn_mp_incr.o bn_mp_init.o bn_mp_init_copy.o bn_mp_init_i32.o \
+bn_mp_init_i64.o bn_mp_init_l.o bn_mp_init_ll.o bn_mp_init_multi.o bn_mp_init_set.o bn_mp_init_size.o \
+bn_mp_init_u32.o bn_mp_init_u64.o bn_mp_init_ul.o bn_mp_init_ull.o bn_mp_invmod.o bn_mp_is_square.o \
+bn_mp_iseven.o bn_mp_isodd.o bn_mp_kronecker.o bn_mp_lcm.o bn_mp_lshd.o bn_mp_mod.o bn_mp_mod_2d.o \
+bn_mp_mod_d.o bn_mp_montgomery_calc_normalization.o bn_mp_montgomery_reduce.o bn_mp_montgomery_setup.o \
+bn_mp_mul.o bn_mp_mul_2.o bn_mp_mul_2d.o bn_mp_mul_d.o bn_mp_mulmod.o bn_mp_n_root.o bn_mp_neg.o bn_mp_or.o \
 bn_mp_prime_fermat.o bn_mp_prime_frobenius_underwood.o bn_mp_prime_is_prime.o \
 bn_mp_prime_miller_rabin.o bn_mp_prime_next_prime.o bn_mp_prime_rabin_miller_trials.o \
 bn_mp_prime_rand.o bn_mp_prime_strong_lucas_selfridge.o bn_mp_radix_size.o bn_mp_radix_smap.o \

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -27,13 +27,13 @@ bn_mp_cnt_lsb.obj bn_mp_complement.obj bn_mp_copy.obj bn_mp_count_bits.obj bn_mp
 bn_mp_div_2d.obj bn_mp_div_3.obj bn_mp_div_d.obj bn_mp_dr_is_modulus.obj bn_mp_dr_reduce.obj bn_mp_dr_setup.obj \
 bn_mp_error_to_string.obj bn_mp_exch.obj bn_mp_export.obj bn_mp_expt_d.obj bn_mp_exptmod.obj bn_mp_exteuclid.obj \
 bn_mp_fread.obj bn_mp_fwrite.obj bn_mp_gcd.obj bn_mp_get_double.obj bn_mp_get_i32.obj bn_mp_get_i64.obj bn_mp_get_l.obj \
-bn_mp_get_ll.obj bn_mp_get_mag32.obj bn_mp_get_mag64.obj bn_mp_get_magl.obj bn_mp_get_magll.obj bn_mp_grow.obj \
-bn_mp_ilogb.obj bn_mp_import.obj bn_mp_incr.obj bn_mp_init.obj bn_mp_init_copy.obj bn_mp_init_i32.obj bn_mp_init_i64.obj \
-bn_mp_init_l.obj bn_mp_init_ll.obj bn_mp_init_multi.obj bn_mp_init_set.obj bn_mp_init_size.obj bn_mp_init_u32.obj \
-bn_mp_init_u64.obj bn_mp_init_ul.obj bn_mp_init_ull.obj bn_mp_invmod.obj bn_mp_is_square.obj bn_mp_iseven.obj \
-bn_mp_isodd.obj bn_mp_kronecker.obj bn_mp_lcm.obj bn_mp_lshd.obj bn_mp_mod.obj bn_mp_mod_2d.obj bn_mp_mod_d.obj \
-bn_mp_montgomery_calc_normalization.obj bn_mp_montgomery_reduce.obj bn_mp_montgomery_setup.obj bn_mp_mul.obj \
-bn_mp_mul_2.obj bn_mp_mul_2d.obj bn_mp_mul_d.obj bn_mp_mulmod.obj bn_mp_n_root.obj bn_mp_neg.obj bn_mp_or.obj \
+bn_mp_get_ll.obj bn_mp_get_mag_u32.obj bn_mp_get_mag_u64.obj bn_mp_get_mag_ul.obj bn_mp_get_mag_ull.obj \
+bn_mp_grow.obj bn_mp_ilogb.obj bn_mp_import.obj bn_mp_incr.obj bn_mp_init.obj bn_mp_init_copy.obj bn_mp_init_i32.obj \
+bn_mp_init_i64.obj bn_mp_init_l.obj bn_mp_init_ll.obj bn_mp_init_multi.obj bn_mp_init_set.obj bn_mp_init_size.obj \
+bn_mp_init_u32.obj bn_mp_init_u64.obj bn_mp_init_ul.obj bn_mp_init_ull.obj bn_mp_invmod.obj bn_mp_is_square.obj \
+bn_mp_iseven.obj bn_mp_isodd.obj bn_mp_kronecker.obj bn_mp_lcm.obj bn_mp_lshd.obj bn_mp_mod.obj bn_mp_mod_2d.obj \
+bn_mp_mod_d.obj bn_mp_montgomery_calc_normalization.obj bn_mp_montgomery_reduce.obj bn_mp_montgomery_setup.obj \
+bn_mp_mul.obj bn_mp_mul_2.obj bn_mp_mul_2d.obj bn_mp_mul_d.obj bn_mp_mulmod.obj bn_mp_n_root.obj bn_mp_neg.obj bn_mp_or.obj \
 bn_mp_prime_fermat.obj bn_mp_prime_frobenius_underwood.obj bn_mp_prime_is_prime.obj \
 bn_mp_prime_miller_rabin.obj bn_mp_prime_next_prime.obj bn_mp_prime_rabin_miller_trials.obj \
 bn_mp_prime_rand.obj bn_mp_prime_strong_lucas_selfridge.obj bn_mp_radix_size.obj bn_mp_radix_smap.obj \

--- a/makefile.shared
+++ b/makefile.shared
@@ -29,13 +29,13 @@ bn_mp_cnt_lsb.o bn_mp_complement.o bn_mp_copy.o bn_mp_count_bits.o bn_mp_decr.o 
 bn_mp_div_2d.o bn_mp_div_3.o bn_mp_div_d.o bn_mp_dr_is_modulus.o bn_mp_dr_reduce.o bn_mp_dr_setup.o \
 bn_mp_error_to_string.o bn_mp_exch.o bn_mp_export.o bn_mp_expt_d.o bn_mp_exptmod.o bn_mp_exteuclid.o \
 bn_mp_fread.o bn_mp_fwrite.o bn_mp_gcd.o bn_mp_get_double.o bn_mp_get_i32.o bn_mp_get_i64.o bn_mp_get_l.o \
-bn_mp_get_ll.o bn_mp_get_mag32.o bn_mp_get_mag64.o bn_mp_get_magl.o bn_mp_get_magll.o bn_mp_grow.o \
-bn_mp_ilogb.o bn_mp_import.o bn_mp_incr.o bn_mp_init.o bn_mp_init_copy.o bn_mp_init_i32.o bn_mp_init_i64.o \
-bn_mp_init_l.o bn_mp_init_ll.o bn_mp_init_multi.o bn_mp_init_set.o bn_mp_init_size.o bn_mp_init_u32.o \
-bn_mp_init_u64.o bn_mp_init_ul.o bn_mp_init_ull.o bn_mp_invmod.o bn_mp_is_square.o bn_mp_iseven.o \
-bn_mp_isodd.o bn_mp_kronecker.o bn_mp_lcm.o bn_mp_lshd.o bn_mp_mod.o bn_mp_mod_2d.o bn_mp_mod_d.o \
-bn_mp_montgomery_calc_normalization.o bn_mp_montgomery_reduce.o bn_mp_montgomery_setup.o bn_mp_mul.o \
-bn_mp_mul_2.o bn_mp_mul_2d.o bn_mp_mul_d.o bn_mp_mulmod.o bn_mp_n_root.o bn_mp_neg.o bn_mp_or.o \
+bn_mp_get_ll.o bn_mp_get_mag_u32.o bn_mp_get_mag_u64.o bn_mp_get_mag_ul.o bn_mp_get_mag_ull.o \
+bn_mp_grow.o bn_mp_ilogb.o bn_mp_import.o bn_mp_incr.o bn_mp_init.o bn_mp_init_copy.o bn_mp_init_i32.o \
+bn_mp_init_i64.o bn_mp_init_l.o bn_mp_init_ll.o bn_mp_init_multi.o bn_mp_init_set.o bn_mp_init_size.o \
+bn_mp_init_u32.o bn_mp_init_u64.o bn_mp_init_ul.o bn_mp_init_ull.o bn_mp_invmod.o bn_mp_is_square.o \
+bn_mp_iseven.o bn_mp_isodd.o bn_mp_kronecker.o bn_mp_lcm.o bn_mp_lshd.o bn_mp_mod.o bn_mp_mod_2d.o \
+bn_mp_mod_d.o bn_mp_montgomery_calc_normalization.o bn_mp_montgomery_reduce.o bn_mp_montgomery_setup.o \
+bn_mp_mul.o bn_mp_mul_2.o bn_mp_mul_2d.o bn_mp_mul_d.o bn_mp_mulmod.o bn_mp_n_root.o bn_mp_neg.o bn_mp_or.o \
 bn_mp_prime_fermat.o bn_mp_prime_frobenius_underwood.o bn_mp_prime_is_prime.o \
 bn_mp_prime_miller_rabin.o bn_mp_prime_next_prime.o bn_mp_prime_rabin_miller_trials.o \
 bn_mp_prime_rand.o bn_mp_prime_strong_lucas_selfridge.o bn_mp_radix_size.o bn_mp_radix_smap.o \

--- a/makefile.unix
+++ b/makefile.unix
@@ -36,13 +36,13 @@ bn_mp_cnt_lsb.o bn_mp_complement.o bn_mp_copy.o bn_mp_count_bits.o bn_mp_decr.o 
 bn_mp_div_2d.o bn_mp_div_3.o bn_mp_div_d.o bn_mp_dr_is_modulus.o bn_mp_dr_reduce.o bn_mp_dr_setup.o \
 bn_mp_error_to_string.o bn_mp_exch.o bn_mp_export.o bn_mp_expt_d.o bn_mp_exptmod.o bn_mp_exteuclid.o \
 bn_mp_fread.o bn_mp_fwrite.o bn_mp_gcd.o bn_mp_get_double.o bn_mp_get_i32.o bn_mp_get_i64.o bn_mp_get_l.o \
-bn_mp_get_ll.o bn_mp_get_mag32.o bn_mp_get_mag64.o bn_mp_get_magl.o bn_mp_get_magll.o bn_mp_grow.o \
-bn_mp_ilogb.o bn_mp_import.o bn_mp_incr.o bn_mp_init.o bn_mp_init_copy.o bn_mp_init_i32.o bn_mp_init_i64.o \
-bn_mp_init_l.o bn_mp_init_ll.o bn_mp_init_multi.o bn_mp_init_set.o bn_mp_init_size.o bn_mp_init_u32.o \
-bn_mp_init_u64.o bn_mp_init_ul.o bn_mp_init_ull.o bn_mp_invmod.o bn_mp_is_square.o bn_mp_iseven.o \
-bn_mp_isodd.o bn_mp_kronecker.o bn_mp_lcm.o bn_mp_lshd.o bn_mp_mod.o bn_mp_mod_2d.o bn_mp_mod_d.o \
-bn_mp_montgomery_calc_normalization.o bn_mp_montgomery_reduce.o bn_mp_montgomery_setup.o bn_mp_mul.o \
-bn_mp_mul_2.o bn_mp_mul_2d.o bn_mp_mul_d.o bn_mp_mulmod.o bn_mp_n_root.o bn_mp_neg.o bn_mp_or.o \
+bn_mp_get_ll.o bn_mp_get_mag_u32.o bn_mp_get_mag_u64.o bn_mp_get_mag_ul.o bn_mp_get_mag_ull.o \
+bn_mp_grow.o bn_mp_ilogb.o bn_mp_import.o bn_mp_incr.o bn_mp_init.o bn_mp_init_copy.o bn_mp_init_i32.o \
+bn_mp_init_i64.o bn_mp_init_l.o bn_mp_init_ll.o bn_mp_init_multi.o bn_mp_init_set.o bn_mp_init_size.o \
+bn_mp_init_u32.o bn_mp_init_u64.o bn_mp_init_ul.o bn_mp_init_ull.o bn_mp_invmod.o bn_mp_is_square.o \
+bn_mp_iseven.o bn_mp_isodd.o bn_mp_kronecker.o bn_mp_lcm.o bn_mp_lshd.o bn_mp_mod.o bn_mp_mod_2d.o \
+bn_mp_mod_d.o bn_mp_montgomery_calc_normalization.o bn_mp_montgomery_reduce.o bn_mp_montgomery_setup.o \
+bn_mp_mul.o bn_mp_mul_2.o bn_mp_mul_2d.o bn_mp_mul_d.o bn_mp_mulmod.o bn_mp_n_root.o bn_mp_neg.o bn_mp_or.o \
 bn_mp_prime_fermat.o bn_mp_prime_frobenius_underwood.o bn_mp_prime_is_prime.o \
 bn_mp_prime_miller_rabin.o bn_mp_prime_next_prime.o bn_mp_prime_rabin_miller_trials.o \
 bn_mp_prime_rand.o bn_mp_prime_strong_lucas_selfridge.o bn_mp_radix_size.o bn_mp_radix_smap.o \

--- a/tommath.def
+++ b/tommath.def
@@ -48,10 +48,10 @@ EXPORTS
     mp_get_ll
     mp_get_long
     mp_get_long_long
-    mp_get_mag32
-    mp_get_mag64
-    mp_get_magl
-    mp_get_magll
+    mp_get_mag_u32
+    mp_get_mag_u64
+    mp_get_mag_ul
+    mp_get_mag_ull
     mp_grow
     mp_ilogb
     mp_import

--- a/tommath.h
+++ b/tommath.h
@@ -295,10 +295,10 @@ void mp_set_u64(mp_int *a, uint64_t b);
 mp_err mp_init_u64(mp_int *a, uint64_t b) MP_WUR;
 
 /* get magnitude */
-uint32_t mp_get_mag32(const mp_int *a) MP_WUR;
-uint64_t mp_get_mag64(const mp_int *a) MP_WUR;
-unsigned long mp_get_magl(const mp_int *a) MP_WUR;
-unsigned long long mp_get_magll(const mp_int *a) MP_WUR;
+uint32_t mp_get_mag_u32(const mp_int *a) MP_WUR;
+uint64_t mp_get_mag_u64(const mp_int *a) MP_WUR;
+unsigned long mp_get_mag_ul(const mp_int *a) MP_WUR;
+unsigned long long mp_get_mag_ull(const mp_int *a) MP_WUR;
 
 /* get integer, set integer (long) */
 long mp_get_l(const mp_int *a) MP_WUR;
@@ -325,9 +325,9 @@ void mp_set(mp_int *a, mp_digit b);
 mp_err mp_init_set(mp_int *a, mp_digit b) MP_WUR;
 
 /* get integer, set integer and init with integer (deprecated) */
-MP_DEPRECATED(mp_get_magl/mp_get_ul) unsigned long mp_get_int(const mp_int *a) MP_WUR;
-MP_DEPRECATED(mp_get_magl/mp_get_ul) unsigned long mp_get_long(const mp_int *a) MP_WUR;
-MP_DEPRECATED(mp_get_magll/mp_get_ull) unsigned long long mp_get_long_long(const mp_int *a) MP_WUR;
+MP_DEPRECATED(mp_get_mag_u32/mp_get_u32) unsigned long mp_get_int(const mp_int *a) MP_WUR;
+MP_DEPRECATED(mp_get_mag_ul/mp_get_ul) unsigned long mp_get_long(const mp_int *a) MP_WUR;
+MP_DEPRECATED(mp_get_mag_ull/mp_get_ull) unsigned long long mp_get_long_long(const mp_int *a) MP_WUR;
 MP_DEPRECATED(mp_set_ul) mp_err mp_set_int(mp_int *a, unsigned long b);
 MP_DEPRECATED(mp_set_ul) mp_err mp_set_long(mp_int *a, unsigned long b);
 MP_DEPRECATED(mp_set_ull) mp_err mp_set_long_long(mp_int *a, unsigned long long b);

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -52,10 +52,10 @@
 #   define BN_MP_GET_I64_C
 #   define BN_MP_GET_L_C
 #   define BN_MP_GET_LL_C
-#   define BN_MP_GET_MAG32_C
-#   define BN_MP_GET_MAG64_C
-#   define BN_MP_GET_MAGL_C
-#   define BN_MP_GET_MAGLL_C
+#   define BN_MP_GET_MAG_U32_C
+#   define BN_MP_GET_MAG_U64_C
+#   define BN_MP_GET_MAG_UL_C
+#   define BN_MP_GET_MAG_ULL_C
 #   define BN_MP_GROW_C
 #   define BN_MP_ILOGB_C
 #   define BN_MP_IMPORT_C
@@ -191,8 +191,9 @@
 #   define BN_MP_GET_INT_C
 #   define BN_MP_GET_LONG_C
 #   define BN_MP_GET_LONG_LONG_C
-#   define BN_MP_GET_MAG32_C
-#   define BN_MP_GET_MAG64_C
+#   define BN_MP_GET_MAG_U32_C
+#   define BN_MP_GET_MAG_ULL_C
+#   define BN_MP_GET_MAG_UL_C
 #   define BN_MP_INIT_SET_INT_C
 #   define BN_MP_INIT_U32_C
 #   define BN_MP_INVMOD_SLOW_C
@@ -450,31 +451,31 @@
 #endif
 
 #if defined(BN_MP_GET_I32_C)
-#   define BN_MP_GET_MAG32_C
+#   define BN_MP_GET_MAG_U32_C
 #endif
 
 #if defined(BN_MP_GET_I64_C)
-#   define BN_MP_GET_MAG64_C
+#   define BN_MP_GET_MAG_U64_C
 #endif
 
 #if defined(BN_MP_GET_L_C)
-#   define BN_MP_GET_MAGL_C
+#   define BN_MP_GET_MAG_UL_C
 #endif
 
 #if defined(BN_MP_GET_LL_C)
-#   define BN_MP_GET_MAGLL_C
+#   define BN_MP_GET_MAG_ULL_C
 #endif
 
-#if defined(BN_MP_GET_MAG32_C)
+#if defined(BN_MP_GET_MAG_U32_C)
 #endif
 
-#if defined(BN_MP_GET_MAG64_C)
+#if defined(BN_MP_GET_MAG_U64_C)
 #endif
 
-#if defined(BN_MP_GET_MAGL_C)
+#if defined(BN_MP_GET_MAG_UL_C)
 #endif
 
-#if defined(BN_MP_GET_MAGLL_C)
+#if defined(BN_MP_GET_MAG_ULL_C)
 #endif
 
 #if defined(BN_MP_GROW_C)


### PR DESCRIPTION
As suggested by @sjaeckel, renaming those functions helps to resolve the possible confusion about the unsigned return type.