### PR TITLE
Minimal mp_radix_size_overestimate, very large error

### DIFF
--- a/bn_mp_radix_size_overestimate.c
+++ b/bn_mp_radix_size_overestimate.c
@@ -1,0 +1,68 @@
+#include "tommath_private.h"
+#ifdef BN_MP_RADIX_SIZE_OVERESTIMATE_C
+/* LibTomMath, multiple-precision integer library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+
+
+
+/*
+   Table of {0, log_2([1..64])} times 2^p where p is the scale
+   factor defined in LTM_RADIX_SIZE_SCALE.
+ */
+/* *INDENT-OFF* */
+#define LTM_RADIX_SIZE_SCALE 13
+static const uint16_t logbases[65] = {
+       0u,     0u,  8192u, 12984u, 16384u,
+   19021u, 21176u, 22997u, 24576u, 25968u,
+   27213u, 28339u, 29368u, 30314u, 31189u,
+   32005u, 32768u, 33484u, 34160u, 34799u,
+   35405u, 35981u, 36531u, 37057u, 37560u,
+   38042u, 38506u, 38952u, 39381u, 39796u,
+   40197u, 40584u, 40960u, 41323u, 41676u,
+   42019u, 42352u, 42675u, 42991u, 43298u,
+   43597u, 43889u, 44173u, 44451u, 44723u,
+   44989u, 45249u, 45503u, 45752u, 45995u,
+   46234u, 46468u, 46698u, 46923u, 47144u,
+   47360u, 47573u, 47783u, 47988u, 48190u,
+   48389u, 48584u, 48776u, 48965u, 49152u
+};
+/* *INDENT-ON* */
+mp_err mp_radix_size_overestimate(const mp_int *a, const int radix, int *size)
+{
+   mp_int bi_bit_count, bi_k;
+   int bit_count;
+   mp_err err = MP_OKAY;
+
+   *size = 0;
+
+   if ((radix < 2) || (radix > 64)) {
+      return MP_VAL;
+   }
+
+   bit_count = mp_count_bits(a) + 1;
+
+   if (bit_count == 0) {
+      *size = 2;
+      return MP_OKAY;
+   }
+
+   if ((err = mp_init_multi(&bi_bit_count, &bi_k, NULL)) != MP_OKAY) {
+      return err;
+   }
+
+   mp_set_l(&bi_bit_count, bit_count);
+   mp_set_u32(&bi_k, logbases[radix]);
+   if ((err = mp_mul_2d(&bi_bit_count, LTM_RADIX_SIZE_SCALE, &bi_bit_count)) != MP_OKAY)  goto LTM_ERR;
+   if ((err = mp_div(&bi_bit_count, &bi_k, &bi_bit_count, NULL)) != MP_OKAY)              goto LTM_ERR;
+
+   *size = (int)mp_get_l(&bi_bit_count) + 4;
+#if ( (defined MP_8BIT) && (INT_MAX > 0xFFFF))
+   *size += 3;
+#endif
+
+LTM_ERR:
+   mp_clear_multi(&bi_bit_count, &bi_k, NULL);
+   return err;
+}
+
+#endif

--- a/demo/test.c
+++ b/demo/test.c
@@ -2271,6 +2271,7 @@ LBL_ERR:
    return EXIT_FAILURE;
 }
 
+
 static int test_mp_radix_size(void)
 {
    mp_err err;
@@ -2326,8 +2327,62 @@ LBL_ERR:
    return EXIT_FAILURE;
 }
 
