### PR TITLE
fix win32 includes, remove support for everything older than Windows XP

### DIFF
--- a/s_mp_rand_platform.c
+++ b/s_mp_rand_platform.c
@@ -16,15 +16,14 @@ static mp_err s_read_arc4random(void *p, size_t n)
 }
 #endif
 
-#if defined(_WIN32) || defined(_WIN32_WCE)
+#if defined(_WIN32)
 #define S_READ_WINCSP_C
 
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0400
+#define _WIN32_WINNT 0x0501
 #endif
-#ifdef _WIN32_WCE
-#define UNDER_CE
-#define ARM
+#ifndef WINVER
+#define WINVER 0x0501
 #endif
 
 #define WIN32_LEAN_AND_MEAN
@@ -36,10 +35,10 @@ static mp_err s_read_wincsp(void *p, size_t n)
    static HCRYPTPROV hProv = 0;
    if (hProv == 0) {
       HCRYPTPROV h = 0;
-      if (!CryptAcquireContext(&h, NULL, MS_DEF_PROV, PROV_RSA_FULL,
-                               (CRYPT_VERIFYCONTEXT | CRYPT_MACHINE_KEYSET)) &&
-          !CryptAcquireContext(&h, NULL, MS_DEF_PROV, PROV_RSA_FULL,
-                               CRYPT_VERIFYCONTEXT | CRYPT_MACHINE_KEYSET | CRYPT_NEWKEYSET)) {
+      if (!CryptAcquireContextW(&h, NULL, MS_DEF_PROV_W, PROV_RSA_FULL,
+                                (CRYPT_VERIFYCONTEXT | CRYPT_MACHINE_KEYSET)) &&
+          !CryptAcquireContextW(&h, NULL, MS_DEF_PROV_W, PROV_RSA_FULL,
+                                CRYPT_VERIFYCONTEXT | CRYPT_MACHINE_KEYSET | CRYPT_NEWKEYSET)) {
          return MP_ERR;
       }
       hProv = h;

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -16,7 +16,7 @@
  * as a shared object. By default, symbols are visible.
  * On Win32 a .def file must be used to specify the exported symbols.
  */
-#if defined(__GNUC__) && __GNUC__ >= 4 && !defined(_WIN32)
+#if defined(__GNUC__) && __GNUC__ >= 4 && !defined(_WIN32) && !defined(__CYGWIN__)
 #   define MP_PRIVATE __attribute__ ((visibility ("hidden")))
 #else
 #   define MP_PRIVATE


### PR DESCRIPTION
The same as #407, but then everything in a single commit.

This removes support for Windows 95/98/ME/2000/CE, no-one cares about any more.

Also add the ".settings" directory (for Eclipse) to .gitignore.