### PR TITLE
fix mp_to_radix

### DIFF
--- a/bn_mp_to_radix.c
+++ b/bn_mp_to_radix.c
@@ -66,8 +66,6 @@ mp_err mp_to_radix(const mp_int *a, char *str, size_t maxlen, int radix)
    /* append a NULL so the string is properly terminated */
    *str = '\0';
 
-   err = MP_OKAY;
-
 LBL_ERR:
    mp_clear(&t);
    return err;


### PR DESCRIPTION
remove an assignment which could overwrite the one with MP_VAL

caused by a conflict between 2 recent commits
 - refactor with goto
 - return error if output-buffer is too small