### PR TITLE
Use MP_SIZEOF_BITS for MP_WARRAY definition

### DIFF
--- a/bn_mp_sub_d.c
+++ b/bn_mp_sub_d.c
@@ -59,7 +59,7 @@ mp_err mp_sub_d(const mp_int *a, mp_digit b, mp_int *c)
       /* subtract digits, mu is carry */
       for (ix = 0; ix < a->used; ix++) {
          *tmpc    = *tmpa++ - mu;
-         mu       = *tmpc >> (MP_SIZEOF_BITS(mp_digit) - 1u);
+         mu       = *tmpc >> (MP_SIZEOF_BITS(mp_digit) - 1);
          *tmpc++ &= MP_MASK;
       }
    }

--- a/bn_s_mp_sub.c
+++ b/bn_s_mp_sub.c
@@ -42,7 +42,7 @@ mp_err s_mp_sub(const mp_int *a, const mp_int *b, mp_int *c)
           * if a carry does occur it will propagate all the way to the
           * MSB.  As a result a single shift is enough to get the carry
           */
-         u = *tmpc >> (MP_SIZEOF_BITS(mp_digit) - 1u);
+         u = *tmpc >> (MP_SIZEOF_BITS(mp_digit) - 1);
 
          /* Clear carry from T[i] */
          *tmpc++ &= MP_MASK;
@@ -54,7 +54,7 @@ mp_err s_mp_sub(const mp_int *a, const mp_int *b, mp_int *c)
          *tmpc = *tmpa++ - u;
 
          /* U = carry bit of T[i] */
-         u = *tmpc >> (MP_SIZEOF_BITS(mp_digit) - 1u);
+         u = *tmpc >> (MP_SIZEOF_BITS(mp_digit) - 1);
 
          /* Clear carry from T[i] */
          *tmpc++ &= MP_MASK;

--- a/demo/test.c
+++ b/demo/test.c
@@ -685,7 +685,7 @@ static int test_mp_get_ul(void)
       return EXIT_FAILURE;
    }
 
