### PR TITLE
add back missing symbols

### DIFF
--- a/bn_deprecated.c
+++ b/bn_deprecated.c
@@ -231,63 +231,55 @@ mp_err mp_n_root(const mp_int *a, mp_digit b, mp_int *c)
    return mp_root_u32(a, (uint32_t)b, c);
 }
 #endif
-
 #ifdef BN_MP_UNSIGNED_BIN_SIZE_C
 int mp_unsigned_bin_size(const mp_int *a)
 {
    return (int)mp_ubin_size(a);
 }
 #endif
-
 #ifdef BN_MP_READ_UNSIGNED_BIN_C
 mp_err mp_read_unsigned_bin(mp_int *a, const unsigned char *b, int c)
 {
    return mp_from_ubin(a, b, (size_t) c);
 }
 #endif
-
 #ifdef BN_MP_TO_UNSIGNED_BIN_C
 mp_err mp_to_unsigned_bin(const mp_int *a, unsigned char *b)
 {
    return mp_to_ubin(a, b, SIZE_MAX, NULL);
 }
 #endif
-
 #ifdef BN_MP_TO_UNSIGNED_BIN_N_C
 mp_err mp_to_unsigned_bin_n(const mp_int *a, unsigned char *b, unsigned long *outlen)
 {
-   if (*outlen < (unsigned long)mp_ubin_size(a)) {
+   size_t n = mp_ubin_size(a);
+   if (*outlen < (unsigned long)n) {
       return MP_VAL;
    }
-   /* TODO: or use "outlen" instead of NULL? */
-   *outlen = (unsigned long)mp_ubin_size(a);
-   return mp_to_ubin(a, b, (size_t)(*outlen), NULL);
+   *outlen = (unsigned long)n;
+   return mp_to_ubin(a, b, n, NULL);
 }
 #endif
-
 #ifdef BN_MP_SIGNED_BIN_SIZE_C
 int mp_signed_bin_size(const mp_int *a)
 {
    return (int)mp_sbin_size(a);
 }
 #endif
-
 #ifdef BN_MP_READ_SIGNED_BIN_C
 mp_err mp_read_signed_bin(mp_int *a, const unsigned char *b, int c)
 {
    return mp_from_sbin(a, b, (size_t) c);
 }
 #endif
-
 #ifdef BN_MP_TO_SIGNED_BIN_C
-mp_err mp_to_unsigned_bin(const mp_int *a, unsigned char *b)
+mp_err mp_to_signed_bin(const mp_int *a, unsigned char *b)
 {
    return mp_to_sbin(a, b, SIZE_MAX, NULL);
 }
 #endif
-
 #ifdef BN_MP_TO_SIGNED_BIN_N_C
-mp_err mp_to_unsigned_bin_n(const mp_int *a, unsigned char *b, unsigned long *outlen)
+mp_err mp_to_signed_bin_n(const mp_int *a, unsigned char *b, unsigned long *outlen)
 {
    if (*outlen < (unsigned long)mp_sbin_size(a)) {
       return MP_VAL;
@@ -296,10 +288,6 @@ mp_err mp_to_unsigned_bin_n(const mp_int *a, unsigned char *b, unsigned long *ou
    return mp_to_sbin(a, b, (size_t)(*outlen), NULL);
 }
 #endif
-
-
-
-
 #ifdef BN_MP_TORADIX_N_C
 mp_err mp_toradix_n(const mp_int *a, char *str, int radix, int maxlen)
 {

--- a/bn_deprecated.c
+++ b/bn_deprecated.c
@@ -281,11 +281,12 @@ mp_err mp_to_signed_bin(const mp_int *a, unsigned char *b)
 #ifdef BN_MP_TO_SIGNED_BIN_N_C
 mp_err mp_to_signed_bin_n(const mp_int *a, unsigned char *b, unsigned long *outlen)
 {
-   if (*outlen < (unsigned long)mp_sbin_size(a)) {
+   size_t n = mp_sbin_size(a);
+   if (*outlen < (unsigned long)n) {
       return MP_VAL;
    }
-   *outlen = (unsigned long)mp_sbin_size(a);
-   return mp_to_sbin(a, b, (size_t)(*outlen), NULL);
+   *outlen = (unsigned long)n;
+   return mp_to_sbin(a, b, n, NULL);
 }
 #endif
 #ifdef BN_MP_TORADIX_N_C

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -232,6 +232,8 @@
 #   define BN_MP_TORADIX_N_C
 #   define BN_MP_TO_RADIX_C
 #   define BN_MP_TO_SBIN_C
+#   define BN_MP_TO_SIGNED_BIN_C
+#   define BN_MP_TO_SIGNED_BIN_N_C
 #   define BN_MP_TO_UBIN_C
 #   define BN_MP_TO_UNSIGNED_BIN_C
 #   define BN_MP_TO_UNSIGNED_BIN_N_C


### PR DESCRIPTION
@sjaeckel Added back the missing symbols. The issue is that the functions have not been compiled due to the invalid ifdef guard. Maybe we can improve the generate perl script somehow to check that the ifdef guard matches the function being defined. We also had the issue before where some invalid code was in bn_deprecated.c, which I fixed in some recent PR.