### PR TITLE
use size_t for mp_radix_size

### DIFF
--- a/demo/shared.c
+++ b/demo/shared.c
@@ -3,19 +3,19 @@
 void ndraw(const mp_int *a, const char *name)
 {
    char *buf;
-   int size;
+   size_t size;
 
    mp_radix_size(a, 10, &size);
-   buf = (char *)malloc((size_t) size);
+   buf = (char *)malloc(size);
    if (buf == NULL) {
-      fprintf(stderr, "\nndraw: malloc(%d) failed\n", size);
+      fprintf(stderr, "\nndraw: malloc(%zu) failed\n", size);
       exit(EXIT_FAILURE);
    }
 
    printf("%s: ", name);
-   mp_to_decimal(a, buf, (size_t) size);
+   mp_to_decimal(a, buf, size);
    printf("%s\n", buf);
-   mp_to_hex(a, buf, (size_t) size);
+   mp_to_hex(a, buf, size);
    printf("0x%s\n", buf);
 
    free(buf);

--- a/demo/test.c
+++ b/demo/test.c
@@ -2275,9 +2275,10 @@ static int test_mp_radix_size(void)
 {
    mp_err err;
    mp_int a;
-   int radix, size;
+   int radix;
+   size_t size;
 /* *INDENT-OFF* */
-   int results[65] = {
+   size_t results[65] = {
        0, 0, 1627, 1027, 814, 702, 630, 581, 543,
        514, 491, 471, 455, 441, 428, 418, 408, 399,
        391, 384, 378, 372, 366, 361, 356, 352, 347,
@@ -2302,7 +2303,7 @@ static int test_mp_radix_size(void)
          goto LBL_ERR;
       }
       if (size != results[radix]) {
-         fprintf(stderr, "mp_radix_size: result for base %d was %d instead of %d\n",
+         fprintf(stderr, "mp_radix_size: result for base %d was %zu instead of %zu\n",
                  radix, size, results[radix]);
          goto LBL_ERR;
       }
@@ -2311,7 +2312,7 @@ static int test_mp_radix_size(void)
          goto LBL_ERR;
       }
       if (size != (results[radix] + 1)) {
-         fprintf(stderr, "mp_radix_size: result for base %d was %d instead of %d\n",
+         fprintf(stderr, "mp_radix_size: result for base %d was %zu instead of %zu\n",
                  radix, size, results[radix]);
          goto LBL_ERR;
       }

--- a/mp_fwrite.c
+++ b/mp_fwrite.c
@@ -8,24 +8,19 @@ mp_err mp_fwrite(const mp_int *a, int radix, FILE *stream)
 {
    char *buf;
    mp_err err;
-   int len;
-   size_t written;
+   size_t len, written;
 
    /* TODO: this function is not in this PR */
-   if (MP_HAS(MP_RADIX_SIZE_OVERESTIMATE)) {
-      /* if ((err = mp_radix_size_overestimate(&t, base, &len)) != MP_OKAY)      goto LBL_ERR; */
-   } else {
-      if ((err = mp_radix_size(a, radix, &len)) != MP_OKAY) {
-         return err;
-      }
+   if ((err = mp_radix_size(a, radix, &len)) != MP_OKAY) {
+      return err;
    }
 
-   buf = (char *) MP_MALLOC((size_t)len);
+   buf = (char *) MP_MALLOC(len);
    if (buf == NULL) {
       return MP_MEM;
    }
 
-   if ((err = mp_to_radix(a, buf, (size_t)len, &written, radix)) != MP_OKAY) {
+   if ((err = mp_to_radix(a, buf, len, &written, radix)) != MP_OKAY) {
       goto LBL_ERR;
    }
 
@@ -37,7 +32,7 @@ mp_err mp_fwrite(const mp_int *a, int radix, FILE *stream)
 
 
 LBL_ERR:
-   MP_FREE_BUFFER(buf, (size_t)len);
+   MP_FREE_BUFFER(buf, len);
    return err;
 }
 #endif

--- a/mp_radix_size.c
+++ b/mp_radix_size.c
@@ -4,7 +4,7 @@
 /* SPDX-License-Identifier: Unlicense */
 
 /* returns size of ASCII representation */
-mp_err mp_radix_size(const mp_int *a, int radix, int *size)
+mp_err mp_radix_size(const mp_int *a, int radix, size_t *size)
 {
    mp_err err;
    mp_int a_;
@@ -26,10 +26,8 @@ mp_err mp_radix_size(const mp_int *a, int radix, int *size)
       goto LBL_ERR;
    }
 
-   *size = (int)b;
-
    /* mp_ilogb truncates to zero, hence we need one extra put on top and one for `\0`. */
-   *size += 2 + ((a->sign == MP_NEG) ? 1 : 0);
+   *size = (size_t)b + 2U + ((a->sign == MP_NEG) ? 1U : 0U);
 
 LBL_ERR:
    return err;

--- a/tommath.h
+++ b/tommath.h
@@ -588,7 +588,7 @@ mp_err mp_to_sbin(const mp_int *a, unsigned char *buf, size_t maxlen, size_t *wr
 
 mp_err mp_read_radix(mp_int *a, const char *str, int radix) MP_WUR;
 mp_err mp_to_radix(const mp_int *a, char *str, size_t maxlen, size_t *written, int radix) MP_WUR;
-mp_err mp_radix_size(const mp_int *a, int radix, int *size) MP_WUR;
+mp_err mp_radix_size(const mp_int *a, int radix, size_t *size) MP_WUR;
 
 #ifndef MP_NO_FILE
 mp_err mp_fread(mp_int *a, int radix, FILE *stream) MP_WUR;


### PR DESCRIPTION
One small step towards #363. Only changes mp_radix_size.
