### PR TITLE
Add message that MP-8BIT is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,11 +95,9 @@ matrix:
     - env: COMPILE_DEBUG=1 BUILDOPTIONS='--with-cc=gcc-5 --with-m64 --cflags=-DLTM_NOTHING --cflags=-DSC_RSA_1_WITH_TESTS --with-travis-valgrind'
 
     # Test "autotuning", the automatic evaluation and setting of the Toom-Cook cut-offs.
-    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_8BIT  --with-travis-valgrind --make-option=tune'
     #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_16BIT --with-travis-valgrind --make-option=tune'
     #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_32BIT --with-travis-valgrind --make-option=tune'
     #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --with-travis-valgrind --make-option=tune'
-    #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_8BIT  --with-travis-valgrind --make-option=tune'
     #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_16BIT --with-travis-valgrind --make-option=tune'
     #- env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-travis-valgrind --make-option=tune'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --with-travis-valgrind --make-option=tune'
@@ -161,12 +159,10 @@ matrix:
     # GCC for the x86-64 architecture with restricted limb sizes
     # formerly started with the option "--with-low-mp" to testme.sh
     # but testing all three in one run took to long and timed out.
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_8BIT  --with-travis-valgrind'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_16BIT --with-travis-valgrind'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_32BIT --with-travis-valgrind'
 
     # clang for the x86-64 architecture with restricted limb sizes
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_8BIT  --with-travis-valgrind'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_16BIT --with-travis-valgrind'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-travis-valgrind'
 

--- a/tommath.h
+++ b/tommath.h
@@ -17,6 +17,14 @@
 #  include <stdio.h>
 #endif
 
+#ifdef MP_8BIT
+#  ifdef _MSC_VER
+#    pragma message("8-bit (MP_8BIT) support is deprecated and will be dropped completely in the next version.")
+#  else
+#    warning "8-bit (MP_8BIT) support is deprecated and will be dropped completely in the next version."
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
As suggested by @sjaeckel in #349

Maybe an "issue", too (mainly for Google) and a note in the Wiki?