### PR TITLE
Fix build with latest visual studio (2019)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,13 @@ branches:
   - /^release/
   - /^travis/
 image:
+- Visual Studio 2019
 - Visual Studio 2017
 - Visual Studio 2015
 build_script:
 - cmd: >-
-    if "Visual Studio 2017"=="%APPVEYOR_BUILD_WORKER_IMAGE%" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+    if "Visual Studio 2019"=="%APPVEYOR_BUILD_WORKER_IMAGE%" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+        if "Visual Studio 2017"=="%APPVEYOR_BUILD_WORKER_IMAGE%" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
         if "Visual Studio 2015"=="%APPVEYOR_BUILD_WORKER_IMAGE%" call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
         if "Visual Studio 2015"=="%APPVEYOR_BUILD_WORKER_IMAGE%" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
         nmake -f makefile.msvc all

--- a/bn_s_mp_rand_platform.c
+++ b/bn_s_mp_rand_platform.c
@@ -27,16 +27,9 @@ static mp_err s_read_arc4random(void *p, size_t n)
 #define ARM
 #endif
 
-#ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning (disable : 4668)
-#endif
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <wincrypt.h>
-#ifdef _MSC_VER
-# pragma warning(pop)
-#endif
 
 static mp_err s_read_wincsp(void *p, size_t n)
 {

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -14,7 +14,7 @@ PREFIX    = c:\devel
 CFLAGS    = /Ox
 
 #Compilation flags
-LTM_CFLAGS  = /nologo /I./ /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D__STDC_WANT_SECURE_LIB__=1 /D_CRT_HAS_CXX17=0 /Wall /wd4146 /wd4127 /wd4710 /wd4711 /wd4820 /WX $(CFLAGS)
+LTM_CFLAGS  = /nologo /I./ /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D__STDC_WANT_SECURE_LIB__=1 /D_CRT_HAS_CXX17=0 /Wall /wd4146 /wd4127 /wd4668 /wd4710 /wd4711 /wd4820 /wd5045 /WX $(CFLAGS)
 LTM_LDFLAGS = advapi32.lib
 
 #Libraries to be created (this makefile builds only static libraries)


### PR DESCRIPTION
When compiling release/1.2.0 with latest Visual Studio (2019), there were 2 new error-messages which resulted in a failed build:

C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.22.27905\include\vcruntime.h(255): error C2220: warning treated as error - no 'object' file generated
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.22.27905\include\vcruntime.h(255): warning C4668: '__cplusplus' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.22.27905\include\vcruntime.h(258): warning C4668: '__cplusplus' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.22.27905\bin\HostX64\x64\cl.EXE"' : return code '0x2'
S
.....
C:\Users\jan.nijtmans\workspace\libtommath\bn_deprecated.c(12) : error C2220: warning treated as error - no 'object' file generated
C:\Users\jan.nijtmans\workspace\libtommath\bn_deprecated.c(12) : warning C5045: Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
C:\Users\jan.nijtmans\workspace\libtommath\bn_deprecated.c(9) : note: index 'b' range checked by comparison on this line
C:\Users\jan.nijtmans\workspace\libtommath\bn_deprecated.c(12) : note: feeds call on this line
C
....

Clearly those are errors in visual studio :-(
