### PR TITLE
MP_MIN_PREC too small, test with MP_PREC=MP_MIN_PREC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,6 +145,7 @@ matrix:
     - env: SANITIZER=1 CONV_WARNINGS=relaxed BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind'
     - env: SANITIZER=1 CONV_WARNINGS=strict BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind'
     - env: SANITIZER=1 CONV_WARNINGS=strict BUILDOPTIONS='--with-cc=clang-7 --c89 --with-m64 --with-travis-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind --cflags=-DMP_PREC=MP_MIN_PREC'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-6.0 --with-m64 --with-travis-valgrind'
       addons:
         apt:

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -177,9 +177,11 @@ MP_STATIC_ASSERT(correct_word_size, sizeof(mp_word) == (2u * sizeof(mp_digit)))
 #   endif
 #endif
 
-/* Minimum number of available digits in mp_int, MP_PREC >= MP_MIN_PREC */
-#define MP_MIN_PREC ((((int)MP_SIZEOF_BITS(long long) + MP_DIGIT_BIT) - 1) / MP_DIGIT_BIT)
-
+/* Minimum number of available digits in mp_int, MP_PREC >= MP_MIN_PREC
+ * - Must be at least 3 for s_mp_div_school.
+ * - Must be large enough such that uint64_t can be stored in mp_int without growing
+ */
+#define MP_MIN_PREC MP_MAX(3, (((int)MP_SIZEOF_BITS(long long) + MP_DIGIT_BIT) - 1) / MP_DIGIT_BIT)
 MP_STATIC_ASSERT(prec_geq_min_prec, MP_PREC >= MP_MIN_PREC)
 
 /* random number source */


### PR DESCRIPTION
The point is that the definition of MP_MIN_PREC is wrong. This is only an issue if the library is compiled with custom MP_PREC=2. So it is not really a serious bug.