-   for (i = 0; i < ((int)MP_SIZEOF_BITS(unsigned long) - 1); ++i) {
+   for (i = 0; i < (MP_SIZEOF_BITS(unsigned long) - 1); ++i) {
       t = (1UL << (i+1)) - 1;
       if (!t)
          t = ~0UL;
@@ -718,7 +718,7 @@ static int test_mp_get_u64(void)
       return EXIT_FAILURE;
    }
 
-   for (i = 0; i < (int)(MP_SIZEOF_BITS(unsigned long long) - 1); ++i) {
+   for (i = 0; i < (MP_SIZEOF_BITS(unsigned long long) - 1); ++i) {
       r = (1ULL << (i+1)) - 1;
       if (!r)
          r = ~0ULL;

--- a/etc/tune.c
+++ b/etc/tune.c
@@ -4,10 +4,8 @@
  */
 #include "../tommath.h"
 #include "../tommath_private.h"
-#include <stdint.h>
 #include <time.h>
 #include <inttypes.h>
-#include <limits.h>
 #include <errno.h>
 
 /*

--- a/mtest/mpi-types.h
+++ b/mtest/mpi-types.h
@@ -5,9 +5,9 @@ typedef unsigned int       mp_word;   /* 4 byte type */
 typedef unsigned int       mp_size;
 typedef int                mp_err;
 
-#define MP_DIGIT_BIT       (CHAR_BIT*sizeof(mp_digit))
+#define MP_DIGIT_BIT       (CHAR_BIT*(int)sizeof(mp_digit))
 #define MP_DIGIT_MAX       USHRT_MAX
-#define MP_WORD_BIT        (CHAR_BIT*sizeof(mp_word))
+#define MP_WORD_BIT        (CHAR_BIT*(int)sizeof(mp_word))
 #define MP_WORD_MAX        UINT_MAX
 
 #define MP_DIGIT_SIZE      2

--- a/tommath.h
+++ b/tommath.h
@@ -174,7 +174,7 @@ TOOM_SQR_CUTOFF;
 #endif
 
 /* size of comba arrays, should be at least 2 * 2**(BITS_PER_WORD - BITS_PER_DIGIT*2) */
-#define PRIVATE_MP_WARRAY (int)(1uLL << (((CHAR_BIT * sizeof(private_mp_word)) - (2 * MP_DIGIT_BIT)) + 1))
+#define PRIVATE_MP_WARRAY (1 << ((MP_SIZEOF_BITS(mp_word) - (2 * MP_DIGIT_BIT)) + 1))
 #define MP_WARRAY (MP_DEPRECATED_PRAGMA("MP_WARRAY is an internal macro") PRIVATE_MP_WARRAY)
 
 #if defined(__GNUC__) && __GNUC__ >= 4
@@ -517,7 +517,7 @@ mp_err mp_lcm(const mp_int *a, const mp_int *b, mp_int *c) MP_WUR;
  */
 mp_err mp_root_u32(const mp_int *a, uint32_t b, mp_int *c) MP_WUR;
 MP_DEPRECATED(mp_root_u32) mp_err mp_n_root(const mp_int *a, mp_digit b, mp_int *c) MP_WUR;
-MP_DEPRECATED(mp_n_root_ex) mp_err mp_n_root_ex(const mp_int *a, mp_digit b, mp_int *c, int fast) MP_WUR;
+MP_DEPRECATED(mp_root_u32) mp_err mp_n_root_ex(const mp_int *a, mp_digit b, mp_int *c, int fast) MP_WUR;
 
 /* special sqrt algo */
 mp_err mp_sqrt(const mp_int *arg, mp_int *ret) MP_WUR;
@@ -683,7 +683,7 @@ mp_err mp_ilogb(const mp_int *a, uint32_t base, mp_int *c) MP_WUR;
 /* c = a**b */
 mp_err mp_expt_u32(const mp_int *a, uint32_t b, mp_int *c) MP_WUR;
 MP_DEPRECATED(mp_expt_u32) mp_err mp_expt_d(const mp_int *a, mp_digit b, mp_int *c) MP_WUR;
-MP_DEPRECATED(mp_expt_d) mp_err mp_expt_d_ex(const mp_int *a, mp_digit b, mp_int *c, int fast) MP_WUR;
+MP_DEPRECATED(mp_expt_u32) mp_err mp_expt_d_ex(const mp_int *a, mp_digit b, mp_int *c, int fast) MP_WUR;
 
 /* ---> radix conversion <--- */
 int mp_count_bits(const mp_int *a) MP_WUR;

--- a/tommath.h
+++ b/tommath.h
@@ -174,7 +174,7 @@ TOOM_SQR_CUTOFF;
 #endif
 
 /* size of comba arrays, should be at least 2 * 2**(BITS_PER_WORD - BITS_PER_DIGIT*2) */
-#define PRIVATE_MP_WARRAY (1 << ((MP_SIZEOF_BITS(mp_word) - (2 * MP_DIGIT_BIT)) + 1))
+#define PRIVATE_MP_WARRAY (1 << ((MP_SIZEOF_BITS(private_mp_word) - (2 * MP_DIGIT_BIT)) + 1))
 #define MP_WARRAY (MP_DEPRECATED_PRAGMA("MP_WARRAY is an internal macro") PRIVATE_MP_WARRAY)
 
 #if defined(__GNUC__) && __GNUC__ >= 4

--- a/tommath.h
+++ b/tommath.h
@@ -174,7 +174,7 @@ TOOM_SQR_CUTOFF;
 #endif
 
 /* size of comba arrays, should be at least 2 * 2**(BITS_PER_WORD - BITS_PER_DIGIT*2) */
-#define PRIVATE_MP_WARRAY (1 << ((MP_SIZEOF_BITS(private_mp_word) - (2 * MP_DIGIT_BIT)) + 1))
+#define PRIVATE_MP_WARRAY (1 << (((CHAR_BIT * (int)sizeof(private_mp_word)) - (2 * MP_DIGIT_BIT)) + 1))
 #define MP_WARRAY (MP_DEPRECATED_PRAGMA("MP_WARRAY is an internal macro") PRIVATE_MP_WARRAY)
 
 #if defined(__GNUC__) && __GNUC__ >= 4

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -267,9 +267,9 @@ MP_DEPRECATED(s_mp_reverse) void bn_reverse(unsigned char *s, int len);
 #define MP_GET_MAG(name, type)                                                         \
     type name(const mp_int* a)                                                         \
     {                                                                                  \
-        unsigned i = MP_MIN((unsigned)a->used, (unsigned)((MP_SIZEOF_BITS(type) + MP_DIGIT_BIT - 1) / MP_DIGIT_BIT)); \
+        int i = MP_MIN(a->used, ((MP_SIZEOF_BITS(type) + MP_DIGIT_BIT - 1) / MP_DIGIT_BIT)); \
         type res = 0u;                                                                 \
-        while (i --> 0u) {                                                             \
+        while (i --> 0) {                                                              \
             res <<= ((MP_SIZEOF_BITS(type) <= MP_DIGIT_BIT) ? 0 : MP_DIGIT_BIT);       \
             res |= (type)a->dp[i];                                                     \
             if (MP_SIZEOF_BITS(type) <= MP_DIGIT_BIT) { break; }                       \

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -155,8 +155,8 @@ typedef private_mp_word mp_word;
 #define MP_IS_EVEN(a) (((a)->used == 0) || (((a)->dp[0] & 1u) == 0u))
 #define MP_IS_ODD(a)  (((a)->used > 0) && (((a)->dp[0] & 1u) == 1u))
 
-#define MP_SIZEOF_BITS(type)    ((size_t)CHAR_BIT * sizeof(type))
-#define MP_MAXFAST              (int)(1uL << (MP_SIZEOF_BITS(mp_word) - (2u * (size_t)MP_DIGIT_BIT)))
+#define MP_SIZEOF_BITS(type)    (CHAR_BIT * (int)sizeof(type))
+#define MP_MAXFAST              (1 << (MP_SIZEOF_BITS(mp_word) - (2 * MP_DIGIT_BIT)))
 
 /* TODO: Remove PRIVATE_MP_WARRAY as soon as deprecated MP_WARRAY is removed from tommath.h */
 #undef MP_WARRAY
@@ -169,7 +169,7 @@ typedef private_mp_word mp_word;
 #endif
 
 /* Minimum number of available digits in mp_int, MP_PREC >= MP_MIN_PREC */
-#define MP_MIN_PREC ((((int)MP_SIZEOF_BITS(long long) + MP_DIGIT_BIT) - 1) / MP_DIGIT_BIT)
+#define MP_MIN_PREC (((MP_SIZEOF_BITS(long long) + MP_DIGIT_BIT) - 1) / MP_DIGIT_BIT)
 
 MP_STATIC_ASSERT(prec_geq_min_prec, MP_PREC >= MP_MIN_PREC)
 


### PR DESCRIPTION
Also fix depreciation messages and remove unnecessary includes.

Just some random improvements, not worth to split in 3 different pull requests.

Inspired by #327