### PR TITLE
enable MP_PRIVATE (visibility=hidden)

### DIFF
--- a/makefile.mingw
+++ b/makefile.mingw
@@ -78,7 +78,7 @@ $(LIBMAIN_S): $(OBJECTS)
 
 #Create DLL + import library libtommath.dll.a
 $(LIBMAIN_D) $(LIBMAIN_I): $(OBJECTS)
-	$(CC) -s -shared -o $(LIBMAIN_D) $^ -Wl,--enable-auto-import,--export-all -Wl,--out-implib=$(LIBMAIN_I) $(LTM_LDFLAGS)
+	$(CC) -s -shared -o $(LIBMAIN_D) $^ tommath.def -Wl,--out-implib=$(LIBMAIN_I) $(LTM_LDFLAGS)
 	$(STRIP) -S $(LIBMAIN_D)
 
 #Build test suite

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -14,11 +14,9 @@
  *
  * On Unix symbols can be marked as hidden if libtommath is compiled
  * as a shared object. By default, symbols are visible.
- * As of now, this feature is opt-in via the MP_PRIVATE_SYMBOLS define.
- *
  * On Win32 a .def file must be used to specify the exported symbols.
  */
-#if defined (MP_PRIVATE_SYMBOLS) && defined(__GNUC__) && __GNUC__ >= 4
+#if defined(__GNUC__) && __GNUC__ >= 4
 #   define MP_PRIVATE __attribute__ ((visibility ("hidden")))
 #else
 #   define MP_PRIVATE

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -16,7 +16,7 @@
  * as a shared object. By default, symbols are visible.
  * On Win32 a .def file must be used to specify the exported symbols.
  */
-#if defined(__GNUC__) && __GNUC__ >= 4
+#if defined(__GNUC__) && __GNUC__ >= 4 && !defined(_WIN32)
 #   define MP_PRIVATE __attribute__ ((visibility ("hidden")))
 #else
 #   define MP_PRIVATE


### PR DESCRIPTION
In 1.2 we had MP_PRIVATE disabled by default. This should be changed now.