### PR TITLE
tommath.h: do not expose limits.h

### DIFF
--- a/etc/tune.c
+++ b/etc/tune.c
@@ -4,10 +4,8 @@
  */
 #include "../tommath.h"
 #include "../tommath_private.h"
-#include <stdint.h>
 #include <time.h>
 #include <inttypes.h>
-#include <limits.h>
 #include <errno.h>
 
 /*

--- a/tommath.h
+++ b/tommath.h
@@ -6,7 +6,6 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include <limits.h>
 
 #ifdef LTM_NO_FILE
 #  warning LTM_NO_FILE has been deprecated, use MP_NO_FILE.
@@ -172,10 +171,6 @@ TOOM_SQR_CUTOFF;
 #   endif
 #   define MP_PREC (MP_DEPRECATED_PRAGMA("MP_PREC is an internal macro") PRIVATE_MP_PREC)
 #endif
-
-/* size of comba arrays, should be at least 2 * 2**(BITS_PER_WORD - BITS_PER_DIGIT*2) */
-#define PRIVATE_MP_WARRAY (int)(1uLL << (((CHAR_BIT * sizeof(private_mp_word)) - (2 * MP_DIGIT_BIT)) + 1))
-#define MP_WARRAY (MP_DEPRECATED_PRAGMA("MP_WARRAY is an internal macro") PRIVATE_MP_WARRAY)
 
 #if defined(__GNUC__) && __GNUC__ >= 4
 #   define MP_NULL_TERMINATED __attribute__((sentinel))

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -6,6 +6,7 @@
 
 #include "tommath.h"
 #include "tommath_class.h"
+#include <limits.h>
 
 /*
  * Private symbols
@@ -158,9 +159,7 @@ typedef private_mp_word mp_word;
 #define MP_SIZEOF_BITS(type)    ((size_t)CHAR_BIT * sizeof(type))
 #define MP_MAXFAST              (int)(1uL << (MP_SIZEOF_BITS(mp_word) - (2u * (size_t)MP_DIGIT_BIT)))
 
-/* TODO: Remove PRIVATE_MP_WARRAY as soon as deprecated MP_WARRAY is removed from tommath.h */
-#undef MP_WARRAY
-#define MP_WARRAY PRIVATE_MP_WARRAY
+#define MP_WARRAY (int)(1uLL << (((CHAR_BIT * sizeof(private_mp_word)) - (2 * MP_DIGIT_BIT)) + 1))
 
 /* TODO: Remove PRIVATE_MP_PREC as soon as deprecated MP_PREC is removed from tommath.h */
 #ifdef PRIVATE_MP_PREC


### PR DESCRIPTION
If we make `MP_WARRAY` private we do not have to expose limits.h in the tommath.h header. I believe `MP_WARRAY` is never used by library consumers. We have deprecated it for now, after this change it would be only available in `tommath_private.h`.