### PR TITLE
added printing of valgrind log to travis.yml in case of error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ dist: xenial
 # Files do not exist in case of success
 after_failure:
   - cat test_*.log
+  - cat valgrind_test.log
   - cat gcc_errors_*.log
 
 # In case of a Travis error a success might get signaled


### PR DESCRIPTION
Errors in valgrind do not seem to get printed (at least not in the test-vs-mtest case).
Decided to add a line in travis for printing `valgrind_test.log` instead of just changing the name to `test_valgrind.log` for legibility reasons.