### PR TITLE
fix link error when building shared lib.

### DIFF
--- a/s_mp_rand_platform.c
+++ b/s_mp_rand_platform.c
@@ -120,10 +120,15 @@ mp_err s_read_urandom(void *p, size_t n);
 mp_err s_mp_rand_platform(void *p, size_t n)
 {
    mp_err err = MP_ERR;
-   if ((err != MP_OKAY) && MP_HAS(S_READ_ARC4RANDOM)) err = s_read_arc4random(p, n);
-   if ((err != MP_OKAY) && MP_HAS(S_READ_WINCSP))     err = s_read_wincsp(p, n);
-   if ((err != MP_OKAY) && MP_HAS(S_READ_GETRANDOM))  err = s_read_getrandom(p, n);
-   if ((err != MP_OKAY) && MP_HAS(S_READ_URANDOM))    err = s_read_urandom(p, n);
+#if defined(S_READ_ARC4RANDOM_C)
+   err = s_read_arc4random(p, n);
+#elif defined(S_READ_WINCSP_C)
+   err = s_read_wincsp(p, n);
+#elif defined(S_READ_GETRANDOM_C)
+   err = s_read_getrandom(p, n);
+#elif defined(S_READ_URANDOM_C)
+   err = s_read_urandom(p, n);
+#endif
    return err;
 }
 


### PR DESCRIPTION
if one of S_READ_* macro undefined, linker can't find s_read_* function.