### PR TITLE
introduce MP_NO_DEPRECATED_PRAGMA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ branches:
     - master
     - develop
     - /^release/
+    - /^support/
     - /^travis/
 
 # Additional installs: Valgrind for memory tests.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ branches:
   - master
   - develop
   - /^release/
+  - /^support/
   - /^travis/
 image:
 - Visual Studio 2019

--- a/tommath.h
+++ b/tommath.h
@@ -157,13 +157,22 @@ MP_TOOM_SQR_CUTOFF;
 
 #if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 405)
 #  define MP_DEPRECATED(x) __attribute__((deprecated("replaced by " #x)))
+#elif defined(_MSC_VER) && _MSC_VER >= 1500
+#  define MP_DEPRECATED(x) __declspec(deprecated("replaced by " #x))
+#else
+#  define MP_DEPRECATED(x)
+#endif
+
+#ifndef MP_NO_DEPRECATED_PRAGMA
+#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 301)
 #  define PRIVATE_MP_DEPRECATED_PRAGMA(s) _Pragma(#s)
 #  define MP_DEPRECATED_PRAGMA(s) PRIVATE_MP_DEPRECATED_PRAGMA(GCC warning s)
 #elif defined(_MSC_VER) && _MSC_VER >= 1500
-#  define MP_DEPRECATED(x) __declspec(deprecated("replaced by " #x))
 #  define MP_DEPRECATED_PRAGMA(s) __pragma(message(s))
-#else
-#  define MP_DEPRECATED(s)
+#endif
+#endif
+
+#ifndef MP_DEPRECATED_PRAGMA
 #  define MP_DEPRECATED_PRAGMA(s)
 #endif
 

--- a/tommath.h
+++ b/tommath.h
@@ -142,17 +142,11 @@ MP_TOOM_SQR_CUTOFF;
  * Most functions in libtommath return an error code.
  * This error code must be checked in order to prevent crashes or invalid
  * results.
- *
- * If you still want to avoid the error checks for quick and dirty programs
- * without robustness guarantees, you can `#define MP_WUR` before including
- * tommath.h, disabling the warnings.
  */
-#ifndef MP_WUR
-#  if defined(__GNUC__) && __GNUC__ >= 4
-#     define MP_WUR __attribute__((warn_unused_result))
-#  else
-#     define MP_WUR
-#  endif
+#if defined(__GNUC__) && __GNUC__ >= 4
+#   define MP_WUR __attribute__((warn_unused_result))
+#else
+#   define MP_WUR
 #endif
 
 #if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 405)


### PR DESCRIPTION
IMO it's no problem if a library user decides to keep on using the old API.

To be able to do so the user can add `-Wno-deprecated-declarations` for the build, but there was no way to disable the deprecated pragma's.