+static int test_mp_radix_size_overestimate(void)
+{
 
+   mp_err err;
+   mp_int a;
+   int radix, size;
+/* *INDENT-OFF* */
+   int results[65] = {
+       0, 0, 1627, 1027, 814, 702, 630, 581, 543,
+       514, 491, 471, 455, 441, 428, 418, 408, 399,
+       391, 384, 378, 372, 366, 361, 356, 352, 347,
+       343, 340, 336, 333, 330, 327, 324, 321, 318,
+       316, 314, 311, 309, 307, 305, 303, 301, 299,
+       298, 296, 294, 293, 291, 290, 288, 287, 285,
+       284, 283, 281, 280, 279, 278, 277, 276, 275,
+       273, 272
+   };
+/* *INDENT-ON* */
 
+   mp_init(&a);
+
+   /* number to result in a different size for every base: 67^(4 * 67) */
+   mp_set(&a, 67);
+   if ((err = mp_expt_u32(&a, 268u, &a)) != MP_OKAY) {
+      goto LTM_ERR;
+   }
+
+   for (radix = 2; radix < 65; radix++) {
+      if ((err = mp_radix_size_overestimate(&a, radix, &size)) != MP_OKAY) {
+         goto LTM_ERR;
+      }
+      if (size < results[radix]) {
+         fprintf(stderr, "mp_radix_size_overestimate: result for base %d was %d instead of %d\n",
+                 radix, size, results[radix]);
+         goto LTM_ERR;
+      }
+      a.sign = MP_NEG;
+      if ((err = mp_radix_size_overestimate(&a, radix, &size)) != MP_OKAY) {
+         goto LTM_ERR;
+      }
+      if (size < results[radix]) {
+         fprintf(stderr, "mp_radix_size_overestimate: result for base %d was %d instead of %d\n",
+                 radix, size, results[radix]);
+         goto LTM_ERR;
+      }
+      a.sign = MP_ZPOS;
+   }
+
+   mp_clear(&a);
+   return EXIT_SUCCESS;
+LTM_ERR:
+   mp_clear(&a);
+   return EXIT_FAILURE;
+}
+
+>>>>>>> Minimal version of bn_mp_radix_size_overestimate
 static int test_mp_read_write_ubin(void)
 {
    mp_int a, b, c;
@@ -2493,6 +2548,7 @@ static int unit_tests(int argc, char **argv)
       T1(mp_reduce_2k, MP_REDUCE_2K),
       T1(mp_reduce_2k_l, MP_REDUCE_2K_L),
       T1(mp_radix_size, MP_RADIX_SIZE),
+      T1(mp_radix_size_overestimate, MP_RADIX_SIZE_OVERESTIMATE),
 #if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559)
       T1(mp_set_double, MP_SET_DOUBLE),
 #endif

--- a/demo/test.c
+++ b/demo/test.c
@@ -2332,17 +2332,18 @@ static int test_mp_radix_size_overestimate(void)
 
    mp_err err;
    mp_int a;
-   int radix, size;
+   int radix;
+   size_t size;
 /* *INDENT-OFF* */
-   int results[65] = {
-       0, 0, 1627, 1027, 814, 702, 630, 581, 543,
-       514, 491, 471, 455, 441, 428, 418, 408, 399,
-       391, 384, 378, 372, 366, 361, 356, 352, 347,
-       343, 340, 336, 333, 330, 327, 324, 321, 318,
-       316, 314, 311, 309, 307, 305, 303, 301, 299,
-       298, 296, 294, 293, 291, 290, 288, 287, 285,
-       284, 283, 281, 280, 279, 278, 277, 276, 275,
-       273, 272
+   size_t results[65] = {
+       0u, 0u, 1627u, 1027u, 814u, 702u, 630u, 581u, 543u,
+       514u, 491u, 471u, 455u, 441u, 428u, 418u, 408u, 399u,
+       391u, 384u, 378u, 372u, 366u, 361u, 356u, 352u, 347u,
+       343u, 340u, 336u, 333u, 330u, 327u, 324u, 321u, 318u,
+       316u, 314u, 311u, 309u, 307u, 305u, 303u, 301u, 299u,
+       298u, 296u, 294u, 293u, 291u, 290u, 288u, 287u, 285u,
+       284u, 283u, 281u, 280u, 279u, 278u, 277u, 276u, 275u,
+       273u, 272u
    };
 /* *INDENT-ON* */
 
@@ -2359,7 +2360,7 @@ static int test_mp_radix_size_overestimate(void)
          goto LTM_ERR;
       }
       if (size < results[radix]) {
-         fprintf(stderr, "mp_radix_size_overestimate: result for base %d was %d instead of %d\n",
+         fprintf(stderr, "mp_radix_size_overestimate: result for base %d was %zu instead of %zu\n",
                  radix, size, results[radix]);
          goto LTM_ERR;
       }
@@ -2368,7 +2369,7 @@ static int test_mp_radix_size_overestimate(void)
          goto LTM_ERR;
       }
       if (size < results[radix]) {
-         fprintf(stderr, "mp_radix_size_overestimate: result for base %d was %d instead of %d\n",
+         fprintf(stderr, "mp_radix_size_overestimate: result for base %d was %zu instead of %zu\n",
                  radix, size, results[radix]);
          goto LTM_ERR;
       }

--- a/demo/test.c
+++ b/demo/test.c
@@ -2382,7 +2382,7 @@ LTM_ERR:
    return EXIT_FAILURE;
 }
 
->>>>>>> Minimal version of bn_mp_radix_size_overestimate
+
 static int test_mp_read_write_ubin(void)
 {
    mp_int a, b, c;

--- a/libtommath_VS2008.vcproj
+++ b/libtommath_VS2008.vcproj
@@ -313,6 +313,10 @@
 	</References>
 	<Files>
 		<File
+			RelativePath="bn_mp_radix_size_overestimate.c"
+			>
+		</File>
+		<File
 			RelativePath="mp_2expt.c"
 			>
 		</File>

--- a/libtommath_VS2008.vcproj
+++ b/libtommath_VS2008.vcproj
@@ -313,10 +313,6 @@
 	</References>
 	<Files>
 		<File
-			RelativePath="bn_mp_radix_size_overestimate.c"
-			>
-		</File>
-		<File
 			RelativePath="mp_2expt.c"
 			>
 		</File>
@@ -686,6 +682,10 @@
 		</File>
 		<File
 			RelativePath="mp_radix_size.c"
+			>
+		</File>
+		<File
+			RelativePath="mp_radix_size_overestimate.c"
 			>
 		</File>
 		<File

--- a/makefile
+++ b/makefile
@@ -26,24 +26,24 @@ endif
 LCOV_ARGS=--directory .
 
 #START_INS
-OBJECTS=mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o mp_clamp.o mp_clear.o mp_clear_multi.o \
-mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o mp_copy.o mp_count_bits.o mp_cutoffs.o \
-mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o mp_dr_is_modulus.o mp_dr_reduce.o \
-mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o mp_exteuclid.o mp_fread.o \
-mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o \
-mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o mp_grow.o mp_incr.o \
-mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o mp_init_multi.o mp_init_set.o \
-mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o mp_invmod.o mp_is_square.o \
-mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o mp_mod_2d.o mp_mod_d.o \
-mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o mp_mul.o mp_mul_2.o \
-mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
-mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
-mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_prime_tab.o \
-mp_radix_size.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o mp_reduce_2k_l.o \
-mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o mp_reduce_setup.o \
-mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o mp_set_l.o \
-mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o mp_sqr.o \
-mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
+OBJECTS=bn_mp_radix_size_overestimate.o mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o \
+mp_clamp.o mp_clear.o mp_clear_multi.o mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o \
+mp_copy.o mp_count_bits.o mp_cutoffs.o mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o \
+mp_dr_is_modulus.o mp_dr_reduce.o mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o \
+mp_exteuclid.o mp_fread.o mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o \
+mp_get_i64.o mp_get_l.o mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o \
+mp_grow.o mp_incr.o mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o \
+mp_init_multi.o mp_init_set.o mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o \
+mp_invmod.o mp_is_square.o mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o \
+mp_mod_2d.o mp_mod_d.o mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o \
+mp_mul.o mp_mul_2.o mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o \
+mp_prime_fermat.o mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o \
+mp_prime_next_prime.o mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o \
+mp_prime_tab.o mp_radix_size.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
+mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
+mp_reduce_setup.o mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
+mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o \
+mp_sqr.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
 mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_balance_mul.o s_mp_exptmod.o \
 s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod_fast.o s_mp_invmod_slow.o s_mp_karatsuba_mul.o \
 s_mp_karatsuba_sqr.o s_mp_log.o s_mp_log_d.o s_mp_montgomery_reduce_fast.o s_mp_mul_digs.o \

--- a/makefile
+++ b/makefile
@@ -26,30 +26,30 @@ endif
 LCOV_ARGS=--directory .
 
 #START_INS
-OBJECTS=bn_mp_radix_size_overestimate.o mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o \
-mp_clamp.o mp_clear.o mp_clear_multi.o mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o \
-mp_copy.o mp_count_bits.o mp_cutoffs.o mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o \
-mp_dr_is_modulus.o mp_dr_reduce.o mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o \
-mp_exteuclid.o mp_fread.o mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o \
-mp_get_i64.o mp_get_l.o mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o \
-mp_grow.o mp_incr.o mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o \
-mp_init_multi.o mp_init_set.o mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o \
-mp_invmod.o mp_is_square.o mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o \
-mp_mod_2d.o mp_mod_d.o mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o \
-mp_mul.o mp_mul_2.o mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o \
-mp_prime_fermat.o mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o \
-mp_prime_next_prime.o mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o \
-mp_prime_tab.o mp_radix_size.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
-mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
-mp_reduce_setup.o mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
-mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o \
-mp_sqr.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
-mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_balance_mul.o s_mp_exptmod.o \
-s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod_fast.o s_mp_invmod_slow.o s_mp_karatsuba_mul.o \
-s_mp_karatsuba_sqr.o s_mp_log.o s_mp_log_d.o s_mp_montgomery_reduce_fast.o s_mp_mul_digs.o \
-s_mp_mul_digs_fast.o s_mp_mul_high_digs.o s_mp_mul_high_digs_fast.o s_mp_prime_is_divisible.o \
-s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_reverse.o s_mp_sqr.o s_mp_sqr_fast.o s_mp_sub.o \
-s_mp_toom_mul.o s_mp_toom_sqr.o
+OBJECTS=mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o mp_clamp.o mp_clear.o mp_clear_multi.o \
+mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o mp_copy.o mp_count_bits.o mp_cutoffs.o \
+mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o mp_dr_is_modulus.o mp_dr_reduce.o \
+mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o mp_exteuclid.o mp_fread.o \
+mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o \
+mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o mp_grow.o mp_incr.o \
+mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o mp_init_multi.o mp_init_set.o \
+mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o mp_invmod.o mp_is_square.o \
+mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o mp_mod_2d.o mp_mod_d.o \
+mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o mp_mul.o mp_mul_2.o \
+mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
+mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
+mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_prime_tab.o \
+mp_radix_size.o mp_radix_size_overestimate.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o \
+mp_reduce_2k.o mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o \
+mp_reduce_is_2k_l.o mp_reduce_setup.o mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o \
+mp_set_i32.o mp_set_i64.o mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o \
+mp_shrink.o mp_signed_rsh.o mp_sqr.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o \
+mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o \
+s_mp_balance_mul.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod_fast.o \
+s_mp_invmod_slow.o s_mp_karatsuba_mul.o s_mp_karatsuba_sqr.o s_mp_log.o s_mp_log_d.o \
+s_mp_montgomery_reduce_fast.o s_mp_mul_digs.o s_mp_mul_digs_fast.o s_mp_mul_high_digs.o \
+s_mp_mul_high_digs_fast.o s_mp_prime_is_divisible.o s_mp_rand_jenkins.o s_mp_rand_platform.o \
+s_mp_reverse.o s_mp_sqr.o s_mp_sqr_fast.o s_mp_sub.o s_mp_toom_mul.o s_mp_toom_sqr.o
 
 #END_INS
 

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -29,24 +29,24 @@ LIBMAIN_I =libtommath.dll.a
 LIBMAIN_D =libtommath.dll
 
 #List of objects to compile (all goes to libtommath.a)
-OBJECTS=mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o mp_clamp.o mp_clear.o mp_clear_multi.o \
-mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o mp_copy.o mp_count_bits.o mp_cutoffs.o \
-mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o mp_dr_is_modulus.o mp_dr_reduce.o \
-mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o mp_exteuclid.o mp_fread.o \
-mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o \
-mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o mp_grow.o mp_incr.o \
-mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o mp_init_multi.o mp_init_set.o \
-mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o mp_invmod.o mp_is_square.o \
-mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o mp_mod_2d.o mp_mod_d.o \
-mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o mp_mul.o mp_mul_2.o \
-mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
-mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
-mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_prime_tab.o \
-mp_radix_size.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o mp_reduce_2k_l.o \
-mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o mp_reduce_setup.o \
-mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o mp_set_l.o \
-mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o mp_sqr.o \
-mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
+OBJECTS=bn_mp_radix_size_overestimate.o mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o \
+mp_clamp.o mp_clear.o mp_clear_multi.o mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o \
+mp_copy.o mp_count_bits.o mp_cutoffs.o mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o \
+mp_dr_is_modulus.o mp_dr_reduce.o mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o \
+mp_exteuclid.o mp_fread.o mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o \
+mp_get_i64.o mp_get_l.o mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o \
+mp_grow.o mp_incr.o mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o \
+mp_init_multi.o mp_init_set.o mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o \
+mp_invmod.o mp_is_square.o mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o \
+mp_mod_2d.o mp_mod_d.o mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o \
+mp_mul.o mp_mul_2.o mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o \
+mp_prime_fermat.o mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o \
+mp_prime_next_prime.o mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o \
+mp_prime_tab.o mp_radix_size.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
+mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
+mp_reduce_setup.o mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
+mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o \
+mp_sqr.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
 mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_balance_mul.o s_mp_exptmod.o \
 s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod_fast.o s_mp_invmod_slow.o s_mp_karatsuba_mul.o \
 s_mp_karatsuba_sqr.o s_mp_log.o s_mp_log_d.o s_mp_montgomery_reduce_fast.o s_mp_mul_digs.o \

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -29,30 +29,30 @@ LIBMAIN_I =libtommath.dll.a
 LIBMAIN_D =libtommath.dll
 
 #List of objects to compile (all goes to libtommath.a)
-OBJECTS=bn_mp_radix_size_overestimate.o mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o \
-mp_clamp.o mp_clear.o mp_clear_multi.o mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o \
-mp_copy.o mp_count_bits.o mp_cutoffs.o mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o \
-mp_dr_is_modulus.o mp_dr_reduce.o mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o \
-mp_exteuclid.o mp_fread.o mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o \
-mp_get_i64.o mp_get_l.o mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o \
-mp_grow.o mp_incr.o mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o \
-mp_init_multi.o mp_init_set.o mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o \
-mp_invmod.o mp_is_square.o mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o \
-mp_mod_2d.o mp_mod_d.o mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o \
-mp_mul.o mp_mul_2.o mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o \
-mp_prime_fermat.o mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o \
-mp_prime_next_prime.o mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o \
-mp_prime_tab.o mp_radix_size.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
-mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
-mp_reduce_setup.o mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
-mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o \
-mp_sqr.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
-mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_balance_mul.o s_mp_exptmod.o \
-s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod_fast.o s_mp_invmod_slow.o s_mp_karatsuba_mul.o \
-s_mp_karatsuba_sqr.o s_mp_log.o s_mp_log_d.o s_mp_montgomery_reduce_fast.o s_mp_mul_digs.o \
-s_mp_mul_digs_fast.o s_mp_mul_high_digs.o s_mp_mul_high_digs_fast.o s_mp_prime_is_divisible.o \
-s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_reverse.o s_mp_sqr.o s_mp_sqr_fast.o s_mp_sub.o \
-s_mp_toom_mul.o s_mp_toom_sqr.o
+OBJECTS=mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o mp_clamp.o mp_clear.o mp_clear_multi.o \
+mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o mp_copy.o mp_count_bits.o mp_cutoffs.o \
+mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o mp_dr_is_modulus.o mp_dr_reduce.o \
+mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o mp_exteuclid.o mp_fread.o \
+mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o \
+mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o mp_grow.o mp_incr.o \
+mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o mp_init_multi.o mp_init_set.o \
+mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o mp_invmod.o mp_is_square.o \
+mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o mp_mod_2d.o mp_mod_d.o \
+mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o mp_mul.o mp_mul_2.o \
+mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
+mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
+mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_prime_tab.o \
+mp_radix_size.o mp_radix_size_overestimate.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o \
+mp_reduce_2k.o mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o \
+mp_reduce_is_2k_l.o mp_reduce_setup.o mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o \
+mp_set_i32.o mp_set_i64.o mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o \
+mp_shrink.o mp_signed_rsh.o mp_sqr.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o \
+mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o \
+s_mp_balance_mul.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod_fast.o \
+s_mp_invmod_slow.o s_mp_karatsuba_mul.o s_mp_karatsuba_sqr.o s_mp_log.o s_mp_log_d.o \
+s_mp_montgomery_reduce_fast.o s_mp_mul_digs.o s_mp_mul_digs_fast.o s_mp_mul_high_digs.o \
+s_mp_mul_high_digs_fast.o s_mp_prime_is_divisible.o s_mp_rand_jenkins.o s_mp_rand_platform.o \
+s_mp_reverse.o s_mp_sqr.o s_mp_sqr_fast.o s_mp_sub.o s_mp_toom_mul.o s_mp_toom_sqr.o
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h tommath_cutoffs.h $(HEADERS_PUB)

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -21,30 +21,30 @@ LTM_LDFLAGS = advapi32.lib
 LIBMAIN_S =tommath.lib
 
 #List of objects to compile (all goes to tommath.lib)
-OBJECTS=bn_mp_radix_size_overestimate.obj mp_2expt.obj mp_abs.obj mp_add.obj mp_add_d.obj mp_addmod.obj mp_and.obj \
-mp_clamp.obj mp_clear.obj mp_clear_multi.obj mp_cmp.obj mp_cmp_d.obj mp_cmp_mag.obj mp_cnt_lsb.obj mp_complement.obj \
-mp_copy.obj mp_count_bits.obj mp_cutoffs.obj mp_decr.obj mp_div.obj mp_div_2.obj mp_div_2d.obj mp_div_3.obj mp_div_d.obj \
-mp_dr_is_modulus.obj mp_dr_reduce.obj mp_dr_setup.obj mp_error_to_string.obj mp_exch.obj mp_expt_u32.obj mp_exptmod.obj \
-mp_exteuclid.obj mp_fread.obj mp_from_sbin.obj mp_from_ubin.obj mp_fwrite.obj mp_gcd.obj mp_get_double.obj mp_get_i32.obj \
-mp_get_i64.obj mp_get_l.obj mp_get_ll.obj mp_get_mag_u32.obj mp_get_mag_u64.obj mp_get_mag_ul.obj mp_get_mag_ull.obj \
-mp_grow.obj mp_incr.obj mp_init.obj mp_init_copy.obj mp_init_i32.obj mp_init_i64.obj mp_init_l.obj mp_init_ll.obj \
-mp_init_multi.obj mp_init_set.obj mp_init_size.obj mp_init_u32.obj mp_init_u64.obj mp_init_ul.obj mp_init_ull.obj \
-mp_invmod.obj mp_is_square.obj mp_iseven.obj mp_isodd.obj mp_kronecker.obj mp_lcm.obj mp_log_u32.obj mp_lshd.obj mp_mod.obj \
-mp_mod_2d.obj mp_mod_d.obj mp_montgomery_calc_normalization.obj mp_montgomery_reduce.obj mp_montgomery_setup.obj \
-mp_mul.obj mp_mul_2.obj mp_mul_2d.obj mp_mul_d.obj mp_mulmod.obj mp_neg.obj mp_or.obj mp_pack.obj mp_pack_count.obj \
-mp_prime_fermat.obj mp_prime_frobenius_underwood.obj mp_prime_is_prime.obj mp_prime_miller_rabin.obj \
-mp_prime_next_prime.obj mp_prime_rabin_miller_trials.obj mp_prime_rand.obj mp_prime_strong_lucas_selfridge.obj \
-mp_prime_tab.obj mp_radix_size.obj mp_radix_smap.obj mp_rand.obj mp_read_radix.obj mp_reduce.obj mp_reduce_2k.obj \
-mp_reduce_2k_l.obj mp_reduce_2k_setup.obj mp_reduce_2k_setup_l.obj mp_reduce_is_2k.obj mp_reduce_is_2k_l.obj \
-mp_reduce_setup.obj mp_root_u32.obj mp_rshd.obj mp_sbin_size.obj mp_set.obj mp_set_double.obj mp_set_i32.obj mp_set_i64.obj \
-mp_set_l.obj mp_set_ll.obj mp_set_u32.obj mp_set_u64.obj mp_set_ul.obj mp_set_ull.obj mp_shrink.obj mp_signed_rsh.obj \
-mp_sqr.obj mp_sqrmod.obj mp_sqrt.obj mp_sqrtmod_prime.obj mp_sub.obj mp_sub_d.obj mp_submod.obj mp_to_radix.obj mp_to_sbin.obj \
-mp_to_ubin.obj mp_ubin_size.obj mp_unpack.obj mp_xor.obj mp_zero.obj s_mp_add.obj s_mp_balance_mul.obj s_mp_exptmod.obj \
-s_mp_exptmod_fast.obj s_mp_get_bit.obj s_mp_invmod_fast.obj s_mp_invmod_slow.obj s_mp_karatsuba_mul.obj \
-s_mp_karatsuba_sqr.obj s_mp_log.obj s_mp_log_d.obj s_mp_montgomery_reduce_fast.obj s_mp_mul_digs.obj \
-s_mp_mul_digs_fast.obj s_mp_mul_high_digs.obj s_mp_mul_high_digs_fast.obj s_mp_prime_is_divisible.obj \
-s_mp_rand_jenkins.obj s_mp_rand_platform.obj s_mp_reverse.obj s_mp_sqr.obj s_mp_sqr_fast.obj s_mp_sub.obj \
-s_mp_toom_mul.obj s_mp_toom_sqr.obj
+OBJECTS=mp_2expt.obj mp_abs.obj mp_add.obj mp_add_d.obj mp_addmod.obj mp_and.obj mp_clamp.obj mp_clear.obj mp_clear_multi.obj \
+mp_cmp.obj mp_cmp_d.obj mp_cmp_mag.obj mp_cnt_lsb.obj mp_complement.obj mp_copy.obj mp_count_bits.obj mp_cutoffs.obj \
+mp_decr.obj mp_div.obj mp_div_2.obj mp_div_2d.obj mp_div_3.obj mp_div_d.obj mp_dr_is_modulus.obj mp_dr_reduce.obj \
+mp_dr_setup.obj mp_error_to_string.obj mp_exch.obj mp_expt_u32.obj mp_exptmod.obj mp_exteuclid.obj mp_fread.obj \
+mp_from_sbin.obj mp_from_ubin.obj mp_fwrite.obj mp_gcd.obj mp_get_double.obj mp_get_i32.obj mp_get_i64.obj mp_get_l.obj \
+mp_get_ll.obj mp_get_mag_u32.obj mp_get_mag_u64.obj mp_get_mag_ul.obj mp_get_mag_ull.obj mp_grow.obj mp_incr.obj \
+mp_init.obj mp_init_copy.obj mp_init_i32.obj mp_init_i64.obj mp_init_l.obj mp_init_ll.obj mp_init_multi.obj mp_init_set.obj \
+mp_init_size.obj mp_init_u32.obj mp_init_u64.obj mp_init_ul.obj mp_init_ull.obj mp_invmod.obj mp_is_square.obj \
+mp_iseven.obj mp_isodd.obj mp_kronecker.obj mp_lcm.obj mp_log_u32.obj mp_lshd.obj mp_mod.obj mp_mod_2d.obj mp_mod_d.obj \
+mp_montgomery_calc_normalization.obj mp_montgomery_reduce.obj mp_montgomery_setup.obj mp_mul.obj mp_mul_2.obj \
+mp_mul_2d.obj mp_mul_d.obj mp_mulmod.obj mp_neg.obj mp_or.obj mp_pack.obj mp_pack_count.obj mp_prime_fermat.obj \
+mp_prime_frobenius_underwood.obj mp_prime_is_prime.obj mp_prime_miller_rabin.obj mp_prime_next_prime.obj \
+mp_prime_rabin_miller_trials.obj mp_prime_rand.obj mp_prime_strong_lucas_selfridge.obj mp_prime_tab.obj \
+mp_radix_size.obj mp_radix_size_overestimate.obj mp_radix_smap.obj mp_rand.obj mp_read_radix.obj mp_reduce.obj \
+mp_reduce_2k.obj mp_reduce_2k_l.obj mp_reduce_2k_setup.obj mp_reduce_2k_setup_l.obj mp_reduce_is_2k.obj \
+mp_reduce_is_2k_l.obj mp_reduce_setup.obj mp_root_u32.obj mp_rshd.obj mp_sbin_size.obj mp_set.obj mp_set_double.obj \
+mp_set_i32.obj mp_set_i64.obj mp_set_l.obj mp_set_ll.obj mp_set_u32.obj mp_set_u64.obj mp_set_ul.obj mp_set_ull.obj \
+mp_shrink.obj mp_signed_rsh.obj mp_sqr.obj mp_sqrmod.obj mp_sqrt.obj mp_sqrtmod_prime.obj mp_sub.obj mp_sub_d.obj \
+mp_submod.obj mp_to_radix.obj mp_to_sbin.obj mp_to_ubin.obj mp_ubin_size.obj mp_unpack.obj mp_xor.obj mp_zero.obj s_mp_add.obj \
+s_mp_balance_mul.obj s_mp_exptmod.obj s_mp_exptmod_fast.obj s_mp_get_bit.obj s_mp_invmod_fast.obj \
+s_mp_invmod_slow.obj s_mp_karatsuba_mul.obj s_mp_karatsuba_sqr.obj s_mp_log.obj s_mp_log_d.obj \
+s_mp_montgomery_reduce_fast.obj s_mp_mul_digs.obj s_mp_mul_digs_fast.obj s_mp_mul_high_digs.obj \
+s_mp_mul_high_digs_fast.obj s_mp_prime_is_divisible.obj s_mp_rand_jenkins.obj s_mp_rand_platform.obj \
+s_mp_reverse.obj s_mp_sqr.obj s_mp_sqr_fast.obj s_mp_sub.obj s_mp_toom_mul.obj s_mp_toom_sqr.obj
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h tommath_cutoffs.h $(HEADERS_PUB)

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -21,24 +21,24 @@ LTM_LDFLAGS = advapi32.lib
 LIBMAIN_S =tommath.lib
 
 #List of objects to compile (all goes to tommath.lib)
-OBJECTS=mp_2expt.obj mp_abs.obj mp_add.obj mp_add_d.obj mp_addmod.obj mp_and.obj mp_clamp.obj mp_clear.obj mp_clear_multi.obj \
-mp_cmp.obj mp_cmp_d.obj mp_cmp_mag.obj mp_cnt_lsb.obj mp_complement.obj mp_copy.obj mp_count_bits.obj mp_cutoffs.obj \
-mp_decr.obj mp_div.obj mp_div_2.obj mp_div_2d.obj mp_div_3.obj mp_div_d.obj mp_dr_is_modulus.obj mp_dr_reduce.obj \
-mp_dr_setup.obj mp_error_to_string.obj mp_exch.obj mp_expt_u32.obj mp_exptmod.obj mp_exteuclid.obj mp_fread.obj \
-mp_from_sbin.obj mp_from_ubin.obj mp_fwrite.obj mp_gcd.obj mp_get_double.obj mp_get_i32.obj mp_get_i64.obj mp_get_l.obj \
-mp_get_ll.obj mp_get_mag_u32.obj mp_get_mag_u64.obj mp_get_mag_ul.obj mp_get_mag_ull.obj mp_grow.obj mp_incr.obj \
-mp_init.obj mp_init_copy.obj mp_init_i32.obj mp_init_i64.obj mp_init_l.obj mp_init_ll.obj mp_init_multi.obj mp_init_set.obj \
-mp_init_size.obj mp_init_u32.obj mp_init_u64.obj mp_init_ul.obj mp_init_ull.obj mp_invmod.obj mp_is_square.obj \
-mp_iseven.obj mp_isodd.obj mp_kronecker.obj mp_lcm.obj mp_log_u32.obj mp_lshd.obj mp_mod.obj mp_mod_2d.obj mp_mod_d.obj \
-mp_montgomery_calc_normalization.obj mp_montgomery_reduce.obj mp_montgomery_setup.obj mp_mul.obj mp_mul_2.obj \
-mp_mul_2d.obj mp_mul_d.obj mp_mulmod.obj mp_neg.obj mp_or.obj mp_pack.obj mp_pack_count.obj mp_prime_fermat.obj \
-mp_prime_frobenius_underwood.obj mp_prime_is_prime.obj mp_prime_miller_rabin.obj mp_prime_next_prime.obj \
-mp_prime_rabin_miller_trials.obj mp_prime_rand.obj mp_prime_strong_lucas_selfridge.obj mp_prime_tab.obj \
-mp_radix_size.obj mp_radix_smap.obj mp_rand.obj mp_read_radix.obj mp_reduce.obj mp_reduce_2k.obj mp_reduce_2k_l.obj \
-mp_reduce_2k_setup.obj mp_reduce_2k_setup_l.obj mp_reduce_is_2k.obj mp_reduce_is_2k_l.obj mp_reduce_setup.obj \
-mp_root_u32.obj mp_rshd.obj mp_sbin_size.obj mp_set.obj mp_set_double.obj mp_set_i32.obj mp_set_i64.obj mp_set_l.obj \
-mp_set_ll.obj mp_set_u32.obj mp_set_u64.obj mp_set_ul.obj mp_set_ull.obj mp_shrink.obj mp_signed_rsh.obj mp_sqr.obj \
-mp_sqrmod.obj mp_sqrt.obj mp_sqrtmod_prime.obj mp_sub.obj mp_sub_d.obj mp_submod.obj mp_to_radix.obj mp_to_sbin.obj \
+OBJECTS=bn_mp_radix_size_overestimate.obj mp_2expt.obj mp_abs.obj mp_add.obj mp_add_d.obj mp_addmod.obj mp_and.obj \
+mp_clamp.obj mp_clear.obj mp_clear_multi.obj mp_cmp.obj mp_cmp_d.obj mp_cmp_mag.obj mp_cnt_lsb.obj mp_complement.obj \
+mp_copy.obj mp_count_bits.obj mp_cutoffs.obj mp_decr.obj mp_div.obj mp_div_2.obj mp_div_2d.obj mp_div_3.obj mp_div_d.obj \
+mp_dr_is_modulus.obj mp_dr_reduce.obj mp_dr_setup.obj mp_error_to_string.obj mp_exch.obj mp_expt_u32.obj mp_exptmod.obj \
+mp_exteuclid.obj mp_fread.obj mp_from_sbin.obj mp_from_ubin.obj mp_fwrite.obj mp_gcd.obj mp_get_double.obj mp_get_i32.obj \
+mp_get_i64.obj mp_get_l.obj mp_get_ll.obj mp_get_mag_u32.obj mp_get_mag_u64.obj mp_get_mag_ul.obj mp_get_mag_ull.obj \
+mp_grow.obj mp_incr.obj mp_init.obj mp_init_copy.obj mp_init_i32.obj mp_init_i64.obj mp_init_l.obj mp_init_ll.obj \
+mp_init_multi.obj mp_init_set.obj mp_init_size.obj mp_init_u32.obj mp_init_u64.obj mp_init_ul.obj mp_init_ull.obj \
+mp_invmod.obj mp_is_square.obj mp_iseven.obj mp_isodd.obj mp_kronecker.obj mp_lcm.obj mp_log_u32.obj mp_lshd.obj mp_mod.obj \
+mp_mod_2d.obj mp_mod_d.obj mp_montgomery_calc_normalization.obj mp_montgomery_reduce.obj mp_montgomery_setup.obj \
+mp_mul.obj mp_mul_2.obj mp_mul_2d.obj mp_mul_d.obj mp_mulmod.obj mp_neg.obj mp_or.obj mp_pack.obj mp_pack_count.obj \
+mp_prime_fermat.obj mp_prime_frobenius_underwood.obj mp_prime_is_prime.obj mp_prime_miller_rabin.obj \
+mp_prime_next_prime.obj mp_prime_rabin_miller_trials.obj mp_prime_rand.obj mp_prime_strong_lucas_selfridge.obj \
+mp_prime_tab.obj mp_radix_size.obj mp_radix_smap.obj mp_rand.obj mp_read_radix.obj mp_reduce.obj mp_reduce_2k.obj \
+mp_reduce_2k_l.obj mp_reduce_2k_setup.obj mp_reduce_2k_setup_l.obj mp_reduce_is_2k.obj mp_reduce_is_2k_l.obj \
+mp_reduce_setup.obj mp_root_u32.obj mp_rshd.obj mp_sbin_size.obj mp_set.obj mp_set_double.obj mp_set_i32.obj mp_set_i64.obj \
+mp_set_l.obj mp_set_ll.obj mp_set_u32.obj mp_set_u64.obj mp_set_ul.obj mp_set_ull.obj mp_shrink.obj mp_signed_rsh.obj \
+mp_sqr.obj mp_sqrmod.obj mp_sqrt.obj mp_sqrtmod_prime.obj mp_sub.obj mp_sub_d.obj mp_submod.obj mp_to_radix.obj mp_to_sbin.obj \
 mp_to_ubin.obj mp_ubin_size.obj mp_unpack.obj mp_xor.obj mp_zero.obj s_mp_add.obj s_mp_balance_mul.obj s_mp_exptmod.obj \
 s_mp_exptmod_fast.obj s_mp_get_bit.obj s_mp_invmod_fast.obj s_mp_invmod_slow.obj s_mp_karatsuba_mul.obj \
 s_mp_karatsuba_sqr.obj s_mp_log.obj s_mp_log_d.obj s_mp_montgomery_reduce_fast.obj s_mp_mul_digs.obj \

--- a/makefile.shared
+++ b/makefile.shared
@@ -24,30 +24,30 @@ LCOV_ARGS=--directory .libs --directory .
 
 #START_INS
 
-OBJECTS=bn_mp_radix_size_overestimate.o mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o \
-mp_clamp.o mp_clear.o mp_clear_multi.o mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o \
-mp_copy.o mp_count_bits.o mp_cutoffs.o mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o \
-mp_dr_is_modulus.o mp_dr_reduce.o mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o \
-mp_exteuclid.o mp_fread.o mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o \
-mp_get_i64.o mp_get_l.o mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o \
-mp_grow.o mp_incr.o mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o \
-mp_init_multi.o mp_init_set.o mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o \
-mp_invmod.o mp_is_square.o mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o \
-mp_mod_2d.o mp_mod_d.o mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o \
-mp_mul.o mp_mul_2.o mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o \
-mp_prime_fermat.o mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o \
-mp_prime_next_prime.o mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o \
-mp_prime_tab.o mp_radix_size.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
-mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
-mp_reduce_setup.o mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
-mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o \
-mp_sqr.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
-mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_balance_mul.o s_mp_exptmod.o \
-s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod_fast.o s_mp_invmod_slow.o s_mp_karatsuba_mul.o \
-s_mp_karatsuba_sqr.o s_mp_log.o s_mp_log_d.o s_mp_montgomery_reduce_fast.o s_mp_mul_digs.o \
-s_mp_mul_digs_fast.o s_mp_mul_high_digs.o s_mp_mul_high_digs_fast.o s_mp_prime_is_divisible.o \
-s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_reverse.o s_mp_sqr.o s_mp_sqr_fast.o s_mp_sub.o \
-s_mp_toom_mul.o s_mp_toom_sqr.o
+OBJECTS=mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o mp_clamp.o mp_clear.o mp_clear_multi.o \
+mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o mp_copy.o mp_count_bits.o mp_cutoffs.o \
+mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o mp_dr_is_modulus.o mp_dr_reduce.o \
+mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o mp_exteuclid.o mp_fread.o \
+mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o \
+mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o mp_grow.o mp_incr.o \
+mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o mp_init_multi.o mp_init_set.o \
+mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o mp_invmod.o mp_is_square.o \
+mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o mp_mod_2d.o mp_mod_d.o \
+mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o mp_mul.o mp_mul_2.o \
+mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
+mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
+mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_prime_tab.o \
+mp_radix_size.o mp_radix_size_overestimate.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o \
+mp_reduce_2k.o mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o \
+mp_reduce_is_2k_l.o mp_reduce_setup.o mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o \
+mp_set_i32.o mp_set_i64.o mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o \
+mp_shrink.o mp_signed_rsh.o mp_sqr.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o \
+mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o \
+s_mp_balance_mul.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod_fast.o \
+s_mp_invmod_slow.o s_mp_karatsuba_mul.o s_mp_karatsuba_sqr.o s_mp_log.o s_mp_log_d.o \
+s_mp_montgomery_reduce_fast.o s_mp_mul_digs.o s_mp_mul_digs_fast.o s_mp_mul_high_digs.o \
+s_mp_mul_high_digs_fast.o s_mp_prime_is_divisible.o s_mp_rand_jenkins.o s_mp_rand_platform.o \
+s_mp_reverse.o s_mp_sqr.o s_mp_sqr_fast.o s_mp_sub.o s_mp_toom_mul.o s_mp_toom_sqr.o
 
 #END_INS
 

--- a/makefile.shared
+++ b/makefile.shared
@@ -23,24 +23,25 @@ LTLINK = $(LIBTOOL) --mode=link --tag=CC $(CC)
 LCOV_ARGS=--directory .libs --directory .
 
 #START_INS
-OBJECTS=mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o mp_clamp.o mp_clear.o mp_clear_multi.o \
-mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o mp_copy.o mp_count_bits.o mp_cutoffs.o \
-mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o mp_dr_is_modulus.o mp_dr_reduce.o \
-mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o mp_exteuclid.o mp_fread.o \
-mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o \
-mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o mp_grow.o mp_incr.o \
-mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o mp_init_multi.o mp_init_set.o \
-mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o mp_invmod.o mp_is_square.o \
-mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o mp_mod_2d.o mp_mod_d.o \
-mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o mp_mul.o mp_mul_2.o \
-mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
-mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
-mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_prime_tab.o \
-mp_radix_size.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o mp_reduce_2k_l.o \
-mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o mp_reduce_setup.o \
-mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o mp_set_l.o \
-mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o mp_sqr.o \
-mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
+
+OBJECTS=bn_mp_radix_size_overestimate.o mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o \
+mp_clamp.o mp_clear.o mp_clear_multi.o mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o \
+mp_copy.o mp_count_bits.o mp_cutoffs.o mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o \
+mp_dr_is_modulus.o mp_dr_reduce.o mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o \
+mp_exteuclid.o mp_fread.o mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o \
+mp_get_i64.o mp_get_l.o mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o \
+mp_grow.o mp_incr.o mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o \
+mp_init_multi.o mp_init_set.o mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o \
+mp_invmod.o mp_is_square.o mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o \
+mp_mod_2d.o mp_mod_d.o mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o \
+mp_mul.o mp_mul_2.o mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o \
+mp_prime_fermat.o mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o \
+mp_prime_next_prime.o mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o \
+mp_prime_tab.o mp_radix_size.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
+mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
+mp_reduce_setup.o mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
+mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o \
+mp_sqr.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
 mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_balance_mul.o s_mp_exptmod.o \
 s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod_fast.o s_mp_invmod_slow.o s_mp_karatsuba_mul.o \
 s_mp_karatsuba_sqr.o s_mp_log.o s_mp_log_d.o s_mp_montgomery_reduce_fast.o s_mp_mul_digs.o \

--- a/makefile.unix
+++ b/makefile.unix
@@ -30,30 +30,30 @@ LTM_LDFLAGS = $(LDFLAGS)
 #Library to be created (this makefile builds only static library)
 LIBMAIN_S = libtommath.a
 
-OBJECTS=bn_mp_radix_size_overestimate.o mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o \
-mp_clamp.o mp_clear.o mp_clear_multi.o mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o \
-mp_copy.o mp_count_bits.o mp_cutoffs.o mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o \
-mp_dr_is_modulus.o mp_dr_reduce.o mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o \
-mp_exteuclid.o mp_fread.o mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o \
-mp_get_i64.o mp_get_l.o mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o \
-mp_grow.o mp_incr.o mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o \
-mp_init_multi.o mp_init_set.o mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o \
-mp_invmod.o mp_is_square.o mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o \
-mp_mod_2d.o mp_mod_d.o mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o \
-mp_mul.o mp_mul_2.o mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o \
-mp_prime_fermat.o mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o \
-mp_prime_next_prime.o mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o \
-mp_prime_tab.o mp_radix_size.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
-mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
-mp_reduce_setup.o mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
-mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o \
-mp_sqr.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
-mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_balance_mul.o s_mp_exptmod.o \
-s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod_fast.o s_mp_invmod_slow.o s_mp_karatsuba_mul.o \
-s_mp_karatsuba_sqr.o s_mp_log.o s_mp_log_d.o s_mp_montgomery_reduce_fast.o s_mp_mul_digs.o \
-s_mp_mul_digs_fast.o s_mp_mul_high_digs.o s_mp_mul_high_digs_fast.o s_mp_prime_is_divisible.o \
-s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_reverse.o s_mp_sqr.o s_mp_sqr_fast.o s_mp_sub.o \
-s_mp_toom_mul.o s_mp_toom_sqr.o
+OBJECTS=mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o mp_clamp.o mp_clear.o mp_clear_multi.o \
+mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o mp_copy.o mp_count_bits.o mp_cutoffs.o \
+mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o mp_dr_is_modulus.o mp_dr_reduce.o \
+mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o mp_exteuclid.o mp_fread.o \
+mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o \
+mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o mp_grow.o mp_incr.o \
+mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o mp_init_multi.o mp_init_set.o \
+mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o mp_invmod.o mp_is_square.o \
+mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o mp_mod_2d.o mp_mod_d.o \
+mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o mp_mul.o mp_mul_2.o \
+mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
+mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
+mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_prime_tab.o \
+mp_radix_size.o mp_radix_size_overestimate.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o \
+mp_reduce_2k.o mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o \
+mp_reduce_is_2k_l.o mp_reduce_setup.o mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o \
+mp_set_i32.o mp_set_i64.o mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o \
+mp_shrink.o mp_signed_rsh.o mp_sqr.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o \
+mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o \
+s_mp_balance_mul.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod_fast.o \
+s_mp_invmod_slow.o s_mp_karatsuba_mul.o s_mp_karatsuba_sqr.o s_mp_log.o s_mp_log_d.o \
+s_mp_montgomery_reduce_fast.o s_mp_mul_digs.o s_mp_mul_digs_fast.o s_mp_mul_high_digs.o \
+s_mp_mul_high_digs_fast.o s_mp_prime_is_divisible.o s_mp_rand_jenkins.o s_mp_rand_platform.o \
+s_mp_reverse.o s_mp_sqr.o s_mp_sqr_fast.o s_mp_sub.o s_mp_toom_mul.o s_mp_toom_sqr.o
 
 
 HEADERS_PUB=tommath.h

--- a/makefile.unix
+++ b/makefile.unix
@@ -30,30 +30,31 @@ LTM_LDFLAGS = $(LDFLAGS)
 #Library to be created (this makefile builds only static library)
 LIBMAIN_S = libtommath.a
 
-OBJECTS=mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o mp_clamp.o mp_clear.o mp_clear_multi.o \
-mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o mp_copy.o mp_count_bits.o mp_cutoffs.o \
-mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o mp_dr_is_modulus.o mp_dr_reduce.o \
-mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o mp_exteuclid.o mp_fread.o \
-mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o \
-mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o mp_grow.o mp_incr.o \
-mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o mp_init_multi.o mp_init_set.o \
-mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o mp_invmod.o mp_is_square.o \
-mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o mp_mod_2d.o mp_mod_d.o \
-mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o mp_mul.o mp_mul_2.o \
-mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
-mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
-mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_prime_tab.o \
-mp_radix_size.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o mp_reduce_2k_l.o \
-mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o mp_reduce_setup.o \
-mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o mp_set_l.o \
-mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o mp_sqr.o \
-mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
+OBJECTS=bn_mp_radix_size_overestimate.o mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o \
+mp_clamp.o mp_clear.o mp_clear_multi.o mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o \
+mp_copy.o mp_count_bits.o mp_cutoffs.o mp_decr.o mp_div.o mp_div_2.o mp_div_2d.o mp_div_3.o mp_div_d.o \
+mp_dr_is_modulus.o mp_dr_reduce.o mp_dr_setup.o mp_error_to_string.o mp_exch.o mp_expt_u32.o mp_exptmod.o \
+mp_exteuclid.o mp_fread.o mp_from_sbin.o mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o \
+mp_get_i64.o mp_get_l.o mp_get_ll.o mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o \
+mp_grow.o mp_incr.o mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o \
+mp_init_multi.o mp_init_set.o mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o \
+mp_invmod.o mp_is_square.o mp_iseven.o mp_isodd.o mp_kronecker.o mp_lcm.o mp_log_u32.o mp_lshd.o mp_mod.o \
+mp_mod_2d.o mp_mod_d.o mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o \
+mp_mul.o mp_mul_2.o mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o \
+mp_prime_fermat.o mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o \
+mp_prime_next_prime.o mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o \
+mp_prime_tab.o mp_radix_size.o mp_radix_smap.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
+mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
+mp_reduce_setup.o mp_root_u32.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
+mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o \
+mp_sqr.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
 mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_balance_mul.o s_mp_exptmod.o \
 s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod_fast.o s_mp_invmod_slow.o s_mp_karatsuba_mul.o \
 s_mp_karatsuba_sqr.o s_mp_log.o s_mp_log_d.o s_mp_montgomery_reduce_fast.o s_mp_mul_digs.o \
 s_mp_mul_digs_fast.o s_mp_mul_high_digs.o s_mp_mul_high_digs_fast.o s_mp_prime_is_divisible.o \
 s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_reverse.o s_mp_sqr.o s_mp_sqr_fast.o s_mp_sub.o \
 s_mp_toom_mul.o s_mp_toom_sqr.o
+
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h tommath_cutoffs.h $(HEADERS_PUB)

--- a/mp_fwrite.c
+++ b/mp_fwrite.c
@@ -10,9 +10,14 @@ mp_err mp_fwrite(const mp_int *a, int radix, FILE *stream)
    mp_err err;
    size_t len, written;
 
-   /* TODO: this function is not in this PR */
-   if ((err = mp_radix_size(a, radix, &len)) != MP_OKAY) {
-      return err;
+   if (MP_HAS(MP_RADIX_SIZE_OVERESTIMATE)) {
+      if ((err = mp_radix_size_overestimate(a, radix, &len)) != MP_OKAY) {
+         return err;
+      }
+   } else {
+      if ((err = mp_radix_size(a, radix, &len)) != MP_OKAY) {
+         return err;
+      }
    }
 
    buf = (char *) MP_MALLOC(len);

--- a/mp_radix_size_overestimate.c
+++ b/mp_radix_size_overestimate.c
@@ -1,9 +1,7 @@
 #include "tommath_private.h"
-#ifdef BN_MP_RADIX_SIZE_OVERESTIMATE_C
+#ifdef MP_RADIX_SIZE_OVERESTIMATE_C
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
-
-
 
 /*
    Table of {0, log_2([1..64])} times 2^p where p is the scale
@@ -27,13 +25,13 @@ static const uint16_t logbases[65] = {
    48389u, 48584u, 48776u, 48965u, 49152u
 };
 /* *INDENT-ON* */
-mp_err mp_radix_size_overestimate(const mp_int *a, const int radix, int *size)
+mp_err mp_radix_size_overestimate(const mp_int *a, const int radix, size_t *size)
 {
    mp_int bi_bit_count, bi_k;
    int bit_count;
    mp_err err = MP_OKAY;
 
-   *size = 0;
+   *size = 0u;
 
    if ((radix < 2) || (radix > 64)) {
       return MP_VAL;
@@ -42,7 +40,7 @@ mp_err mp_radix_size_overestimate(const mp_int *a, const int radix, int *size)
    bit_count = mp_count_bits(a) + 1;
 
    if (bit_count == 0) {
-      *size = 2;
+      *size = 2u;
       return MP_OKAY;
    }
 
@@ -55,10 +53,8 @@ mp_err mp_radix_size_overestimate(const mp_int *a, const int radix, int *size)
    if ((err = mp_mul_2d(&bi_bit_count, LTM_RADIX_SIZE_SCALE, &bi_bit_count)) != MP_OKAY)  goto LTM_ERR;
    if ((err = mp_div(&bi_bit_count, &bi_k, &bi_bit_count, NULL)) != MP_OKAY)              goto LTM_ERR;
 
-   *size = (int)mp_get_l(&bi_bit_count) + 4;
-#if ( (defined MP_8BIT) && (INT_MAX > 0xFFFF))
-   *size += 3;
-#endif
+   *size = (size_t)(mp_get_l(&bi_bit_count) + 4);
+
 
 LTM_ERR:
    mp_clear_multi(&bi_bit_count, &bi_k, NULL);

--- a/tommath.def
+++ b/tommath.def
@@ -41,8 +41,6 @@ EXPORTS
     mp_from_sbin
     mp_from_ubin
     mp_fwrite
-    mp_fwrite
-    mp_fwrite
     mp_gcd
     mp_get_double
     mp_get_i32

--- a/tommath.def
+++ b/tommath.def
@@ -41,6 +41,8 @@ EXPORTS
     mp_from_sbin
     mp_from_ubin
     mp_fwrite
+    mp_fwrite
+    mp_fwrite
     mp_gcd
     mp_get_double
     mp_get_i32
@@ -99,6 +101,7 @@ EXPORTS
     mp_prime_strong_lucas_selfridge
     mp_prime_tab
     mp_radix_size
+    mp_radix_size_overestimate
     mp_rand
     mp_read_radix
     mp_reduce

--- a/tommath.h
+++ b/tommath.h
@@ -590,7 +590,7 @@ mp_err mp_read_radix(mp_int *a, const char *str, int radix) MP_WUR;
 mp_err mp_to_radix(const mp_int *a, char *str, size_t maxlen, size_t *written, int radix) MP_WUR;
 
 mp_err mp_radix_size(const mp_int *a, int radix, size_t *size) MP_WUR;
-mp_err mp_radix_size_overestimate(const mp_int *a, const int radix, int *size) MP_WUR;
+mp_err mp_radix_size_overestimate(const mp_int *a, const int radix, size_t *size) MP_WUR;
 
 #ifndef MP_NO_FILE
 mp_err mp_fread(mp_int *a, int radix, FILE *stream) MP_WUR;

--- a/tommath.h
+++ b/tommath.h
@@ -588,7 +588,9 @@ mp_err mp_to_sbin(const mp_int *a, unsigned char *buf, size_t maxlen, size_t *wr
 
 mp_err mp_read_radix(mp_int *a, const char *str, int radix) MP_WUR;
 mp_err mp_to_radix(const mp_int *a, char *str, size_t maxlen, size_t *written, int radix) MP_WUR;
+
 mp_err mp_radix_size(const mp_int *a, int radix, size_t *size) MP_WUR;
+mp_err mp_radix_size_overestimate(const mp_int *a, const int radix, int *size) MP_WUR;
 
 #ifndef MP_NO_FILE
 mp_err mp_fread(mp_int *a, int radix, FILE *stream) MP_WUR;

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -11,7 +11,6 @@
 #endif
 #define LTM1
 #if defined(LTM_ALL)
-#   define BN_MP_RADIX_SIZE_OVERESTIMATE_C
 #   define MP_2EXPT_C
 #   define MP_ABS_C
 #   define MP_ADD_C
@@ -105,6 +104,7 @@
 #   define MP_PRIME_STRONG_LUCAS_SELFRIDGE_C
 #   define MP_PRIME_TAB_C
 #   define MP_RADIX_SIZE_C
+#   define MP_RADIX_SIZE_OVERESTIMATE_C
 #   define MP_RADIX_SMAP_C
 #   define MP_RAND_C
 #   define MP_READ_RADIX_C
@@ -172,17 +172,6 @@
 #   define S_MP_TOOM_SQR_C
 #endif
 #endif
-#if defined(BN_MP_RADIX_SIZE_OVERESTIMATE_C)
-#   define MP_CLEAR_MULTI_C
-#   define MP_COUNT_BITS_C
-#   define MP_DIV_C
-#   define MP_GET_L_C
-#   define MP_INIT_MULTI_C
-#   define MP_MUL_2D_C
-#   define MP_SET_L_C
-#   define MP_SET_U32_C
-#endif
-
 #if defined(MP_2EXPT_C)
 #   define MP_GROW_C
 #   define MP_ZERO_C
@@ -760,6 +749,17 @@
 
 #if defined(MP_RADIX_SIZE_C)
 #   define MP_LOG_U32_C
+#endif
+
+#if defined(MP_RADIX_SIZE_OVERESTIMATE_C)
+#   define MP_CLEAR_MULTI_C
+#   define MP_COUNT_BITS_C
+#   define MP_DIV_C
+#   define MP_GET_L_C
+#   define MP_INIT_MULTI_C
+#   define MP_MUL_2D_C
+#   define MP_SET_L_C
+#   define MP_SET_U32_C
 #endif
 
 #if defined(MP_RADIX_SMAP_C)

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -11,6 +11,7 @@
 #endif
 #define LTM1
 #if defined(LTM_ALL)
+#   define BN_MP_RADIX_SIZE_OVERESTIMATE_C
 #   define MP_2EXPT_C
 #   define MP_ABS_C
 #   define MP_ADD_C
@@ -171,6 +172,17 @@
 #   define S_MP_TOOM_SQR_C
 #endif
 #endif
+#if defined(BN_MP_RADIX_SIZE_OVERESTIMATE_C)
+#   define MP_CLEAR_MULTI_C
+#   define MP_COUNT_BITS_C
+#   define MP_DIV_C
+#   define MP_GET_L_C
+#   define MP_INIT_MULTI_C
+#   define MP_MUL_2D_C
+#   define MP_SET_L_C
+#   define MP_SET_U32_C
+#endif
+
 #if defined(MP_2EXPT_C)
 #   define MP_GROW_C
 #   define MP_ZERO_C
@@ -370,6 +382,7 @@
 
 #if defined(MP_FWRITE_C)
 #   define MP_RADIX_SIZE_C
+#   define MP_RADIX_SIZE_OVERESTIMATE_C
 #   define MP_TO_RADIX_C
 #endif
 


### PR DESCRIPTION
This is the version with a large error range `-0,+x` (with `x < 28,328`)
PR slicing as asked for in #343 
**EDIT:** corrected sign for thousands separator.