### PR TITLE
Removed the resets to INT_MAX in `etc/tune.c`

### DIFF
--- a/etc/tune.c
+++ b/etc/tune.c
@@ -467,7 +467,6 @@ int main(int argc, char **argv)
          if (test[n].fn != NULL) {
             s_run(test[n].name, test[n].fn, test[n].cutoff);
             *test[n].update = *test[n].cutoff;
-            *test[n].cutoff = INT_MAX;
          }
       }
    }

--- a/etc/tune.c
+++ b/etc/tune.c
@@ -467,8 +467,12 @@ int main(int argc, char **argv)
          if (test[n].fn != NULL) {
             s_run(test[n].name, test[n].fn, test[n].cutoff);
             *test[n].update = *test[n].cutoff;
+            *test[n].cutoff = INT_MAX;
          }
       }
+   }
+   if (printpreset == 1) {
+      updated = orig;
    }
    if (args.terse == 1) {
       printf("%d %d %d %d\n",


### PR DESCRIPTION
Restarted the work on Toom-Cook 4,5-way and got an irritating first result from `tune.c`:

```c
#define MP_DEFAULT_MUL_KARATSUBA_CUTOFF 101
#define MP_DEFAULT_SQR_KARATSUBA_CUTOFF 128 <- MP_MAX_COMBA/2 (60 bit)
#define MP_DEFAULT_MUL_TOOM_CUTOFF      132
#define MP_DEFAULT_SQR_TOOM_CUTOFF      128 <- MP_MAX_COMBA/2 (60 bit)
#define MP_DEFAULT_MUL_TOOM_4_CUTOFF    210
#define MP_DEFAULT_SQR_TOOM_4_CUTOFF    128 <- MP_MAX_COMBA/2 (60 bit)
#define MP_DEFAULT_MUL_TOOM_5_CUTOFF    244
#define MP_DEFAULT_SQR_TOOM_5_CUTOFF    128 <- MP_MAX_COMBA/2 (60 bit)
```

Switching off COMBA gave a more reasonable result:

```c
#define MP_DEFAULT_MUL_KARATSUBA_CUTOFF 59
#define MP_DEFAULT_SQR_KARATSUBA_CUTOFF 51
#define MP_DEFAULT_MUL_TOOM_CUTOFF      74
#define MP_DEFAULT_SQR_TOOM_CUTOFF      47
#define MP_DEFAULT_MUL_TOOM_4_CUTOFF    107
#define MP_DEFAULT_SQR_TOOM_4_CUTOFF    52
#define MP_DEFAULT_MUL_TOOM_5_CUTOFF    129
#define MP_DEFAULT_SQR_TOOM_5_CUTOFF    65
```
(Yes, it is reasonable that T-C 3-way can be faster than Karatsuba, at least according to Paul Zimmerman and Marco Bodrato)
These values are all below `MP_MAX_COMBA/2` for squaring and `MP_MAX_COMBA` for multiplication, COMBA is faster than Karatsuba up to the `WARRAY` limit,  hence the curious results in the very first listing here.

The original used the slower algorithms at their benchmarked cut-off points, too, that is without the resetting (as in this PR). With that method and comba switched back on:

```c
#define MP_DEFAULT_MUL_KARATSUBA_CUTOFF 104
#define MP_DEFAULT_SQR_KARATSUBA_CUTOFF 128
#define MP_DEFAULT_MUL_TOOM_CUTOFF      164
#define MP_DEFAULT_SQR_TOOM_CUTOFF      239
#define MP_DEFAULT_MUL_TOOM_4_CUTOFF    707
#define MP_DEFAULT_SQR_TOOM_4_CUTOFF    997 <- maxed out
#define MP_DEFAULT_MUL_TOOM_5_CUTOFF    666
#define MP_DEFAULT_SQR_TOOM_5_CUTOFF    821
```

These are just the cut-offs and are relative values, COMBA is still faster in its limits! But  I haven't measured the actual timings yet to get a better picture, the new functions might have some potential for optimizations (they are not usable otherwise) and there is #447 , too.

This PR gives more realistic results for Toom-Cook 3-way (ignoring the new ones) but doesn't *fully* solve the underlying problem.
Your opinion?