### PR TITLE
Fix wrong use of uLL suffix

### DIFF
--- a/bn_mp_log_u32.c
+++ b/bn_mp_log_u32.c
@@ -6,7 +6,7 @@
 /* Compute log_{base}(a) */
 static mp_word s_pow(mp_word base, mp_word exponent)
 {
-   mp_word result = 1uLL;
+   mp_word result = 1u;
    while (exponent != 0u) {
       if ((exponent & 1u) == 1u) {
          result *= base;
@@ -20,8 +20,8 @@ static mp_word s_pow(mp_word base, mp_word exponent)
 
 static mp_digit s_digit_ilogb(mp_digit base, mp_digit n)
 {
-   mp_word bracket_low = 1uLL, bracket_mid, bracket_high, N;
-   mp_digit ret, high = 1uL, low = 0uL, mid;
+   mp_word bracket_low = 1u, bracket_mid, bracket_high, N;
+   mp_digit ret, high = 1u, low = 0uL, mid;
 
    if (n < base) {
       return 0uL;
@@ -40,7 +40,7 @@ static mp_digit s_digit_ilogb(mp_digit base, mp_digit n)
       bracket_high *= bracket_high;
    }
 
-   while (((mp_digit)(high - low)) > 1uL) {
+   while (((mp_digit)(high - low)) > 1u) {
       mid = (low + high) >> 1;
       bracket_mid = bracket_low * s_pow(base, (mp_word)(mid - low));
 

--- a/bn_mp_set_double.c
+++ b/bn_mp_set_double.c
@@ -16,7 +16,7 @@ mp_err mp_set_double(mp_int *a, double b)
    cast.dbl = b;
 
    exp = (int)((unsigned)(cast.bits >> 52) & 0x7FFu);
-   frac = (cast.bits & ((UINT64_C(1) << 52) - UINT64_C(1))) | (UINT64_C(1) << 52);
+   frac = (cast.bits & (((uint64_t)1 << 52) - (uint64_t)1)) | ((uint64_t)1 << 52);
 
    if (exp == 0x7FF) { /* +-inf, NaN */
       return MP_VAL;

--- a/bn_mp_set_double.c
+++ b/bn_mp_set_double.c
@@ -16,7 +16,7 @@ mp_err mp_set_double(mp_int *a, double b)
    cast.dbl = b;
 
    exp = (int)((unsigned)(cast.bits >> 52) & 0x7FFu);
-   frac = (cast.bits & ((1uLL << 52) - 1uLL)) | (1uLL << 52);
+   frac = (cast.bits & ((UINT64_C(1) << 52) - UINT64_C(1))) | (UINT64_C(1) << 52);
 
    if (exp == 0x7FF) { /* +-inf, NaN */
       return MP_VAL;
@@ -30,7 +30,7 @@ mp_err mp_set_double(mp_int *a, double b)
       return err;
    }
 
-   if (((cast.bits >> 63) != 0uLL) && !MP_IS_ZERO(a)) {
+   if (((cast.bits >> 63) != 0u) && !MP_IS_ZERO(a)) {
       a->sign = MP_NEG;
    }
 

--- a/bn_s_mp_rand_jenkins.c
+++ b/bn_s_mp_rand_jenkins.c
@@ -27,10 +27,10 @@ static uint64_t s_rand_jenkins_val(void)
 
 void s_mp_rand_jenkins_init(uint64_t seed)
 {
-   uint64_t i;
+   int i;
    jenkins_x.a = 0xf1ea5eedULL;
    jenkins_x.b = jenkins_x.c = jenkins_x.d = seed;
-   for (i = 0uLL; i < 20uLL; ++i) {
+   for (i = 0; i < 20; ++i) {
       (void)s_rand_jenkins_val();
    }
 }

--- a/demo/test.c
+++ b/demo/test.c
@@ -763,7 +763,7 @@ static int test_mp_get_u64(void)
    }
 
    for (i = 0; i < (int)(MP_SIZEOF_BITS(uint64_t) - 1); ++i) {
-      r = (UINT64_C(1) << (i+1)) - 1;
+      r = ((uint64_t)1 << (i+1)) - 1;
       if (!r)
          r = UINT64_MAX;
       printf(" r = 0x%" PRIx64 " i = %d\r", r, i);

--- a/demo/test.c
+++ b/demo/test.c
@@ -754,7 +754,7 @@ LBL_ERR:
 
 static int test_mp_get_u64(void)
 {
-   unsigned long long q, r;
+   uint64_t q, r;
    int i;
 
    mp_int a, b;
@@ -762,20 +762,20 @@ static int test_mp_get_u64(void)
       return EXIT_FAILURE;
    }
 
-   for (i = 0; i < (int)(MP_SIZEOF_BITS(unsigned long long) - 1); ++i) {
-      r = (1ULL << (i+1)) - 1;
+   for (i = 0; i < (int)(MP_SIZEOF_BITS(uint64_t) - 1); ++i) {
+      r = (UINT64_C(1) << (i+1)) - 1;
       if (!r)
-         r = ~0ULL;
-      printf(" r = 0x%llx i = %d\r", r, i);
+         r = UINT64_MAX;
+      printf(" r = 0x%" PRIx64 " i = %d\r", r, i);
       do {
          mp_set_u64(&a, r);
          q = mp_get_u64(&a);
          if (q != r) {
-            printf("\nmp_get_u64() bad result! 0x%llx != 0x%llx", q, r);
+            printf("\nmp_get_u64() bad result! 0x%" PRIx64 " != 0x%" PRIx64, q, r);
             goto LBL_ERR;
          }
          r <<= 1;
-      } while (r != 0uLL);
+      } while (r != 0u);
    }
 
    mp_clear_multi(&a, &b, NULL);
@@ -2313,7 +2313,7 @@ static int test_mp_read_write_ubin(void)
 
    size = mp_ubin_size(&a);
    printf("mp_to_ubin_size  %zu\n", size);
-   buf = malloc(sizeof(*buf) * size);
+   buf = (unsigned char *)malloc(sizeof(*buf) * size);
    if (buf == NULL) {
       fprintf(stderr, "test_read_write_binaries (u) failed to allocate %zu bytes\n",
               sizeof(*buf) * size);
@@ -2354,7 +2354,7 @@ static int test_mp_read_write_sbin(void)
 
    size = mp_sbin_size(&a);
    printf("mp_to_sbin_size  %zu\n", size);
-   buf = malloc(sizeof(*buf) * size);
+   buf = (unsigned char *)malloc(sizeof(*buf) * size);
    if (buf == NULL) {
       fprintf(stderr, "test_read_write_binaries (s) failed to allocate %zu bytes\n",
               sizeof(*buf) * size);
@@ -2395,7 +2395,7 @@ static int test_mp_pack_unpack(void)
 
    count = mp_pack_count(&a, 0, 1);
 
-   buf = malloc(count);
+   buf = (unsigned char *)malloc(count);
    if (buf == NULL) {
       fprintf(stderr, "test_pack_unpack failed to allocate\n");
       goto LTM_ERR;
@@ -2483,7 +2483,7 @@ static int unit_tests(int argc, char **argv)
    ok = fail = nop = 0;
 
    t = (uint64_t)time(NULL);
-   printf("SEED: 0x%"PRIx64"\n\n", t);
+   printf("SEED: 0x%" PRIx64 "\n\n", t);
    s_mp_rand_jenkins_init(t);
    mp_rand_source(s_mp_rand_jenkins);
 

--- a/etc/tune.c
+++ b/etc/tune.c
@@ -93,7 +93,7 @@ static uint64_t s_time_mul(int size)
          }
          if (mp_cmp(&c, &d) != MP_EQ) {
             /* Time of 0 cannot happen (famous last words?) */
-            t1 = 0uLL;
+            t1 = 0u;
             goto LTM_ERR;
          }
       }
@@ -134,7 +134,7 @@ static uint64_t s_time_sqr(int size)
             goto LTM_ERR;
          }
          if (mp_cmp(&c, &b) != MP_EQ) {
-            t1 = 0uLL;
+            t1 = 0u;
             goto LTM_ERR;
          }
       }
@@ -166,16 +166,16 @@ static void s_run(const char *name, uint64_t (*op)(int), int *cutoff)
    for (x = 8; x < args.upper_limit_print; x += args.increment_print) {
       *cutoff = INT_MAX;
       t1 = op(x);
-      if ((t1 == 0uLL) || (t1 == UINT64_MAX)) {
+      if ((t1 == 0u) || (t1 == UINT64_MAX)) {
          fprintf(stderr,"%s failed at x = INT_MAX (%s)\n", name,
-                 (t1 == 0uLL)?"wrong result":"internal error");
+                 (t1 == 0u)?"wrong result":"internal error");
          exit(EXIT_FAILURE);
       }
       *cutoff = x;
       t2 = op(x);
-      if ((t2 == 0uLL) || (t2 == UINT64_MAX)) {
+      if ((t2 == 0u) || (t2 == UINT64_MAX)) {
          fprintf(stderr,"%s failed (%s)\n", name,
-                 (t2 == 0uLL)?"wrong result":"internal error");
+                 (t2 == 0u)?"wrong result":"internal error");
          exit(EXIT_FAILURE);
       }
       if (args.verbose == 1) {

--- a/tommath.h
+++ b/tommath.h
@@ -200,7 +200,7 @@ TOOM_SQR_CUTOFF;
 #endif
 
 /* size of comba arrays, should be at least 2 * 2**(BITS_PER_WORD - BITS_PER_DIGIT*2) */
-#define PRIVATE_MP_WARRAY (int)(1uLL << (((CHAR_BIT * sizeof(private_mp_word)) - (2 * MP_DIGIT_BIT)) + 1))
+#define PRIVATE_MP_WARRAY (int)(1 << (((CHAR_BIT * (int)sizeof(private_mp_word)) - (2 * MP_DIGIT_BIT)) + 1))
 #define MP_WARRAY (MP_DEPRECATED_PRAGMA("MP_WARRAY is an internal macro") PRIVATE_MP_WARRAY)
 
 #if defined(__GNUC__) && __GNUC__ >= 4


### PR DESCRIPTION
Some platforms (e.g. VC++ 6.0) don't use the uLL postfix for constants. Even ... it's wrong to use it for uint64_t constants, because uint64_t might be actually "long" while "long long" is 128-bit on some platforms. Therefore <stdint.h> has macro's for it doing it in a portiable way. But ... in most places, simply using the "u" suffix is sufficient.

This PR contains fixes for all places I found. And a few more things, like explicit casts for malloc() results (on most places this is done correctly, needed for C++, but I found 3 places this was missing)

This PR can be merged as-is for the support/1.x branch, it gives conflicts when merged on master.