### PR TITLE
Add a new mp_todec_fast...

### DIFF
--- a/bn_mp_div_d.c
+++ b/bn_mp_div_d.c
@@ -43,12 +43,10 @@ mp_err mp_div_d(const mp_int *a, mp_digit b, mp_int *c, mp_digit *d)
       return MP_OKAY;
    }
 
-#ifdef BN_MP_DIV_3_C
    /* three? */
-   if (b == 3u) {
+   if (MP_HAS(MP_DIV_3) && b == 3u) {
       return mp_div_3(a, c, d);
    }
-#endif
 
    /* no easy answer [c'est la vie].  Just division */
    if ((err = mp_init_size(&q, a->used)) != MP_OKAY) {

--- a/bn_mp_exptmod.c
+++ b/bn_mp_exptmod.c
@@ -19,9 +19,12 @@ mp_err mp_exptmod(const mp_int *G, const mp_int *X, const mp_int *P, mp_int *Y)
 
    /* if exponent X is negative we have to recurse */
    if (X->sign == MP_NEG) {
-#ifdef BN_MP_INVMOD_C
       mp_int tmpG, tmpX;
       mp_err err;
+
+      if (!MP_HAS(MP_INVMOD)) {
+         return MP_VAL;
+      }
 
       /* first compute 1/G mod P */
       if ((err = mp_init(&tmpG)) != MP_OKAY) {
@@ -46,50 +49,32 @@ mp_err mp_exptmod(const mp_int *G, const mp_int *X, const mp_int *P, mp_int *Y)
       err = mp_exptmod(&tmpG, &tmpX, P, Y);
       mp_clear_multi(&tmpG, &tmpX, NULL);
       return err;
-#else
-      /* no invmod */
-      return MP_VAL;
-#endif
    }
 
    /* modified diminished radix reduction */
-#if defined(BN_MP_REDUCE_IS_2K_L_C) && defined(BN_MP_REDUCE_2K_L_C) && defined(BN_S_MP_EXPTMOD_C)
-   if (mp_reduce_is_2k_l(P) == MP_YES) {
+   if (MP_HAS(MP_REDUCE_IS_2K_L) && MP_HAS(MP_REDUCE_2K_L) && MP_HAS(S_MP_EXPTMOD) &&
+       mp_reduce_is_2k_l(P) == MP_YES) {
       return s_mp_exptmod(G, X, P, Y, 1);
    }
-#endif
 
-#ifdef BN_MP_DR_IS_MODULUS_C
-   /* is it a DR modulus? */
-   dr = (mp_dr_is_modulus(P) == MP_YES) ? 1 : 0;
-#else
-   /* default to no */
-   dr = 0;
-#endif
+   /* is it a DR modulus? default to no */
+   dr = MP_HAS(MP_DR_IS_MODULUS) && mp_dr_is_modulus(P) == MP_YES ? 1 : 0;
 
-#ifdef BN_MP_REDUCE_IS_2K_C
    /* if not, is it a unrestricted DR modulus? */
-   if (dr == 0) {
+   if (MP_HAS(MP_REDUCE_IS_2K) && dr == 0) {
       dr = (mp_reduce_is_2k(P) == MP_YES) ? 2 : 0;
    }
-#endif
 
    /* if the modulus is odd or dr != 0 use the montgomery method */
-#ifdef BN_S_MP_EXPTMOD_FAST_C
-   if (MP_IS_ODD(P) || (dr !=  0)) {
+   if (MP_HAS(S_MP_EXPTMOD_FAST) && (MP_IS_ODD(P) || (dr != 0))) {
       return s_mp_exptmod_fast(G, X, P, Y, dr);
-   } else {
-#endif
-#ifdef BN_S_MP_EXPTMOD_C
+   } else if (MP_HAS(S_MP_EXPTMOD)) {
       /* otherwise use the generic Barrett reduction technique */
       return s_mp_exptmod(G, X, P, Y, 0);
-#else
+   } else {
       /* no exptmod for evens */
       return MP_VAL;
-#endif
-#ifdef BN_S_MP_EXPTMOD_FAST_C
    }
-#endif
 }
 
 #endif

--- a/bn_mp_invmod.c
+++ b/bn_mp_invmod.c
@@ -11,17 +11,13 @@ mp_err mp_invmod(const mp_int *a, const mp_int *b, mp_int *c)
       return MP_VAL;
    }
 
-#ifdef BN_S_MP_INVMOD_FAST_C
    /* if the modulus is odd we can use a faster routine instead */
-   if (MP_IS_ODD(b)) {
+   if (MP_HAS(S_MP_INVMOD_FAST) && MP_IS_ODD(b)) {
       return s_mp_invmod_fast(a, b, c);
    }
-#endif
 
-#ifdef BN_S_MP_INVMOD_SLOW_C
-   return s_mp_invmod_slow(a, b, c);
-#else
-   return MP_VAL;
-#endif
+   return MP_HAS(S_MP_INVMOD_SLOW)
+          ? s_mp_invmod_slow(a, b, c)
+          : MP_VAL;
 }
 #endif

--- a/bn_mp_mul.c
+++ b/bn_mp_mul.c
@@ -6,80 +6,46 @@
 /* high level multiplication (handles sign) */
 mp_err mp_mul(const mp_int *a, const mp_int *b, mp_int *c)
 {
-   mp_err  err;
-   mp_sign neg;
-#ifdef BN_S_MP_BALANCE_MUL_C
-   int len_b, len_a;
-#endif
-   neg = (a->sign == b->sign) ? MP_ZPOS : MP_NEG;
-#ifdef BN_S_MP_BALANCE_MUL_C
-   len_a = a->used;
-   len_b = b->used;
+   mp_err err;
+   int min_len = MP_MIN(a->used, b->used),
+       max_len = MP_MAX(a->used, b->used),
+       digs = a->used + b->used + 1;
+   mp_sign neg = (a->sign == b->sign) ? MP_ZPOS : MP_NEG;
 
-   if (len_a == len_b) {
-      goto GO_ON;
-   }
-   /*
-    * Check sizes. The smaller one needs to be larger than the Karatsuba cut-off.
-    * The bigger one needs to be at least about one KARATSUBA_MUL_CUTOFF bigger
-    * to make some sense, but it depends on architecture, OS, position of the
-    * stars... so YMMV.
-    * Using it to cut the input into slices small enough for fast_s_mp_mul_digs
-    * was actually slower on the author's machine, but YMMV.
-    */
-   if ((MP_MIN(len_a, len_b) < MP_KARATSUBA_MUL_CUTOFF)
-       || ((MP_MAX(len_a, len_b) / 2) < MP_KARATSUBA_MUL_CUTOFF)) {
-      goto GO_ON;
-   }
-   /*
-    * Not much effect was observed below a ratio of 1:2, but again: YMMV.
-    */
-   if ((MP_MAX(len_a, len_b) /  MP_MIN(len_a, len_b)) < 2) {
-      goto GO_ON;
-   }
-
-   err = s_mp_balance_mul(a,b,c);
-   goto END;
-
-GO_ON:
-#endif
-
-   /* use Toom-Cook? */
-#ifdef BN_S_MP_TOOM_MUL_C
-   if (MP_MIN(a->used, b->used) >= MP_TOOM_MUL_CUTOFF) {
+   if (MP_HAS(S_MP_BALANCE_MUL) &&
+       /* Check sizes. The smaller one needs to be larger than the Karatsuba cut-off.
+        * The bigger one needs to be at least about one MP_KARATSUBA_MUL_CUTOFF bigger
+        * to make some sense, but it depends on architecture, OS, position of the
+        * stars... so YMMV.
+        * Using it to cut the input into slices small enough for fast_s_mp_mul_digs
+        * was actually slower on the author's machine, but YMMV.
+        */
+       (min_len >= MP_KARATSUBA_MUL_CUTOFF) &&
+       (max_len / 2 >= MP_KARATSUBA_MUL_CUTOFF) &&
+       /* Not much effect was observed below a ratio of 1:2, but again: YMMV. */
+       (max_len >= (2 * min_len))) {
+      err = s_mp_balance_mul(a,b,c);
+   } else if (MP_HAS(S_MP_TOOM_MUL) &&
+              (min_len >= MP_TOOM_MUL_CUTOFF)) {
       err = s_mp_toom_mul(a, b, c);
-   } else
-#endif
-#ifdef BN_S_MP_KARATSUBA_MUL_C
-      /* use Karatsuba? */
-      if (MP_MIN(a->used, b->used) >= MP_KARATSUBA_MUL_CUTOFF) {
-         err = s_mp_karatsuba_mul(a, b, c);
-      } else
-#endif
-      {
-         /* can we use the fast multiplier?
-          *
-          * The fast multiplier can be used if the output will
-          * have less than MP_WARRAY digits and the number of
-          * digits won't affect carry propagation
-          */
-         int     digs = a->used + b->used + 1;
-
-#ifdef BN_S_MP_MUL_DIGS_FAST_C
-         if ((digs < MP_WARRAY) &&
-             (MP_MIN(a->used, b->used) <= MP_MAXFAST)) {
-            err = s_mp_mul_digs_fast(a, b, c, digs);
-         } else
-#endif
-         {
-#ifdef BN_S_MP_MUL_DIGS_C
-            err = s_mp_mul_digs(a, b, c, a->used + b->used + 1);
-#else
-            err = MP_VAL;
-#endif
-         }
-      }
-END:
+   } else if (MP_HAS(S_MP_KARATSUBA_MUL) &&
+              (min_len >= MP_KARATSUBA_MUL_CUTOFF)) {
+      err = s_mp_karatsuba_mul(a, b, c);
+   } else if (MP_HAS(S_MP_MUL_DIGS_FAST) &&
+              /* can we use the fast multiplier?
+               *
+               * The fast multiplier can be used if the output will
+               * have less than MP_WARRAY digits and the number of
+               * digits won't affect carry propagation
+               */
+              (digs < MP_WARRAY) &&
+              (min_len <= MP_MAXFAST)) {
+      err = s_mp_mul_digs_fast(a, b, c, digs);
+   } else if (MP_HAS(S_MP_MUL_DIGS)) {
+      err = s_mp_mul_digs(a, b, c, digs);
+   } else {
+      err = MP_VAL;
+   }
    c->sign = (c->used > 0) ? neg : MP_ZPOS;
    return err;
 }

--- a/bn_mp_reduce.c
+++ b/bn_mp_reduce.c
@@ -26,21 +26,17 @@ mp_err mp_reduce(mp_int *x, const mp_int *m, const mp_int *mu)
       if ((err = mp_mul(&q, mu, &q)) != MP_OKAY) {
          goto CLEANUP;
       }
-   } else {
-#ifdef BN_S_MP_MUL_HIGH_DIGS_C
+   } else if (MP_HAS(S_MP_MUL_HIGH_DIGS)) {
       if ((err = s_mp_mul_high_digs(&q, mu, &q, um)) != MP_OKAY) {
          goto CLEANUP;
       }
-#elif defined(BN_S_MP_MUL_HIGH_DIGS_FAST_C)
+   } else if (MP_HAS(S_MP_MUL_HIGH_DIGS_FAST)) {
       if ((err = s_mp_mul_high_digs_fast(&q, mu, &q, um)) != MP_OKAY) {
          goto CLEANUP;
       }
-#else
-      {
-         err = MP_VAL;
-         goto CLEANUP;
-      }
-#endif
+   } else {
+      err = MP_VAL;
+      goto CLEANUP;
    }
 
    /* q3 = q2 / b**(k+1) */

--- a/bn_mp_sqr.c
+++ b/bn_mp_sqr.c
@@ -7,35 +7,21 @@
 mp_err mp_sqr(const mp_int *a, mp_int *b)
 {
    mp_err err;
-
-#ifdef BN_S_MP_TOOM_SQR_C
-   /* use Toom-Cook? */
-   if (a->used >= MP_TOOM_SQR_CUTOFF) {
+   if (MP_HAS(S_MP_TOOM_SQR) && /* use Toom-Cook? */
+       a->used >= MP_TOOM_SQR_CUTOFF) {
       err = s_mp_toom_sqr(a, b);
-      /* Karatsuba? */
-   } else
-#endif
-#ifdef BN_S_MP_KARATSUBA_SQR_C
-      if (a->used >= MP_KARATSUBA_SQR_CUTOFF) {
-         err = s_mp_karatsuba_sqr(a, b);
-      } else
-#endif
-      {
-#ifdef BN_S_MP_SQR_FAST_C
-         /* can we use the fast comba multiplier? */
-         if ((((a->used * 2) + 1) < MP_WARRAY) &&
-             (a->used < (MP_MAXFAST / 2))) {
-            err = s_mp_sqr_fast(a, b);
-         } else
-#endif
-         {
-#ifdef BN_S_MP_SQR_C
-            err = s_mp_sqr(a, b);
-#else
-            err = MP_VAL;
-#endif
-         }
-      }
+   } else if (MP_HAS(S_MP_KARATSUBA_SQR) &&  /* Karatsuba? */
+              a->used >= MP_KARATSUBA_SQR_CUTOFF) {
+      err = s_mp_karatsuba_sqr(a, b);
+   } else if (MP_HAS(S_MP_SQR_FAST) && /* can we use the fast comba multiplier? */
+              (((a->used * 2) + 1) < MP_WARRAY) &&
+              (a->used < (MP_MAXFAST / 2))) {
+      err = s_mp_sqr_fast(a, b);
+   } else if (MP_HAS(S_MP_SQR)) {
+      err = s_mp_sqr(a, b);
+   } else {
+      err = MP_VAL;
+   }
    b->sign = MP_ZPOS;
    return err;
 }

--- a/bn_mp_todecimal.c
+++ b/bn_mp_todecimal.c
@@ -1,0 +1,23 @@
+#include "tommath_private.h"
+#ifdef BN_MP_TODECIMAL_C
+/* LibTomMath, multiple-precision integer library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+
+/* stores a bignum as a decimal ASCII string, using Barrett
+ * reduction if available.
+ */
+
+mp_err mp_todecimal(const mp_int *a, char *str)
+{
+   mp_err err;
+
+   if (MP_HAS(S_MP_TODECIMAL_FAST)) {
+      err = s_mp_todecimal_fast(a, str);
+   } else {
+      err = mp_toradix(a, str, 10);
+   }
+
+   return err;
+}
+
+#endif

--- a/bn_mp_todecimal_fast.c
+++ b/bn_mp_todecimal_fast.c
@@ -1,6 +1,5 @@
 #include "tommath_private.h"
 #include <string.h>
-#include <stdio.h>
 #ifdef BN_MP_TODECIMAL_FAST_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
@@ -13,12 +12,9 @@ mp_err mp_todecimal_fast_rec(mp_int *number, mp_int *nL, mp_int *shiftL, mp_int 
    mp_err err;
 
    if (precalc_array_index < 0) {
-      char *next_piece = calloc(4, sizeof(char));
-      int s_s = left ? snprintf(next_piece, 4, "%u", mp_get_i32(number)) : snprintf(next_piece, 4, "%03u",
-                mp_get_i32(number));
-      int r_s = (int)strlen(*result);
-      (*result) = realloc(*result, (size_t)(r_s + s_s + 2));
-      strcat(*result, next_piece);
+      int new_pos = left ? snprintf(*result, 4, "%u", mp_get_i32(number)) : snprintf(*result, 4, "%03u",
+                    mp_get_i32(number));
+      *result += new_pos;
       return MP_OKAY;
    }
 
@@ -70,11 +66,12 @@ LBL_ERR:
    return err;
 }
 
-mp_err mp_todecimal_fast(mp_int *number, char **result)
+mp_err mp_todecimal_fast(mp_int *number, char *result)
 {
    mp_int n, shift, M, M2, M22, M4, M44;
    mp_int nL[20], shiftL[20], mL[20];
    mp_err err;
+   char **result_addr = &result;
    int precalc_array_index = 1;
 
    if ((err = mp_init_multi(&M2, &M22, &M4, &M44, NULL)) != MP_OKAY) {
@@ -85,7 +82,8 @@ mp_err mp_todecimal_fast(mp_int *number, char **result)
       if ((err = mp_neg(number, number)) != MP_OKAY) {
          goto LBL_ERR;
       }
-      *result[0] = '-';
+      result[0] = '-';
+      result_addr += 1;
    }
    if ((err = mp_init_set(&n, (mp_digit)1000)) != MP_OKAY) {
       goto LBL_ERR;
@@ -189,7 +187,7 @@ mp_err mp_todecimal_fast(mp_int *number, char **result)
       precalc_array_index++;
    }
 
-   if ((err = mp_todecimal_fast_rec(number, nL, shiftL, mL, precalc_array_index - 1, 1, result)) != MP_OKAY) {
+   if ((err = mp_todecimal_fast_rec(number, nL, shiftL, mL, precalc_array_index - 1, 1, result_addr)) != MP_OKAY) {
       goto LBL_ERR;
    }
 

--- a/bn_mp_todecimal_fast.c
+++ b/bn_mp_todecimal_fast.c
@@ -1,0 +1,199 @@
+#include "tommath_private.h"
+#include <string.h>
+#ifdef BN_MP_TODECIMAL_FAST_C
+/* LibTomMath, multiple-precision integer library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+
+/* store a bignum as a decimal ASCII string */
+mp_err mp_todecimal_fast_rec(mp_int *number, mp_int *nL, mp_int *shiftL, mp_int *mL, int index, int left, char **result) {
+    mp_int q, nLq, r;
+    mp_err err;
+
+    if (index < 0) {
+        char *next_piece = calloc(4, sizeof(char));
+        int s_s = snprintf(next_piece, 4, left ? "%u" : "%03u", mp_get_u32(number));
+        int r_s = strlen(*result);
+        (*result) = realloc(*result, r_s + s_s + 2);
+        strcat(*result, next_piece);
+        return MP_OKAY;
+    }
+
+    if ((err = mp_init_multi(&q, &nLq, &r, NULL)) != MP_OKAY) {
+        goto LBL_ERR;
+    }
+    if ((err = mp_mul(number, &mL[index], &q)) != MP_OKAY) {
+        goto LBL_ERR;
+    }
+    if ((err = mp_div_2d(&q, mp_get_u32(&shiftL[index]), &q, NULL)) != MP_OKAY) {
+        goto LBL_ERR;
+    }
+
+    if ((err = mp_mul(&nL[index], &q, &nLq)) != MP_OKAY) {
+        goto LBL_ERR;
+    }
+
+    if ((err = mp_sub(number, &nLq, &r)) != MP_OKAY) {
+        goto LBL_ERR;
+    }
+
+    if (mp_isneg(&r)) {
+        if ((err = mp_sub_d(&q, 1, &q)) != MP_OKAY) {
+            goto LBL_ERR;
+        }
+        if ((err = mp_add(&r, &nL[index], &r)) != MP_OKAY) {
+            goto LBL_ERR;
+        }
+    }
+
+    --index;
+    if (left && mp_iszero(&q)) {
+        if ((err = mp_todecimal_fast_rec(&r, nL, shiftL, mL, index, 1, result)) != MP_OKAY) {
+            goto LBL_ERR;
+        }
+    } else {
+        if ((err = mp_todecimal_fast_rec(&q, nL, shiftL, mL, index, left, result)) != MP_OKAY) {
+            goto LBL_ERR;
+        }
+        if ((err = mp_todecimal_fast_rec(&r, nL, shiftL, mL, index, 0, result)) != MP_OKAY) {
+            goto LBL_ERR;
+        }
+    }
+
+    err = MP_OKAY;
+
+LBL_ERR:mp_clear_multi (&q, &nLq, &r, NULL);
+    return err;
+}
+
+mp_err mp_todecimal_fast(mp_int *number, char **result) {
+    mp_int n, shift, M, M2, M22, M4, M44;
+    mp_int *nL, *shiftL, *mL;
+    mp_err err;
+    int index = 1;
+
+    if ((err = mp_init_multi(&M2, &M22, &M4, &M44, NULL)) != MP_OKAY) {
+        goto LBL_ERR;
+    }
+
+    if (mp_isneg(number)) {
+        if ((err = mp_neg(number, number)) != MP_OKAY) {
+            goto LBL_ERR;
+        }
+        *result[0] = '-';
+    }
+    if ((err = mp_init_set(&n, 1000)) != MP_OKAY) {
+        goto LBL_ERR;
+    }
+
+    nL = malloc(20 * sizeof(mp_int));
+    if ((err = mp_init_copy(&nL[0], &n)) != MP_OKAY) {
+        goto LBL_ERR;
+    }
+
+    if ((err = mp_init_set(&shift, 20)) != MP_OKAY) {
+        goto LBL_ERR;
+    }
+
+    shiftL = malloc(20 * sizeof(mp_int));
+    if ((err = mp_init_copy(&shiftL[0], &shift)) != MP_OKAY) {
+        goto LBL_ERR;
+    }
+
+    /* (8 * 2**$shift) / $n rounded up */
+    if ((err = mp_init_set(&M, 8389)) != MP_OKAY) {
+        goto LBL_ERR;
+    }
+
+    /* $M / 8, rounded up */
+    mL = malloc(20 * sizeof(mp_int));
+    if ((err = mp_init_set(&mL[0], 1049)) != MP_OKAY) {
+        goto LBL_ERR;
+    }
+
+    while (1) {
+        if ((err = mp_sqr(&n, &n)) != MP_OKAY) {
+            goto LBL_ERR;
+        }
+        if (mp_cmp(&n, number) == MP_GT) {
+            break;
+        }
+
+        if ((err = mp_mul_2(&shift, &shift)) != MP_OKAY) {
+            goto LBL_ERR;
+        }
+
+        /* The following is a Newton-Raphson step, to restore the invariant
+         * that $M is (8 * 2**$shift) / $n, rounded up. */
+        {
+            if ((err = mp_sqr(&M, &M2)) != MP_OKAY) {
+                goto LBL_ERR;
+            }
+            if ((err = mp_sqr(&M2, &M4)) != MP_OKAY) {
+                goto LBL_ERR;
+            }
+
+            if ((err = mp_mul(&M4, &n, &M4)) != MP_OKAY) {
+                goto LBL_ERR;
+            }
+            if ((err = mp_div_2d(&M4, mp_get_ul(&shift) + 6, &M4, NULL)) != MP_OKAY) {
+                goto LBL_ERR;
+            }
+            if ((err = mp_mul_2(&M2, &M2)) != MP_OKAY) {
+                goto LBL_ERR;
+            }
+            if ((err = mp_sub(&M4, &M2, &M4)) != MP_OKAY) {
+                goto LBL_ERR;
+            }
+            if ((err = mp_add_d(&M4, 1, &M4)) != MP_OKAY) {
+                goto LBL_ERR;
+            }
+            if ((err = mp_div_2d(&M4, 3, &M4, NULL)) != MP_OKAY) {
+                goto LBL_ERR;
+            }
+            if ((err = mp_sub_d(&M4, 1, &M4)) != MP_OKAY) {
+                goto LBL_ERR;
+            }
+            if ((err = mp_neg(&M4, &M)) != MP_OKAY) {
+                goto LBL_ERR;
+            }
+        }
+
+        if ((err = mp_init_copy(&nL[index], &n)) != MP_OKAY) {
+            goto LBL_ERR;
+        }
+        if ((err = mp_init_copy(&shiftL[index], &shift)) != MP_OKAY) {
+            goto LBL_ERR;
+        }
+
+        /* Divide by 8, round up */
+        {
+            if ((err = mp_add_d(&M4, 1, &M4)) != MP_OKAY) {
+                goto LBL_ERR;
+            }
+            if ((err = mp_div_2d(&M4, 3, &M4, NULL)) != MP_OKAY) {
+                goto LBL_ERR;
+            }
+            if ((err = mp_sub_d(&M4, 1, &M4)) != MP_OKAY) {
+                goto LBL_ERR;
+            }
+            if ((err = mp_neg(&M4, &M4)) != MP_OKAY) {
+                goto LBL_ERR;
+            }
+        }
+        if ((err = mp_init_copy(&mL[index], &M4)) != MP_OKAY) {
+            goto LBL_ERR;
+        }
+        index++;
+    }
+
+    if ((err = mp_todecimal_fast_rec(number, nL, shiftL, mL, index - 1, 1, result)) != MP_OKAY) {
+        goto LBL_ERR;
+    }
+
+    err = MP_OKAY;
+
+LBL_ERR:mp_clear_multi (&n, &shift, &M, &M2, &M22, &M4, &M44, NULL);
+    return err;
+}
+
+#endif

--- a/bn_mp_todecimal_fast.c
+++ b/bn_mp_todecimal_fast.c
@@ -1,199 +1,203 @@
 #include "tommath_private.h"
 #include <string.h>
+#include <stdio.h>
 #ifdef BN_MP_TODECIMAL_FAST_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
 /* store a bignum as a decimal ASCII string */
-mp_err mp_todecimal_fast_rec(mp_int *number, mp_int *nL, mp_int *shiftL, mp_int *mL, int index, int left, char **result) {
-    mp_int q, nLq, r;
-    mp_err err;
+mp_err mp_todecimal_fast_rec(mp_int *number, mp_int *nL, mp_int *shiftL, mp_int *mL, int precalc_array_index, int left,
+                             char **result)
+{
+   mp_int q, nLq, r;
+   mp_err err;
 
-    if (index < 0) {
-        char *next_piece = calloc(4, sizeof(char));
-        int s_s = snprintf(next_piece, 4, left ? "%u" : "%03u", mp_get_u32(number));
-        int r_s = strlen(*result);
-        (*result) = realloc(*result, r_s + s_s + 2);
-        strcat(*result, next_piece);
-        return MP_OKAY;
-    }
+   if (precalc_array_index < 0) {
+      char *next_piece = calloc(4, sizeof(char));
+      int s_s = left ? snprintf(next_piece, 4, "%u", mp_get_i32(number)) : snprintf(next_piece, 4, "%03u",
+                mp_get_i32(number));
+      int r_s = (int)strlen(*result);
+      (*result) = realloc(*result, (size_t)(r_s + s_s + 2));
+      strcat(*result, next_piece);
+      return MP_OKAY;
+   }
 
-    if ((err = mp_init_multi(&q, &nLq, &r, NULL)) != MP_OKAY) {
-        goto LBL_ERR;
-    }
-    if ((err = mp_mul(number, &mL[index], &q)) != MP_OKAY) {
-        goto LBL_ERR;
-    }
-    if ((err = mp_div_2d(&q, mp_get_u32(&shiftL[index]), &q, NULL)) != MP_OKAY) {
-        goto LBL_ERR;
-    }
+   if ((err = mp_init_multi(&q, &nLq, &r, NULL)) != MP_OKAY) {
+      goto LBL_ERR;
+   }
+   if ((err = mp_mul(number, &mL[precalc_array_index], &q)) != MP_OKAY) {
+      goto LBL_ERR;
+   }
+   if ((err = mp_div_2d(&q, mp_get_i32(&shiftL[precalc_array_index]), &q, NULL)) != MP_OKAY) {
+      goto LBL_ERR;
+   }
 
-    if ((err = mp_mul(&nL[index], &q, &nLq)) != MP_OKAY) {
-        goto LBL_ERR;
-    }
+   if ((err = mp_mul(&nL[precalc_array_index], &q, &nLq)) != MP_OKAY) {
+      goto LBL_ERR;
+   }
 
-    if ((err = mp_sub(number, &nLq, &r)) != MP_OKAY) {
-        goto LBL_ERR;
-    }
+   if ((err = mp_sub(number, &nLq, &r)) != MP_OKAY) {
+      goto LBL_ERR;
+   }
 
-    if (mp_isneg(&r)) {
-        if ((err = mp_sub_d(&q, 1, &q)) != MP_OKAY) {
-            goto LBL_ERR;
-        }
-        if ((err = mp_add(&r, &nL[index], &r)) != MP_OKAY) {
-            goto LBL_ERR;
-        }
-    }
+   if (mp_isneg(&r)) {
+      if ((err = mp_sub_d(&q, 1, &q)) != MP_OKAY) {
+         goto LBL_ERR;
+      }
+      if ((err = mp_add(&r, &nL[precalc_array_index], &r)) != MP_OKAY) {
+         goto LBL_ERR;
+      }
+   }
 
-    --index;
-    if (left && mp_iszero(&q)) {
-        if ((err = mp_todecimal_fast_rec(&r, nL, shiftL, mL, index, 1, result)) != MP_OKAY) {
-            goto LBL_ERR;
-        }
-    } else {
-        if ((err = mp_todecimal_fast_rec(&q, nL, shiftL, mL, index, left, result)) != MP_OKAY) {
-            goto LBL_ERR;
-        }
-        if ((err = mp_todecimal_fast_rec(&r, nL, shiftL, mL, index, 0, result)) != MP_OKAY) {
-            goto LBL_ERR;
-        }
-    }
+   --precalc_array_index;
+   if (left && mp_iszero(&q)) {
+      if ((err = mp_todecimal_fast_rec(&r, nL, shiftL, mL, precalc_array_index, 1, result)) != MP_OKAY) {
+         goto LBL_ERR;
+      }
+   } else {
+      if ((err = mp_todecimal_fast_rec(&q, nL, shiftL, mL, precalc_array_index, left, result)) != MP_OKAY) {
+         goto LBL_ERR;
+      }
+      if ((err = mp_todecimal_fast_rec(&r, nL, shiftL, mL, precalc_array_index, 0, result)) != MP_OKAY) {
+         goto LBL_ERR;
+      }
+   }
 
-    err = MP_OKAY;
+   err = MP_OKAY;
 
-LBL_ERR:mp_clear_multi (&q, &nLq, &r, NULL);
-    return err;
+LBL_ERR:
+   mp_clear_multi(&q, &nLq, &r, NULL);
+   return err;
 }
 
-mp_err mp_todecimal_fast(mp_int *number, char **result) {
-    mp_int n, shift, M, M2, M22, M4, M44;
-    mp_int *nL, *shiftL, *mL;
-    mp_err err;
-    int index = 1;
+mp_err mp_todecimal_fast(mp_int *number, char **result)
+{
+   mp_int n, shift, M, M2, M22, M4, M44;
+   mp_int nL[20], shiftL[20], mL[20];
+   mp_err err;
+   int precalc_array_index = 1;
 
-    if ((err = mp_init_multi(&M2, &M22, &M4, &M44, NULL)) != MP_OKAY) {
-        goto LBL_ERR;
-    }
+   if ((err = mp_init_multi(&M2, &M22, &M4, &M44, NULL)) != MP_OKAY) {
+      goto LBL_ERR;
+   }
 
-    if (mp_isneg(number)) {
-        if ((err = mp_neg(number, number)) != MP_OKAY) {
+   if (mp_isneg(number)) {
+      if ((err = mp_neg(number, number)) != MP_OKAY) {
+         goto LBL_ERR;
+      }
+      *result[0] = '-';
+   }
+   if ((err = mp_init_set(&n, (mp_digit)1000)) != MP_OKAY) {
+      goto LBL_ERR;
+   }
+
+   if ((err = mp_init_copy(&nL[0], &n)) != MP_OKAY) {
+      goto LBL_ERR;
+   }
+
+   if ((err = mp_init_set(&shift, (mp_digit)20)) != MP_OKAY) {
+      goto LBL_ERR;
+   }
+
+   if ((err = mp_init_copy(&shiftL[0], &shift)) != MP_OKAY) {
+      goto LBL_ERR;
+   }
+
+   /* (8 * 2**$shift) / $n rounded up */
+   if ((err = mp_init_set(&M, (mp_digit)8389)) != MP_OKAY) {
+      goto LBL_ERR;
+   }
+
+   /* $M / 8, rounded up */
+   if ((err = mp_init_set(&mL[0], (mp_digit)1049)) != MP_OKAY) {
+      goto LBL_ERR;
+   }
+
+   while (1) {
+      if ((err = mp_sqr(&n, &n)) != MP_OKAY) {
+         goto LBL_ERR;
+      }
+      if (mp_cmp(&n, number) == MP_GT) {
+         break;
+      }
+
+      if ((err = mp_mul_2(&shift, &shift)) != MP_OKAY) {
+         goto LBL_ERR;
+      }
+
+      /* The following is a Newton-Raphson step, to restore the invariant
+       * that $M is (8 * 2**$shift) / $n, rounded up. */
+      {
+         if ((err = mp_sqr(&M, &M2)) != MP_OKAY) {
             goto LBL_ERR;
-        }
-        *result[0] = '-';
-    }
-    if ((err = mp_init_set(&n, 1000)) != MP_OKAY) {
-        goto LBL_ERR;
-    }
-
-    nL = malloc(20 * sizeof(mp_int));
-    if ((err = mp_init_copy(&nL[0], &n)) != MP_OKAY) {
-        goto LBL_ERR;
-    }
-
-    if ((err = mp_init_set(&shift, 20)) != MP_OKAY) {
-        goto LBL_ERR;
-    }
-
-    shiftL = malloc(20 * sizeof(mp_int));
-    if ((err = mp_init_copy(&shiftL[0], &shift)) != MP_OKAY) {
-        goto LBL_ERR;
-    }
-
-    /* (8 * 2**$shift) / $n rounded up */
-    if ((err = mp_init_set(&M, 8389)) != MP_OKAY) {
-        goto LBL_ERR;
-    }
-
-    /* $M / 8, rounded up */
-    mL = malloc(20 * sizeof(mp_int));
-    if ((err = mp_init_set(&mL[0], 1049)) != MP_OKAY) {
-        goto LBL_ERR;
-    }
-
-    while (1) {
-        if ((err = mp_sqr(&n, &n)) != MP_OKAY) {
+         }
+         if ((err = mp_sqr(&M2, &M4)) != MP_OKAY) {
             goto LBL_ERR;
-        }
-        if (mp_cmp(&n, number) == MP_GT) {
-            break;
-        }
+         }
 
-        if ((err = mp_mul_2(&shift, &shift)) != MP_OKAY) {
+         if ((err = mp_mul(&M4, &n, &M4)) != MP_OKAY) {
             goto LBL_ERR;
-        }
-
-        /* The following is a Newton-Raphson step, to restore the invariant
-         * that $M is (8 * 2**$shift) / $n, rounded up. */
-        {
-            if ((err = mp_sqr(&M, &M2)) != MP_OKAY) {
-                goto LBL_ERR;
-            }
-            if ((err = mp_sqr(&M2, &M4)) != MP_OKAY) {
-                goto LBL_ERR;
-            }
-
-            if ((err = mp_mul(&M4, &n, &M4)) != MP_OKAY) {
-                goto LBL_ERR;
-            }
-            if ((err = mp_div_2d(&M4, mp_get_ul(&shift) + 6, &M4, NULL)) != MP_OKAY) {
-                goto LBL_ERR;
-            }
-            if ((err = mp_mul_2(&M2, &M2)) != MP_OKAY) {
-                goto LBL_ERR;
-            }
-            if ((err = mp_sub(&M4, &M2, &M4)) != MP_OKAY) {
-                goto LBL_ERR;
-            }
-            if ((err = mp_add_d(&M4, 1, &M4)) != MP_OKAY) {
-                goto LBL_ERR;
-            }
-            if ((err = mp_div_2d(&M4, 3, &M4, NULL)) != MP_OKAY) {
-                goto LBL_ERR;
-            }
-            if ((err = mp_sub_d(&M4, 1, &M4)) != MP_OKAY) {
-                goto LBL_ERR;
-            }
-            if ((err = mp_neg(&M4, &M)) != MP_OKAY) {
-                goto LBL_ERR;
-            }
-        }
-
-        if ((err = mp_init_copy(&nL[index], &n)) != MP_OKAY) {
+         }
+         if ((err = mp_div_2d(&M4, mp_get_i32(&shift) + 6, &M4, NULL)) != MP_OKAY) {
             goto LBL_ERR;
-        }
-        if ((err = mp_init_copy(&shiftL[index], &shift)) != MP_OKAY) {
+         }
+         if ((err = mp_mul_2(&M2, &M2)) != MP_OKAY) {
             goto LBL_ERR;
-        }
-
-        /* Divide by 8, round up */
-        {
-            if ((err = mp_add_d(&M4, 1, &M4)) != MP_OKAY) {
-                goto LBL_ERR;
-            }
-            if ((err = mp_div_2d(&M4, 3, &M4, NULL)) != MP_OKAY) {
-                goto LBL_ERR;
-            }
-            if ((err = mp_sub_d(&M4, 1, &M4)) != MP_OKAY) {
-                goto LBL_ERR;
-            }
-            if ((err = mp_neg(&M4, &M4)) != MP_OKAY) {
-                goto LBL_ERR;
-            }
-        }
-        if ((err = mp_init_copy(&mL[index], &M4)) != MP_OKAY) {
+         }
+         if ((err = mp_sub(&M4, &M2, &M4)) != MP_OKAY) {
             goto LBL_ERR;
-        }
-        index++;
-    }
+         }
+         if ((err = mp_add_d(&M4, 1, &M4)) != MP_OKAY) {
+            goto LBL_ERR;
+         }
+         if ((err = mp_div_2d(&M4, 3, &M4, NULL)) != MP_OKAY) {
+            goto LBL_ERR;
+         }
+         if ((err = mp_sub_d(&M4, 1, &M4)) != MP_OKAY) {
+            goto LBL_ERR;
+         }
+         if ((err = mp_neg(&M4, &M)) != MP_OKAY) {
+            goto LBL_ERR;
+         }
+      }
 
-    if ((err = mp_todecimal_fast_rec(number, nL, shiftL, mL, index - 1, 1, result)) != MP_OKAY) {
-        goto LBL_ERR;
-    }
+      if ((err = mp_init_copy(&nL[precalc_array_index], &n)) != MP_OKAY) {
+         goto LBL_ERR;
+      }
+      if ((err = mp_init_copy(&shiftL[precalc_array_index], &shift)) != MP_OKAY) {
+         goto LBL_ERR;
+      }
 
-    err = MP_OKAY;
+      /* Divide by 8, round up */
+      {
+         if ((err = mp_add_d(&M4, 1, &M4)) != MP_OKAY) {
+            goto LBL_ERR;
+         }
+         if ((err = mp_div_2d(&M4, 3, &M4, NULL)) != MP_OKAY) {
+            goto LBL_ERR;
+         }
+         if ((err = mp_sub_d(&M4, 1, &M4)) != MP_OKAY) {
+            goto LBL_ERR;
+         }
+         if ((err = mp_neg(&M4, &M4)) != MP_OKAY) {
+            goto LBL_ERR;
+         }
+      }
+      if ((err = mp_init_copy(&mL[precalc_array_index], &M4)) != MP_OKAY) {
+         goto LBL_ERR;
+      }
+      precalc_array_index++;
+   }
 
-LBL_ERR:mp_clear_multi (&n, &shift, &M, &M2, &M22, &M4, &M44, NULL);
-    return err;
+   if ((err = mp_todecimal_fast_rec(number, nL, shiftL, mL, precalc_array_index - 1, 1, result)) != MP_OKAY) {
+      goto LBL_ERR;
+   }
+
+   err = MP_OKAY;
+
+LBL_ERR:
+   mp_clear_multi(&n, &shift, &M, &M2, &M22, &M4, &M44, NULL);
+   return err;
 }
 
 #endif

--- a/bn_prime_tab.c
+++ b/bn_prime_tab.c
@@ -44,7 +44,7 @@ const mp_digit ltm_prime_tab[] = {
 #endif
 };
 
-#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 301)
+#if defined(__GNUC__) && __GNUC__ >= 4
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 const mp_digit *s_mp_prime_tab = ltm_prime_tab;

--- a/bn_s_mp_exptmod.c
+++ b/bn_s_mp_exptmod.c
@@ -5,8 +5,10 @@
 
 #ifdef MP_LOW_MEM
 #   define TAB_SIZE 32
+#   define MAX_WINSIZE 5
 #else
 #   define TAB_SIZE 256
+#   define MAX_WINSIZE 0
 #endif
 
 mp_err s_mp_exptmod(const mp_int *G, const mp_int *X, const mp_int *P, mp_int *Y, int redmode)
@@ -35,11 +37,7 @@ mp_err s_mp_exptmod(const mp_int *G, const mp_int *X, const mp_int *P, mp_int *Y
       winsize = 8;
    }
 
-#ifdef MP_LOW_MEM
-   if (winsize > 5) {
-      winsize = 5;
-   }
-#endif
+   winsize = MAX_WINSIZE ? MP_MIN(MAX_WINSIZE, winsize) : winsize;
 
    /* init M array */
    /* init first cell */

--- a/bn_s_mp_mul_high_digs.c
+++ b/bn_s_mp_mul_high_digs.c
@@ -16,12 +16,11 @@ mp_err s_mp_mul_high_digs(const mp_int *a, const mp_int *b, mp_int *c, int digs)
    mp_digit tmpx, *tmpt, *tmpy;
 
    /* can we use the fast multiplier? */
-#ifdef BN_S_MP_MUL_HIGH_DIGS_FAST_C
-   if (((a->used + b->used + 1) < MP_WARRAY)
+   if (MP_HAS(S_MP_MUL_HIGH_DIGS_FAST)
+       && ((a->used + b->used + 1) < MP_WARRAY)
        && (MP_MIN(a->used, b->used) < MP_MAXFAST)) {
       return s_mp_mul_high_digs_fast(a, b, c, digs);
    }
-#endif
 
    if ((err = mp_init_size(&t, a->used + b->used + 1)) != MP_OKAY) {
       return err;

--- a/bn_s_mp_rand_platform.c
+++ b/bn_s_mp_rand_platform.c
@@ -8,11 +8,16 @@
  * - Windows
  */
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
-#  define MP_ARC4RANDOM
+#define BN_S_READ_ARC4RANDOM_C
+static mp_err s_read_arc4random(void *p, size_t n)
+{
+   arc4random_buf(p, n);
+   return MP_OKAY;
+}
 #endif
 
 #if defined(_WIN32) || defined(_WIN32_WCE)
-#define MP_WIN_CSP
+#define BN_S_READ_WINCSP_C
 
 #ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0400
@@ -33,7 +38,7 @@
 # pragma warning(pop)
 #endif
 
-static mp_err s_read_win_csp(void *p, size_t n)
+static mp_err s_read_wincsp(void *p, size_t n)
 {
    static HCRYPTPROV hProv = 0;
    if (hProv == 0) {
@@ -50,9 +55,9 @@ static mp_err s_read_win_csp(void *p, size_t n)
 }
 #endif /* WIN32 */
 
-#if !defined(MP_WIN_CSP) && defined(__linux__) && defined(__GLIBC_PREREQ)
+#if !defined(BN_S_READ_WINCSP_C) && defined(__linux__) && defined(__GLIBC_PREREQ)
 #if __GLIBC_PREREQ(2, 25)
-#define MP_GETRANDOM
+#define BN_S_READ_GETRANDOM_C
 #include <sys/random.h>
 #include <errno.h>
 
@@ -78,7 +83,8 @@ static mp_err s_read_getrandom(void *p, size_t n)
 /* We assume all platforms besides windows provide "/dev/urandom".
  * In case yours doesn't, define MP_NO_DEV_URANDOM at compile-time.
  */
-#if !defined(MP_WIN_CSP) && !defined(MP_NO_DEV_URANDOM)
+#if !defined(BN_S_READ_WINCSP_C) && !defined(MP_NO_DEV_URANDOM)
+#define BN_S_READ_URANDOM_C
 #ifndef MP_DEV_URANDOM
 #define MP_DEV_URANDOM "/dev/urandom"
 #endif
@@ -86,7 +92,7 @@ static mp_err s_read_getrandom(void *p, size_t n)
 #include <errno.h>
 #include <unistd.h>
 
-static mp_err s_read_dev_urandom(void *p, size_t n)
+static mp_err s_read_urandom(void *p, size_t n)
 {
    int fd;
    char *q = (char *)p;
@@ -115,6 +121,7 @@ static mp_err s_read_dev_urandom(void *p, size_t n)
 #endif
 
 #if defined(MP_PRNG_ENABLE_LTM_RNG)
+#define B_S_READ_LTM_RNG
 unsigned long (*ltm_rng)(unsigned char *out, unsigned long outlen, void (*callback)(void));
 void (*ltm_rng_callback)(void);
 
@@ -128,37 +135,21 @@ static mp_err s_read_ltm_rng(void *p, size_t n)
 }
 #endif
 
+mp_err s_read_arc4random(void *p, size_t n);
+mp_err s_read_wincsp(void *p, size_t n);
+mp_err s_read_getrandom(void *p, size_t n);
+mp_err s_read_urandom(void *p, size_t n);
+mp_err s_read_ltm_rng(void *p, size_t n);
+
 mp_err s_mp_rand_platform(void *p, size_t n)
 {
-#if defined(MP_ARC4RANDOM)
-   arc4random_buf(p, n);
-   return MP_OKAY;
-#else
-
-   mp_err res = MP_ERR;
-
-#if defined(MP_WIN_CSP)
-   res = s_read_win_csp(p, n);
-   if (res == MP_OKAY) return res;
-#endif
-
-#if defined(MP_GETRANDOM)
-   res = s_read_getrandom(p, n);
-   if (res == MP_OKAY) return res;
-#endif
-
-#if defined(MP_DEV_URANDOM)
-   res = s_read_dev_urandom(p, n);
-   if (res == MP_OKAY) return res;
-#endif
-
-#if defined(MP_PRNG_ENABLE_LTM_RNG)
-   res = s_read_ltm_rng(p, n);
-   if (res == MP_OKAY) return res;
-#endif
-
-   return res;
-#endif
+   mp_err err = MP_ERR;
+   if ((err != MP_OKAY) && MP_HAS(S_READ_ARC4RANDOM)) err = s_read_arc4random(p, n);
+   if ((err != MP_OKAY) && MP_HAS(S_READ_WINCSP))     err = s_read_wincsp(p, n);
+   if ((err != MP_OKAY) && MP_HAS(S_READ_GETRANDOM))  err = s_read_getrandom(p, n);
+   if ((err != MP_OKAY) && MP_HAS(S_READ_URANDOM))    err = s_read_urandom(p, n);
+   if ((err != MP_OKAY) && MP_HAS(S_READ_LTM_RNG))    err = s_read_ltm_rng(p, n);
+   return err;
 }
 
 #endif

--- a/bn_s_mp_todecimal_fast.c
+++ b/bn_s_mp_todecimal_fast.c
@@ -1,12 +1,13 @@
 #include "tommath_private.h"
 #include <string.h>
-#ifdef BN_MP_TODECIMAL_FAST_C
+#ifdef BN_S_MP_TODECIMAL_FAST_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
 /* store a bignum as a decimal ASCII string */
-mp_err mp_todecimal_fast_rec(mp_int *number, mp_int *nL, mp_int *shiftL, mp_int *mL, int precalc_array_index, int left,
-                             char **result)
+mp_err s_mp_todecimal_fast_rec(const mp_int *number, mp_int *nL, mp_int *shiftL, mp_int *mL, int precalc_array_index,
+                               int left,
+                               char **result)
 {
    mp_int q, nLq, r;
    mp_err err;
@@ -47,14 +48,14 @@ mp_err mp_todecimal_fast_rec(mp_int *number, mp_int *nL, mp_int *shiftL, mp_int 
 
    --precalc_array_index;
    if (left && mp_iszero(&q)) {
-      if ((err = mp_todecimal_fast_rec(&r, nL, shiftL, mL, precalc_array_index, 1, result)) != MP_OKAY) {
+      if ((err = s_mp_todecimal_fast_rec(&r, nL, shiftL, mL, precalc_array_index, 1, result)) != MP_OKAY) {
          goto LBL_ERR;
       }
    } else {
-      if ((err = mp_todecimal_fast_rec(&q, nL, shiftL, mL, precalc_array_index, left, result)) != MP_OKAY) {
+      if ((err = s_mp_todecimal_fast_rec(&q, nL, shiftL, mL, precalc_array_index, left, result)) != MP_OKAY) {
          goto LBL_ERR;
       }
-      if ((err = mp_todecimal_fast_rec(&r, nL, shiftL, mL, precalc_array_index, 0, result)) != MP_OKAY) {
+      if ((err = s_mp_todecimal_fast_rec(&r, nL, shiftL, mL, precalc_array_index, 0, result)) != MP_OKAY) {
          goto LBL_ERR;
       }
    }
@@ -66,9 +67,9 @@ LBL_ERR:
    return err;
 }
 
-mp_err mp_todecimal_fast(mp_int *number, char *result)
+mp_err s_mp_todecimal_fast(const mp_int *a, char *result)
 {
-   mp_int n, shift, M, M2, M22, M4, M44;
+   mp_int number, n, shift, M, M2, M22, M4, M44;
    mp_int nL[20], shiftL[20], mL[20];
    mp_err err;
    char **result_addr = &result;
@@ -78,8 +79,11 @@ mp_err mp_todecimal_fast(mp_int *number, char *result)
       goto LBL_ERR;
    }
 
-   if (mp_isneg(number)) {
-      if ((err = mp_neg(number, number)) != MP_OKAY) {
+   if ((err = mp_init_copy(&number, a)) != MP_OKAY) {
+      goto LBL_ERR;
+   }
+   if (mp_isneg(&number)) {
+      if ((err = mp_neg(&number, &number)) != MP_OKAY) {
          goto LBL_ERR;
       }
       result[0] = '-';
@@ -115,7 +119,7 @@ mp_err mp_todecimal_fast(mp_int *number, char *result)
       if ((err = mp_sqr(&n, &n)) != MP_OKAY) {
          goto LBL_ERR;
       }
-      if (mp_cmp(&n, number) == MP_GT) {
+      if (mp_cmp(&n, &number) == MP_GT) {
          break;
       }
 
@@ -187,7 +191,7 @@ mp_err mp_todecimal_fast(mp_int *number, char *result)
       precalc_array_index++;
    }
 
-   if ((err = mp_todecimal_fast_rec(number, nL, shiftL, mL, precalc_array_index - 1, 1, result_addr)) != MP_OKAY) {
+   if ((err = s_mp_todecimal_fast_rec(&number, nL, shiftL, mL, precalc_array_index - 1, 1, result_addr)) != MP_OKAY) {
       goto LBL_ERR;
    }
 

--- a/demo/test.c
+++ b/demo/test.c
@@ -50,6 +50,49 @@ static uint64_t uabs64(int64_t x)
    return x > 0 ? (uint64_t)x : -(uint64_t)x;
 }
 
+/* This function prototype is needed
+ * to test dead code elimination
+ * which is used for feature detection.
+ *
+ * If the feature detection does not
+ * work as desired we will get a linker error.
+ */
+void does_not_exist(void);
+
+static int test_feature_detection(void)
+{
+#define BN_TEST_FEATURE1_C
+   if (!MP_HAS(TEST_FEATURE1)) {
+      does_not_exist();
+      return EXIT_FAILURE;
+   }
+
+#define BN_TEST_FEATURE2_C 1
+   if (MP_HAS(TEST_FEATURE2)) {
+      does_not_exist();
+      return EXIT_FAILURE;
+   }
+
+#define BN_TEST_FEATURE3_C 0
+   if (MP_HAS(TEST_FEATURE3)) {
+      does_not_exist();
+      return EXIT_FAILURE;
+   }
+
+#define BN_TEST_FEATURE4_C something
+   if (MP_HAS(TEST_FEATURE4)) {
+      does_not_exist();
+      return EXIT_FAILURE;
+   }
+
+   if (MP_HAS(TEST_FEATURE5)) {
+      does_not_exist();
+      return EXIT_FAILURE;
+   }
+
+   return EXIT_SUCCESS;
+}
+
 static int test_trivial_stuff(void)
 {
    mp_int a, b, c, d;
@@ -2046,6 +2089,7 @@ int unit_tests(int argc, char **argv)
       int (*fn)(void);
    } test[] = {
 #define T(n) { #n, test_##n }
+      T(feature_detection),
       T(trivial_stuff),
       T(mp_get_set_i32),
       T(mp_get_set_i64),

--- a/libtommath_VS2008.vcproj
+++ b/libtommath_VS2008.vcproj
@@ -833,7 +833,7 @@
 			>
 		</File>
 		<File
-			RelativePath="bn_mp_todecimal_fast.c"
+			RelativePath="bn_mp_todecimal.c"
 			>
 		</File>
 		<File
@@ -942,6 +942,10 @@
 		</File>
 		<File
 			RelativePath="bn_s_mp_sub.c"
+			>
+		</File>
+		<File
+			RelativePath="bn_s_mp_todecimal_fast.c"
 			>
 		</File>
 		<File

--- a/libtommath_VS2008.vcproj
+++ b/libtommath_VS2008.vcproj
@@ -833,6 +833,10 @@
 			>
 		</File>
 		<File
+			RelativePath="bn_mp_todecimal_fast.c"
+			>
+		</File>
+		<File
 			RelativePath="bn_mp_toradix.c"
 			>
 		</File>

--- a/makefile
+++ b/makefile
@@ -49,13 +49,13 @@ bn_mp_set.o bn_mp_set_double.o bn_mp_set_i32.o bn_mp_set_i64.o bn_mp_set_l.o bn_
 bn_mp_set_u32.o bn_mp_set_u64.o bn_mp_set_ul.o bn_mp_set_ull.o bn_mp_shrink.o bn_mp_signed_bin_size.o \
 bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o \
 bn_mp_submod.o bn_mp_to_signed_bin.o bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o \
-bn_mp_to_unsigned_bin_n.o bn_mp_toradix.o bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o bn_mp_xor.o \
-bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o \
-bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o bn_s_mp_karatsuba_mul.o \
-bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o bn_s_mp_mul_digs_fast.o \
-bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o bn_s_mp_prime_is_divisible.o \
-bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o bn_s_mp_sqr.o bn_s_mp_sqr_fast.o \
-bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
+bn_mp_to_unsigned_bin_n.o bn_mp_todecimal_fast.o bn_mp_toradix.o bn_mp_toradix_n.o \
+bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o \
+bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o \
+bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o \
+bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o \
+bn_s_mp_prime_is_divisible.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
+bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
 
 #END_INS
 

--- a/makefile
+++ b/makefile
@@ -49,13 +49,14 @@ bn_mp_set.o bn_mp_set_double.o bn_mp_set_i32.o bn_mp_set_i64.o bn_mp_set_l.o bn_
 bn_mp_set_u32.o bn_mp_set_u64.o bn_mp_set_ul.o bn_mp_set_ull.o bn_mp_shrink.o bn_mp_signed_bin_size.o \
 bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o \
 bn_mp_submod.o bn_mp_to_signed_bin.o bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o \
-bn_mp_to_unsigned_bin_n.o bn_mp_todecimal_fast.o bn_mp_toradix.o bn_mp_toradix_n.o \
-bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o \
-bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o \
+bn_mp_to_unsigned_bin_n.o bn_mp_todecimal.o bn_mp_toradix.o bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o \
+bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o bn_s_mp_exptmod.o \
+bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o \
 bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o \
 bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o \
 bn_s_mp_prime_is_divisible.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
-bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
+bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_todecimal_fast.o bn_s_mp_toom_mul.o \
+bn_s_mp_toom_sqr.o
 
 #END_INS
 

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -52,13 +52,13 @@ bn_mp_set.o bn_mp_set_double.o bn_mp_set_i32.o bn_mp_set_i64.o bn_mp_set_l.o bn_
 bn_mp_set_u32.o bn_mp_set_u64.o bn_mp_set_ul.o bn_mp_set_ull.o bn_mp_shrink.o bn_mp_signed_bin_size.o \
 bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o \
 bn_mp_submod.o bn_mp_to_signed_bin.o bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o \
-bn_mp_to_unsigned_bin_n.o bn_mp_toradix.o bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o bn_mp_xor.o \
-bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o \
-bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o bn_s_mp_karatsuba_mul.o \
-bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o bn_s_mp_mul_digs_fast.o \
-bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o bn_s_mp_prime_is_divisible.o \
-bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o bn_s_mp_sqr.o bn_s_mp_sqr_fast.o \
-bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
+bn_mp_to_unsigned_bin_n.o bn_mp_todecimal_fast.o bn_mp_toradix.o bn_mp_toradix_n.o \
+bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o \
+bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o \
+bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o \
+bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o \
+bn_s_mp_prime_is_divisible.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
+bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h $(HEADERS_PUB)

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -52,13 +52,14 @@ bn_mp_set.o bn_mp_set_double.o bn_mp_set_i32.o bn_mp_set_i64.o bn_mp_set_l.o bn_
 bn_mp_set_u32.o bn_mp_set_u64.o bn_mp_set_ul.o bn_mp_set_ull.o bn_mp_shrink.o bn_mp_signed_bin_size.o \
 bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o \
 bn_mp_submod.o bn_mp_to_signed_bin.o bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o \
-bn_mp_to_unsigned_bin_n.o bn_mp_todecimal_fast.o bn_mp_toradix.o bn_mp_toradix_n.o \
-bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o \
-bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o \
+bn_mp_to_unsigned_bin_n.o bn_mp_todecimal.o bn_mp_toradix.o bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o \
+bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o bn_s_mp_exptmod.o \
+bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o \
 bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o \
 bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o \
 bn_s_mp_prime_is_divisible.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
-bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
+bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_todecimal_fast.o bn_s_mp_toom_mul.o \
+bn_s_mp_toom_sqr.o
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h $(HEADERS_PUB)

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -44,13 +44,13 @@ bn_mp_set.obj bn_mp_set_double.obj bn_mp_set_i32.obj bn_mp_set_i64.obj bn_mp_set
 bn_mp_set_u32.obj bn_mp_set_u64.obj bn_mp_set_ul.obj bn_mp_set_ull.obj bn_mp_shrink.obj bn_mp_signed_bin_size.obj \
 bn_mp_signed_rsh.obj bn_mp_sqr.obj bn_mp_sqrmod.obj bn_mp_sqrt.obj bn_mp_sqrtmod_prime.obj bn_mp_sub.obj bn_mp_sub_d.obj \
 bn_mp_submod.obj bn_mp_to_signed_bin.obj bn_mp_to_signed_bin_n.obj bn_mp_to_unsigned_bin.obj \
-bn_mp_to_unsigned_bin_n.obj bn_mp_toradix.obj bn_mp_toradix_n.obj bn_mp_unsigned_bin_size.obj bn_mp_xor.obj \
-bn_mp_zero.obj bn_prime_tab.obj bn_s_mp_add.obj bn_s_mp_balance_mul.obj bn_s_mp_exptmod.obj bn_s_mp_exptmod_fast.obj \
-bn_s_mp_get_bit.obj bn_s_mp_invmod_fast.obj bn_s_mp_invmod_slow.obj bn_s_mp_karatsuba_mul.obj \
-bn_s_mp_karatsuba_sqr.obj bn_s_mp_montgomery_reduce_fast.obj bn_s_mp_mul_digs.obj bn_s_mp_mul_digs_fast.obj \
-bn_s_mp_mul_high_digs.obj bn_s_mp_mul_high_digs_fast.obj bn_s_mp_prime_is_divisible.obj \
-bn_s_mp_rand_jenkins.obj bn_s_mp_rand_platform.obj bn_s_mp_reverse.obj bn_s_mp_sqr.obj bn_s_mp_sqr_fast.obj \
-bn_s_mp_sub.obj bn_s_mp_toom_mul.obj bn_s_mp_toom_sqr.obj
+bn_mp_to_unsigned_bin_n.obj bn_mp_todecimal_fast.obj bn_mp_toradix.obj bn_mp_toradix_n.obj \
+bn_mp_unsigned_bin_size.obj bn_mp_xor.obj bn_mp_zero.obj bn_prime_tab.obj bn_s_mp_add.obj bn_s_mp_balance_mul.obj \
+bn_s_mp_exptmod.obj bn_s_mp_exptmod_fast.obj bn_s_mp_get_bit.obj bn_s_mp_invmod_fast.obj bn_s_mp_invmod_slow.obj \
+bn_s_mp_karatsuba_mul.obj bn_s_mp_karatsuba_sqr.obj bn_s_mp_montgomery_reduce_fast.obj bn_s_mp_mul_digs.obj \
+bn_s_mp_mul_digs_fast.obj bn_s_mp_mul_high_digs.obj bn_s_mp_mul_high_digs_fast.obj \
+bn_s_mp_prime_is_divisible.obj bn_s_mp_rand_jenkins.obj bn_s_mp_rand_platform.obj bn_s_mp_reverse.obj \
+bn_s_mp_sqr.obj bn_s_mp_sqr_fast.obj bn_s_mp_sub.obj bn_s_mp_toom_mul.obj bn_s_mp_toom_sqr.obj
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h $(HEADERS_PUB)

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -14,7 +14,7 @@ PREFIX    = c:\devel
 CFLAGS    = /Ox
 
 #Compilation flags
-LTM_CFLAGS  = /nologo /I./ /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D__STDC_WANT_SECURE_LIB__=1 /D_CRT_HAS_CXX17=0 /Wall /wd4146 /wd4127 /wd4710 /wd4711 /wd4820 /WX $(CFLAGS)
+LTM_CFLAGS  = /nologo /I./ /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D__STDC_WANT_SECURE_LIB__=1 /D_CRT_HAS_CXX17=0 /Wall /wd4146 /wd4127 /wd4710 /wd4711 /wd4820 /wd4003 /WX $(CFLAGS)
 LTM_LDFLAGS = advapi32.lib
 
 #Libraries to be created (this makefile builds only static libraries)

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -44,13 +44,14 @@ bn_mp_set.obj bn_mp_set_double.obj bn_mp_set_i32.obj bn_mp_set_i64.obj bn_mp_set
 bn_mp_set_u32.obj bn_mp_set_u64.obj bn_mp_set_ul.obj bn_mp_set_ull.obj bn_mp_shrink.obj bn_mp_signed_bin_size.obj \
 bn_mp_signed_rsh.obj bn_mp_sqr.obj bn_mp_sqrmod.obj bn_mp_sqrt.obj bn_mp_sqrtmod_prime.obj bn_mp_sub.obj bn_mp_sub_d.obj \
 bn_mp_submod.obj bn_mp_to_signed_bin.obj bn_mp_to_signed_bin_n.obj bn_mp_to_unsigned_bin.obj \
-bn_mp_to_unsigned_bin_n.obj bn_mp_todecimal_fast.obj bn_mp_toradix.obj bn_mp_toradix_n.obj \
-bn_mp_unsigned_bin_size.obj bn_mp_xor.obj bn_mp_zero.obj bn_prime_tab.obj bn_s_mp_add.obj bn_s_mp_balance_mul.obj \
-bn_s_mp_exptmod.obj bn_s_mp_exptmod_fast.obj bn_s_mp_get_bit.obj bn_s_mp_invmod_fast.obj bn_s_mp_invmod_slow.obj \
+bn_mp_to_unsigned_bin_n.obj bn_mp_todecimal.obj bn_mp_toradix.obj bn_mp_toradix_n.obj bn_mp_unsigned_bin_size.obj \
+bn_mp_xor.obj bn_mp_zero.obj bn_prime_tab.obj bn_s_mp_add.obj bn_s_mp_balance_mul.obj bn_s_mp_exptmod.obj \
+bn_s_mp_exptmod_fast.obj bn_s_mp_get_bit.obj bn_s_mp_invmod_fast.obj bn_s_mp_invmod_slow.obj \
 bn_s_mp_karatsuba_mul.obj bn_s_mp_karatsuba_sqr.obj bn_s_mp_montgomery_reduce_fast.obj bn_s_mp_mul_digs.obj \
 bn_s_mp_mul_digs_fast.obj bn_s_mp_mul_high_digs.obj bn_s_mp_mul_high_digs_fast.obj \
 bn_s_mp_prime_is_divisible.obj bn_s_mp_rand_jenkins.obj bn_s_mp_rand_platform.obj bn_s_mp_reverse.obj \
-bn_s_mp_sqr.obj bn_s_mp_sqr_fast.obj bn_s_mp_sub.obj bn_s_mp_toom_mul.obj bn_s_mp_toom_sqr.obj
+bn_s_mp_sqr.obj bn_s_mp_sqr_fast.obj bn_s_mp_sub.obj bn_s_mp_todecimal_fast.obj bn_s_mp_toom_mul.obj \
+bn_s_mp_toom_sqr.obj
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h $(HEADERS_PUB)

--- a/makefile.shared
+++ b/makefile.shared
@@ -46,13 +46,14 @@ bn_mp_set.o bn_mp_set_double.o bn_mp_set_i32.o bn_mp_set_i64.o bn_mp_set_l.o bn_
 bn_mp_set_u32.o bn_mp_set_u64.o bn_mp_set_ul.o bn_mp_set_ull.o bn_mp_shrink.o bn_mp_signed_bin_size.o \
 bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o \
 bn_mp_submod.o bn_mp_to_signed_bin.o bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o \
-bn_mp_to_unsigned_bin_n.o bn_mp_todecimal_fast.o bn_mp_toradix.o bn_mp_toradix_n.o \
-bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o \
-bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o \
+bn_mp_to_unsigned_bin_n.o bn_mp_todecimal.o bn_mp_toradix.o bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o \
+bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o bn_s_mp_exptmod.o \
+bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o \
 bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o \
 bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o \
 bn_s_mp_prime_is_divisible.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
-bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
+bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_todecimal_fast.o bn_s_mp_toom_mul.o \
+bn_s_mp_toom_sqr.o
 
 #END_INS
 

--- a/makefile.shared
+++ b/makefile.shared
@@ -46,13 +46,13 @@ bn_mp_set.o bn_mp_set_double.o bn_mp_set_i32.o bn_mp_set_i64.o bn_mp_set_l.o bn_
 bn_mp_set_u32.o bn_mp_set_u64.o bn_mp_set_ul.o bn_mp_set_ull.o bn_mp_shrink.o bn_mp_signed_bin_size.o \
 bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o \
 bn_mp_submod.o bn_mp_to_signed_bin.o bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o \
-bn_mp_to_unsigned_bin_n.o bn_mp_toradix.o bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o bn_mp_xor.o \
-bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o \
-bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o bn_s_mp_karatsuba_mul.o \
-bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o bn_s_mp_mul_digs_fast.o \
-bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o bn_s_mp_prime_is_divisible.o \
-bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o bn_s_mp_sqr.o bn_s_mp_sqr_fast.o \
-bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
+bn_mp_to_unsigned_bin_n.o bn_mp_todecimal_fast.o bn_mp_toradix.o bn_mp_toradix_n.o \
+bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o \
+bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o \
+bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o \
+bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o \
+bn_s_mp_prime_is_divisible.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
+bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
 
 #END_INS
 

--- a/makefile.unix
+++ b/makefile.unix
@@ -53,13 +53,13 @@ bn_mp_set.o bn_mp_set_double.o bn_mp_set_i32.o bn_mp_set_i64.o bn_mp_set_l.o bn_
 bn_mp_set_u32.o bn_mp_set_u64.o bn_mp_set_ul.o bn_mp_set_ull.o bn_mp_shrink.o bn_mp_signed_bin_size.o \
 bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o \
 bn_mp_submod.o bn_mp_to_signed_bin.o bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o \
-bn_mp_to_unsigned_bin_n.o bn_mp_toradix.o bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o bn_mp_xor.o \
-bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o \
-bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o bn_s_mp_karatsuba_mul.o \
-bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o bn_s_mp_mul_digs_fast.o \
-bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o bn_s_mp_prime_is_divisible.o \
-bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o bn_s_mp_sqr.o bn_s_mp_sqr_fast.o \
-bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
+bn_mp_to_unsigned_bin_n.o bn_mp_todecimal_fast.o bn_mp_toradix.o bn_mp_toradix_n.o \
+bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o \
+bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o \
+bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o \
+bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o \
+bn_s_mp_prime_is_divisible.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
+bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h $(HEADERS_PUB)

--- a/makefile.unix
+++ b/makefile.unix
@@ -53,13 +53,14 @@ bn_mp_set.o bn_mp_set_double.o bn_mp_set_i32.o bn_mp_set_i64.o bn_mp_set_l.o bn_
 bn_mp_set_u32.o bn_mp_set_u64.o bn_mp_set_ul.o bn_mp_set_ull.o bn_mp_shrink.o bn_mp_signed_bin_size.o \
 bn_mp_signed_rsh.o bn_mp_sqr.o bn_mp_sqrmod.o bn_mp_sqrt.o bn_mp_sqrtmod_prime.o bn_mp_sub.o bn_mp_sub_d.o \
 bn_mp_submod.o bn_mp_to_signed_bin.o bn_mp_to_signed_bin_n.o bn_mp_to_unsigned_bin.o \
-bn_mp_to_unsigned_bin_n.o bn_mp_todecimal_fast.o bn_mp_toradix.o bn_mp_toradix_n.o \
-bn_mp_unsigned_bin_size.o bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o \
-bn_s_mp_exptmod.o bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o \
+bn_mp_to_unsigned_bin_n.o bn_mp_todecimal.o bn_mp_toradix.o bn_mp_toradix_n.o bn_mp_unsigned_bin_size.o \
+bn_mp_xor.o bn_mp_zero.o bn_prime_tab.o bn_s_mp_add.o bn_s_mp_balance_mul.o bn_s_mp_exptmod.o \
+bn_s_mp_exptmod_fast.o bn_s_mp_get_bit.o bn_s_mp_invmod_fast.o bn_s_mp_invmod_slow.o \
 bn_s_mp_karatsuba_mul.o bn_s_mp_karatsuba_sqr.o bn_s_mp_montgomery_reduce_fast.o bn_s_mp_mul_digs.o \
 bn_s_mp_mul_digs_fast.o bn_s_mp_mul_high_digs.o bn_s_mp_mul_high_digs_fast.o \
 bn_s_mp_prime_is_divisible.o bn_s_mp_rand_jenkins.o bn_s_mp_rand_platform.o bn_s_mp_reverse.o \
-bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_toom_mul.o bn_s_mp_toom_sqr.o
+bn_s_mp_sqr.o bn_s_mp_sqr_fast.o bn_s_mp_sub.o bn_s_mp_todecimal_fast.o bn_s_mp_toom_mul.o \
+bn_s_mp_toom_sqr.o
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h $(HEADERS_PUB)

--- a/tommath.def
+++ b/tommath.def
@@ -140,6 +140,7 @@ EXPORTS
     mp_to_signed_bin_n
     mp_to_unsigned_bin
     mp_to_unsigned_bin_n
+    mp_todecimal_fast
     mp_toradix
     mp_toradix_n
     mp_unsigned_bin_size

--- a/tommath.def
+++ b/tommath.def
@@ -140,7 +140,7 @@ EXPORTS
     mp_to_signed_bin_n
     mp_to_unsigned_bin
     mp_to_unsigned_bin_n
-    mp_todecimal_fast
+    mp_todecimal
     mp_toradix
     mp_toradix_n
     mp_unsigned_bin_size

--- a/tommath.h
+++ b/tommath.h
@@ -702,6 +702,7 @@ mp_err mp_read_radix(mp_int *a, const char *str, int radix) MP_WUR;
 mp_err mp_toradix(const mp_int *a, char *str, int radix) MP_WUR;
 mp_err mp_toradix_n(const mp_int *a, char *str, int radix, int maxlen) MP_WUR;
 mp_err mp_radix_size(const mp_int *a, int radix, int *size) MP_WUR;
+mp_err mp_todecimal(const mp_int *a, char *str) MP_WUR;
 
 #ifndef MP_NO_FILE
 mp_err mp_fread(mp_int *a, int radix, FILE *stream) MP_WUR;
@@ -717,7 +718,6 @@ mp_err mp_fwrite(const mp_int *a, int radix, FILE *stream) MP_WUR;
 
 #define mp_tobinary(M, S)  mp_toradix((M), (S), 2)
 #define mp_tooctal(M, S)   mp_toradix((M), (S), 8)
-#define mp_todecimal(M, S) mp_toradix((M), (S), 10)
 #define mp_tohex(M, S)     mp_toradix((M), (S), 16)
 
 #ifdef __cplusplus

--- a/tommath.h
+++ b/tommath.h
@@ -206,7 +206,7 @@ TOOM_SQR_CUTOFF;
 #  endif
 #endif
 
-#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 301)
+#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 405)
 #  define MP_DEPRECATED(x) __attribute__((deprecated("replaced by " #x)))
 #  define PRIVATE_MP_DEPRECATED_PRAGMA(s) _Pragma(#s)
 #  define MP_DEPRECATED_PRAGMA(s) PRIVATE_MP_DEPRECATED_PRAGMA(GCC warning s)

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -141,7 +141,7 @@
 #   define BN_MP_TO_SIGNED_BIN_N_C
 #   define BN_MP_TO_UNSIGNED_BIN_C
 #   define BN_MP_TO_UNSIGNED_BIN_N_C
-#   define BN_MP_TODECIMAL_FAST_C
+#   define BN_MP_TODECIMAL_C
 #   define BN_MP_TORADIX_C
 #   define BN_MP_TORADIX_N_C
 #   define BN_MP_UNSIGNED_BIN_SIZE_C
@@ -169,6 +169,7 @@
 #   define BN_S_MP_SQR_C
 #   define BN_S_MP_SQR_FAST_C
 #   define BN_S_MP_SUB_C
+#   define BN_S_MP_TODECIMAL_FAST_C
 #   define BN_S_MP_TOOM_MUL_C
 #   define BN_S_MP_TOOM_SQR_C
 #endif
@@ -1072,23 +1073,9 @@
 #   define BN_MP_UNSIGNED_BIN_SIZE_C
 #endif
 
-#if defined(BN_MP_TODECIMAL_FAST_C)
-#   define BN_MP_ADD_C
-#   define BN_MP_ADD_D_C
-#   define BN_MP_CLEAR_MULTI_C
-#   define BN_MP_CMP_C
-#   define BN_MP_DIV_2D_C
-#   define BN_MP_GET_I32_C
-#   define BN_MP_INIT_COPY_C
-#   define BN_MP_INIT_MULTI_C
-#   define BN_MP_INIT_SET_C
-#   define BN_MP_MUL_2_C
-#   define BN_MP_MUL_C
-#   define BN_MP_NEG_C
-#   define BN_MP_SQR_C
-#   define BN_MP_SUB_C
-#   define BN_MP_SUB_D_C
-#   define BN_MP_TODECIMAL_FAST_REC_C
+#if defined(BN_MP_TODECIMAL_C)
+#   define BN_MP_TORADIX_C
+#   define BN_S_MP_TODECIMAL_FAST_C
 #endif
 
 #if defined(BN_MP_TORADIX_C)
@@ -1284,6 +1271,25 @@
 #if defined(BN_S_MP_SUB_C)
 #   define BN_MP_CLAMP_C
 #   define BN_MP_GROW_C
+#endif
+
+#if defined(BN_S_MP_TODECIMAL_FAST_C)
+#   define BN_MP_ADD_C
+#   define BN_MP_ADD_D_C
+#   define BN_MP_CLEAR_MULTI_C
+#   define BN_MP_CMP_C
+#   define BN_MP_DIV_2D_C
+#   define BN_MP_GET_I32_C
+#   define BN_MP_INIT_COPY_C
+#   define BN_MP_INIT_MULTI_C
+#   define BN_MP_INIT_SET_C
+#   define BN_MP_MUL_2_C
+#   define BN_MP_MUL_C
+#   define BN_MP_NEG_C
+#   define BN_MP_SQR_C
+#   define BN_MP_SUB_C
+#   define BN_MP_SUB_D_C
+#   define BN_S_MP_TODECIMAL_FAST_REC_C
 #endif
 
 #if defined(BN_S_MP_TOOM_MUL_C)

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -141,6 +141,7 @@
 #   define BN_MP_TO_SIGNED_BIN_N_C
 #   define BN_MP_TO_UNSIGNED_BIN_C
 #   define BN_MP_TO_UNSIGNED_BIN_N_C
+#   define BN_MP_TODECIMAL_FAST_C
 #   define BN_MP_TORADIX_C
 #   define BN_MP_TORADIX_N_C
 #   define BN_MP_UNSIGNED_BIN_SIZE_C
@@ -1069,6 +1070,28 @@
 #if defined(BN_MP_TO_UNSIGNED_BIN_N_C)
 #   define BN_MP_TO_UNSIGNED_BIN_C
 #   define BN_MP_UNSIGNED_BIN_SIZE_C
+#endif
+
+#if defined(BN_MP_TODECIMAL_FAST_C)
+#   define BN_MP_2EXPT_C
+#   define BN_MP_ADD_C
+#   define BN_MP_ADD_D_C
+#   define BN_MP_BARRETT_TODECIMAL_C
+#   define BN_MP_BARRETT_TODECIMAL_REC_C
+#   define BN_MP_CMP_C
+#   define BN_MP_DIV_2D_C
+#   define BN_MP_GET_INT_C
+#   define BN_MP_GET_LONG_C
+#   define BN_MP_INIT_C
+#   define BN_MP_INIT_COPY_C
+#   define BN_MP_INIT_MULTI_C
+#   define BN_MP_INIT_SET_C
+#   define BN_MP_MUL_2_C
+#   define BN_MP_MUL_C
+#   define BN_MP_NEG_C
+#   define BN_MP_SQR_C
+#   define BN_MP_SUB_C
+#   define BN_MP_SUB_D_C
 #endif
 
 #if defined(BN_MP_TORADIX_C)

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -1073,16 +1073,12 @@
 #endif
 
 #if defined(BN_MP_TODECIMAL_FAST_C)
-#   define BN_MP_2EXPT_C
 #   define BN_MP_ADD_C
 #   define BN_MP_ADD_D_C
-#   define BN_MP_BARRETT_TODECIMAL_C
-#   define BN_MP_BARRETT_TODECIMAL_REC_C
+#   define BN_MP_CLEAR_MULTI_C
 #   define BN_MP_CMP_C
 #   define BN_MP_DIV_2D_C
-#   define BN_MP_GET_INT_C
-#   define BN_MP_GET_LONG_C
-#   define BN_MP_INIT_C
+#   define BN_MP_GET_I32_C
 #   define BN_MP_INIT_COPY_C
 #   define BN_MP_INIT_MULTI_C
 #   define BN_MP_INIT_SET_C
@@ -1092,6 +1088,7 @@
 #   define BN_MP_SQR_C
 #   define BN_MP_SUB_C
 #   define BN_MP_SUB_D_C
+#   define BN_MP_TODECIMAL_FAST_REC_C
 #endif
 
 #if defined(BN_MP_TORADIX_C)

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -860,6 +860,7 @@
 #   define BN_MP_SUB_C
 #   define BN_S_MP_MUL_DIGS_C
 #   define BN_S_MP_MUL_HIGH_DIGS_C
+#   define BN_S_MP_MUL_HIGH_DIGS_FAST_C
 #   define BN_S_MP_SUB_C
 #endif
 

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -17,7 +17,7 @@
  *
  * On Win32 a .def file must be used to specify the exported symbols.
  */
-#if defined (MP_PRIVATE_SYMBOLS) && __GNUC__ >= 4
+#if defined (MP_PRIVATE_SYMBOLS) && defined(__GNUC__) && __GNUC__ >= 4
 #   define MP_PRIVATE __attribute__ ((visibility ("hidden")))
 #else
 #   define MP_PRIVATE

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -140,6 +140,11 @@ extern void *MP_CALLOC(size_t nmemb, size_t size);
 extern void MP_FREE(void *mem, size_t size);
 #endif
 
+/* feature detection macro */
+#define MP_STRINGIZE(x)  MP__STRINGIZE(x)
+#define MP__STRINGIZE(x) ""#x""
+#define MP_HAS(x)        (sizeof(MP_STRINGIZE(BN_##x##_C)) == 1)
+
 /* TODO: Remove private_mp_word as soon as deprecated mp_word is removed from tommath. */
 #undef mp_word
 typedef private_mp_word mp_word;

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -205,6 +205,7 @@ MP_PRIVATE mp_err s_mp_rand_platform(void *p, size_t n) MP_WUR;
 MP_PRIVATE mp_err s_mp_prime_random_ex(mp_int *a, int t, int size, int flags, private_mp_prime_callback cb, void *dat);
 MP_PRIVATE void s_mp_reverse(unsigned char *s, int len);
 MP_PRIVATE mp_err s_mp_prime_is_divisible(const mp_int *a, mp_bool *result);
+MP_PRIVATE mp_err s_mp_todecimal_fast(const mp_int *a, char *result) MP_WUR;
 
 /* TODO: jenkins prng is not thread safe as of now */
 MP_PRIVATE mp_err s_mp_rand_jenkins(void *p, size_t n) MP_WUR;


### PR DESCRIPTION
that uses Barrett reduction to speed up stringifying large integers.

Some benchmarking, done with a lightly modified `demo/timing.c`:
```
CLK_PER_SEC == 3600313344
mp_torad of 2**1 =>  22224156/sec,       162 cycles, 0.0000 seconds
mp_todec of 2**1 =>   1492667/sec,      2412 cycles, 0.0000 seconds
mp_torad of 13**1 =>  15385954/sec,       234 cycles, 0.0000 seconds
mp_todec of 13**1 =>   1503890/sec,      2394 cycles, 0.0000 seconds

mp_torad of 2**2 =>  22224156/sec,       162 cycles, 0.0000 seconds
mp_todec of 2**2 =>   1503890/sec,      2394 cycles, 0.0000 seconds
mp_torad of 13**2 =>  11765729/sec,       306 cycles, 0.0000 seconds
mp_todec of 13**2 =>   1459981/sec,      2466 cycles, 0.0000 seconds

mp_torad of 2**4 =>  14286957/sec,       252 cycles, 0.0000 seconds
mp_todec of 2**4 =>   1459981/sec,      2466 cycles, 0.0000 seconds
mp_torad of 13**4 =>   7143478/sec,       504 cycles, 0.0000 seconds
mp_todec of 13**4 =>   1273996/sec,      2826 cycles, 0.0000 seconds

mp_torad of 2**8 =>  11112078/sec,       324 cycles, 0.0000 seconds
mp_todec of 2**8 =>   1438974/sec,      2502 cycles, 0.0000 seconds
mp_torad of 13**8 =>   4348204/sec,       828 cycles, 0.0000 seconds
mp_todec of 13**8 =>    639033/sec,      5634 cycles, 0.0000 seconds

mp_torad of 2**16 =>   7143478/sec,       504 cycles, 0.0000 seconds
mp_todec of 2**16 =>   1242344/sec,      2898 cycles, 0.0000 seconds
mp_torad of 13**16 =>   2325783/sec,      1548 cycles, 0.0000 seconds
mp_todec of 13**16 =>    381712/sec,      9432 cycles, 0.0000 seconds

mp_torad of 2**32 =>   3704026/sec,       972 cycles, 0.0000 seconds
mp_todec of 2**32 =>    617337/sec,      5832 cycles, 0.0000 seconds
mp_torad of 13**32 =>   1000087/sec,      3600 cycles, 0.0000 seconds
mp_todec of 13**32 =>    216469/sec,     16632 cycles, 0.0000 seconds

mp_torad of 2**64 =>   2040993/sec,      1764 cycles, 0.0000 seconds
mp_todec of 2**64 =>    347856/sec,     10350 cycles, 0.0000 seconds
mp_torad of 13**64 =>    376680/sec,      9558 cycles, 0.0000 seconds
mp_todec of 13**64 =>    115952/sec,     31050 cycles, 0.0000 seconds

mp_torad of 2**128 =>    869640/sec,      4140 cycles, 0.0000 seconds
mp_todec of 2**128 =>    197255/sec,     18252 cycles, 0.0000 seconds
mp_torad of 13**128 =>    122484/sec,     29394 cycles, 0.0000 seconds
mp_todec of 13**128 =>     59778/sec,     60228 cycles, 0.0000 seconds

mp_torad of 2**256 =>    336729/sec,     10692 cycles, 0.0000 seconds
mp_todec of 2**256 =>    103851/sec,     34668 cycles, 0.0000 seconds
mp_torad of 13**256 =>     35017/sec,    102816 cycles, 0.0000 seconds
mp_todec of 13**256 =>     29042/sec,    123966 cycles, 0.0000 seconds

mp_torad of 2**512 =>    107305/sec,     33552 cycles, 0.0000 seconds
mp_todec of 2**512 =>     53494/sec,     67302 cycles, 0.0000 seconds
mp_torad of 13**512 =>      9245/sec,    389430 cycles, 0.0001 seconds
mp_todec of 13**512 =>     14733/sec,    244368 cycles, 0.0001 seconds

mp_torad of 2**1024 =>     30425/sec,    118332 cycles, 0.0000 seconds
mp_todec of 2**1024 =>     52900/sec,     68058 cycles, 0.0000 seconds
mp_torad of 13**1024 =>      4827/sec,    745865 cycles, 0.0002 seconds
mp_todec of 13**1024 =>     13844/sec,    260046 cycles, 0.0001 seconds

mp_torad of 2**2048 =>     15603/sec,    230742 cycles, 0.0001 seconds
mp_todec of 2**2048 =>     26176/sec,    137538 cycles, 0.0000 seconds
mp_torad of 13**2048 =>      1269/sec,   2835144 cycles, 0.0008 seconds
mp_todec of 13**2048 =>      6411/sec,    561582 cycles, 0.0002 seconds

mp_torad of 2**4096 =>      4148/sec,    867797 cycles, 0.0002 seconds
mp_todec of 2**4096 =>     12749/sec,    282384 cycles, 0.0001 seconds
mp_torad of 13**4096 =>       323/sec,  11136150 cycles, 0.0031 seconds
mp_todec of 13**4096 =>      2852/sec,   1262358 cycles, 0.0004 seconds

mp_torad of 2**8192 =>      1081/sec,   3328344 cycles, 0.0009 seconds
mp_todec of 2**8192 =>      5991/sec,    600948 cycles, 0.0002 seconds
mp_torad of 13**8192 =>        81/sec,  44357363 cycles, 0.0123 seconds
mp_todec of 13**8192 =>      1198/sec,   3004920 cycles, 0.0008 seconds

mp_torad of 2**16384 =>       274/sec,  13116996 cycles, 0.0036 seconds
mp_todec of 2**16384 =>      2677/sec,   1344762 cycles, 0.0004 seconds
mp_torad of 13**16384 =>        20/sec, 176360310 cycles, 0.0490 seconds
mp_todec of 13**16384 =>       474/sec,   7579854 cycles, 0.0021 seconds

mp_torad of 2**32768 =>        69/sec,  51832746 cycles, 0.0144 seconds
mp_todec of 2**32768 =>      1146/sec,   3139524 cycles, 0.0009 seconds
mp_torad of 13**32768 =>         5/sec, 702303642 cycles, 0.1951 seconds
mp_todec of 13**32768 =>       176/sec,  20395908 cycles, 0.0057 seconds

mp_torad of 2**65536 =>        17/sec, 205633044 cycles, 0.0571 seconds
mp_todec of 2**65536 =>       456/sec,   7885224 cycles, 0.0022 seconds
mp_torad of 13**65536 =>         1/sec, 2803178970 cycles, 0.7786 seconds
mp_todec of 13**65536 =>        57/sec,  62507790 cycles, 0.0174 seconds

mp_torad of 2**131072 =>         4/sec, 820253700 cycles, 0.2278 seconds
mp_todec of 2**131072 =>       165/sec,  21787452 cycles, 0.0061 seconds
mp_torad of 13**131072 =>         0/sec, 11200695156 cycles, 3.1110 seconds
mp_todec of 13**131072 =>        17/sec, 200245194 cycles, 0.0556 seconds

mp_torad of 2**262144 =>         1/sec, 3273670044 cycles, 0.9093 seconds
mp_todec of 2**262144 =>        53/sec,  67087368 cycles, 0.0186 seconds
mp_torad of 13**262144 =>         0/sec, 44720842806 cycles, 12.4214 seconds
mp_todec of 13**262144 =>         5/sec, 661838760 cycles, 0.1838 seconds

mp_torad of 2**524288 =>         0/sec, 13101782489 cycles, 3.6391 seconds
mp_todec of 2**524288 =>        16/sec, 217065492 cycles, 0.0603 seconds
mp_torad of 13**524288 =>         0/sec, 177629371344 cycles, 49.3372 seconds
mp_todec of 13**524288 =>         1/sec, 2334986874 cycles, 0.6486 seconds
```