### PR TITLE
Better use of isneg

### DIFF
--- a/etc/mersenne.c
+++ b/etc/mersenne.c
@@ -43,7 +43,7 @@ static mp_err is_mersenne(long s, bool *pp)
       }
 
       /* make sure u is positive */
-      while (u.sign == MP_NEG) {
+      while (mp_isneg(&u)) {
          if ((res = mp_add(&u, &n, &u)) != MP_OKAY) {
             goto LBL_MU;
          }

--- a/mp_add_d.c
+++ b/mp_add_d.c
@@ -11,13 +11,13 @@ mp_err mp_add_d(const mp_int *a, mp_digit b, mp_int *c)
 
    /* fast path for a == c */
    if (a == c) {
-      if ((c->sign == MP_ZPOS) &&
+      if (!mp_isneg(c) &&
           !mp_iszero(c) &&
           ((c->dp[0] + b) < MP_DIGIT_MAX)) {
          c->dp[0] += b;
          return MP_OKAY;
       }
-      if ((c->sign == MP_NEG) &&
+      if (mp_isneg(c) &&
           (c->dp[0] > b)) {
          c->dp[0] -= b;
          return MP_OKAY;
@@ -30,7 +30,7 @@ mp_err mp_add_d(const mp_int *a, mp_digit b, mp_int *c)
    }
 
    /* if a is negative and |a| >= b, call c = |a| - b */
-   if ((a->sign == MP_NEG) && ((a->used > 1) || (a->dp[0] >= b))) {
+   if (mp_isneg(a) && ((a->used > 1) || (a->dp[0] >= b))) {
       mp_int a_ = *a;
       /* temporarily fix sign of a */
       a_.sign = MP_ZPOS;
@@ -51,7 +51,7 @@ mp_err mp_add_d(const mp_int *a, mp_digit b, mp_int *c)
    oldused = c->used;
 
    /* if a is positive */
-   if (a->sign == MP_ZPOS) {
+   if (!mp_isneg(a)) {
       /* add digits, mu is carry */
       int i;
       mp_digit mu = b;

--- a/mp_and.c
+++ b/mp_and.c
@@ -9,7 +9,7 @@ mp_err mp_and(const mp_int *a, const mp_int *b, mp_int *c)
    int used = MP_MAX(a->used, b->used) + 1, i;
    mp_err err;
    mp_digit ac = 1, bc = 1, cc = 1;
-   mp_sign csign = ((a->sign == MP_NEG) && (b->sign == MP_NEG)) ? MP_NEG : MP_ZPOS;
+   bool neg = (mp_isneg(a) && mp_isneg(b));
 
    if ((err = mp_grow(c, used)) != MP_OKAY) {
       return err;
@@ -19,7 +19,7 @@ mp_err mp_and(const mp_int *a, const mp_int *b, mp_int *c)
       mp_digit x, y;
 
       /* convert to two complement if negative */
-      if (a->sign == MP_NEG) {
+      if (mp_isneg(a)) {
          ac += (i >= a->used) ? MP_MASK : (~a->dp[i] & MP_MASK);
          x = ac & MP_MASK;
          ac >>= MP_DIGIT_BIT;
@@ -28,7 +28,7 @@ mp_err mp_and(const mp_int *a, const mp_int *b, mp_int *c)
       }
 
       /* convert to two complement if negative */
-      if (b->sign == MP_NEG) {
+      if (mp_isneg(b)) {
          bc += (i >= b->used) ? MP_MASK : (~b->dp[i] & MP_MASK);
          y = bc & MP_MASK;
          bc >>= MP_DIGIT_BIT;
@@ -39,7 +39,7 @@ mp_err mp_and(const mp_int *a, const mp_int *b, mp_int *c)
       c->dp[i] = x & y;
 
       /* convert to to sign-magnitude if negative */
-      if (csign == MP_NEG) {
+      if (neg) {
          cc += ~c->dp[i] & MP_MASK;
          c->dp[i] = cc & MP_MASK;
          cc >>= MP_DIGIT_BIT;
@@ -47,7 +47,7 @@ mp_err mp_and(const mp_int *a, const mp_int *b, mp_int *c)
    }
 
    c->used = used;
-   c->sign = csign;
+   c->sign = (neg ? MP_NEG : MP_ZPOS);
    mp_clamp(c);
    return MP_OKAY;
 }

--- a/mp_clamp.c
+++ b/mp_clamp.c
@@ -19,8 +19,8 @@ void mp_clamp(mp_int *a)
       --(a->used);
    }
 
-   /* reset the sign flag if used == 0 */
-   if (a->used == 0) {
+   /* reset the sign flag if zero */
+   if (mp_iszero(a)) {
       a->sign = MP_ZPOS;
    }
 }

--- a/mp_cmp.c
+++ b/mp_cmp.c
@@ -8,11 +8,11 @@ mp_ord mp_cmp(const mp_int *a, const mp_int *b)
 {
    /* compare based on sign */
    if (a->sign != b->sign) {
-      return a->sign == MP_NEG ? MP_LT : MP_GT;
+      return mp_isneg(a) ? MP_LT : MP_GT;
    }
 
    /* if negative compare opposite direction */
-   if (a->sign == MP_NEG) {
+   if (mp_isneg(a)) {
       MP_EXCH(const mp_int *, a, b);
    }
 

--- a/mp_cmp_d.c
+++ b/mp_cmp_d.c
@@ -7,7 +7,7 @@
 mp_ord mp_cmp_d(const mp_int *a, mp_digit b)
 {
    /* compare based on sign */
-   if (a->sign == MP_NEG) {
+   if (mp_isneg(a)) {
       return MP_LT;
    }
 

--- a/mp_exptmod.c
+++ b/mp_exptmod.c
@@ -13,12 +13,12 @@ mp_err mp_exptmod(const mp_int *G, const mp_int *X, const mp_int *P, mp_int *Y)
    int dr;
 
    /* modulus P must be positive */
-   if (P->sign == MP_NEG) {
+   if (mp_isneg(P)) {
       return MP_VAL;
    }
 
    /* if exponent X is negative we have to recurse */
-   if (X->sign == MP_NEG) {
+   if (mp_isneg(X)) {
       mp_int tmpG, tmpX;
       mp_err err;
 

--- a/mp_exteuclid.c
+++ b/mp_exteuclid.c
@@ -48,7 +48,7 @@ mp_err mp_exteuclid(const mp_int *a, const mp_int *b, mp_int *U1, mp_int *U2, mp
    }
 
    /* make sure U3 >= 0 */
-   if (u3.sign == MP_NEG) {
+   if (mp_isneg(&u3)) {
       if ((err = mp_neg(&u1, &u1)) != MP_OKAY)                    goto LBL_ERR;
       if ((err = mp_neg(&u2, &u2)) != MP_OKAY)                    goto LBL_ERR;
       if ((err = mp_neg(&u3, &u3)) != MP_OKAY)                    goto LBL_ERR;

--- a/mp_fread.c
+++ b/mp_fread.c
@@ -8,7 +8,7 @@
 mp_err mp_fread(mp_int *a, int radix, FILE *stream)
 {
    mp_err err;
-   mp_sign neg = MP_ZPOS;
+   mp_sign sign = MP_ZPOS;
    int ch;
 
    /* make sure the radix is ok */
@@ -19,7 +19,7 @@ mp_err mp_fread(mp_int *a, int radix, FILE *stream)
    /* if first digit is - then set negative */
    ch = fgetc(stream);
    if (ch == (int)'-') {
-      neg = MP_NEG;
+      sign = MP_NEG;
       ch = fgetc(stream);
    }
 
@@ -56,7 +56,7 @@ mp_err mp_fread(mp_int *a, int radix, FILE *stream)
    } while ((ch = fgetc(stream)) != EOF);
 
    if (!mp_iszero(a)) {
-      a->sign = neg;
+      a->sign = sign;
    }
 
    return MP_OKAY;

--- a/mp_from_sbin.c
+++ b/mp_from_sbin.c
@@ -14,7 +14,7 @@ mp_err mp_from_sbin(mp_int *a, const uint8_t *buf, size_t size)
    }
 
    /* first byte is 0 for positive, non-zero for negative */
-   a->sign = (buf[0] == (uint8_t)0) ? MP_ZPOS : MP_NEG;
+   a->sign = (buf[0] != (uint8_t)0) ? MP_NEG : MP_ZPOS;
 
    return MP_OKAY;
 }

--- a/mp_get_double.c
+++ b/mp_get_double.c
@@ -13,6 +13,6 @@ double mp_get_double(const mp_int *a)
    for (i = a->used; i --> 0;) {
       d = (d * fac) + (double)a->dp[i];
    }
-   return (a->sign == MP_NEG) ? -d : d;
+   return mp_isneg(a) ? -d : d;
 }
 #endif

--- a/mp_invmod.c
+++ b/mp_invmod.c
@@ -7,7 +7,7 @@
 mp_err mp_invmod(const mp_int *a, const mp_int *b, mp_int *c)
 {
    /* b cannot be negative and has to be >1 */
-   if ((b->sign == MP_NEG) || (mp_cmp_d(b, 1uL) != MP_GT)) {
+   if (mp_isneg(b) || (mp_cmp_d(b, 1uL) != MP_GT)) {
       return MP_VAL;
    }
 

--- a/mp_is_square.c
+++ b/mp_is_square.c
@@ -36,7 +36,7 @@ mp_err mp_is_square(const mp_int *arg, bool *ret)
    /* Default to Non-square :) */
    *ret = false;
 
-   if (arg->sign == MP_NEG) {
+   if (mp_isneg(arg)) {
       return MP_VAL;
    }
 

--- a/mp_kronecker.c
+++ b/mp_kronecker.c
@@ -57,9 +57,9 @@ mp_err mp_kronecker(const mp_int *a, const mp_int *p, int *c)
       k = table[a->dp[0] & 7u];
    }
 
-   if (p1.sign == MP_NEG) {
+   if (mp_isneg(&p1)) {
       p1.sign = MP_ZPOS;
-      if (a1.sign == MP_NEG) {
+      if (mp_isneg(&a1)) {
          k = -k;
       }
    }
@@ -88,7 +88,7 @@ mp_err mp_kronecker(const mp_int *a, const mp_int *p, int *c)
          k = k * table[p1.dp[0] & 7u];
       }
 
-      if (a1.sign == MP_NEG) {
+      if (mp_isneg(&a1)) {
          /*
           * Compute k = (-1)^((a1)*(p1-1)/4) * k
           * a1.dp[0] + 1 cannot overflow because the MSB

--- a/mp_log_u32.c
+++ b/mp_log_u32.c
@@ -5,15 +5,7 @@
 
 mp_err mp_log_u32(const mp_int *a, uint32_t base, uint32_t *c)
 {
-   if (a->sign == MP_NEG) {
-      return MP_VAL;
-   }
-
-   if (mp_iszero(a)) {
-      return MP_VAL;
-   }
-
-   if (base < 2u) {
+   if (mp_isneg(a) || mp_iszero(a) || (base < 2u)) {
       return MP_VAL;
    }
 

--- a/mp_mul.c
+++ b/mp_mul.c
@@ -10,7 +10,7 @@ mp_err mp_mul(const mp_int *a, const mp_int *b, mp_int *c)
    int min = MP_MIN(a->used, b->used),
        max = MP_MAX(a->used, b->used),
        digs = a->used + b->used + 1;
-   mp_sign neg = (a->sign == b->sign) ? MP_ZPOS : MP_NEG;
+   bool neg = (a->sign != b->sign);
 
    if ((a == b) &&
        MP_HAS(S_MP_SQR_TOOM) && /* use Toom-Cook? */
@@ -62,7 +62,7 @@ mp_err mp_mul(const mp_int *a, const mp_int *b, mp_int *c)
    } else {
       err = MP_VAL;
    }
-   c->sign = (c->used > 0) ? neg : MP_ZPOS;
+   c->sign = ((c->used > 0) && neg) ? MP_NEG : MP_ZPOS;
    return err;
 }
 #endif

--- a/mp_neg.c
+++ b/mp_neg.c
@@ -11,7 +11,7 @@ mp_err mp_neg(const mp_int *a, mp_int *b)
       return err;
    }
 
-   b->sign = mp_iszero(b) || b->sign == MP_NEG ? MP_ZPOS : MP_NEG;
+   b->sign = ((!mp_iszero(b) && !mp_isneg(b)) ? MP_NEG : MP_ZPOS);
 
    return MP_OKAY;
 }

--- a/mp_or.c
+++ b/mp_or.c
@@ -9,7 +9,7 @@ mp_err mp_or(const mp_int *a, const mp_int *b, mp_int *c)
    int used = MP_MAX(a->used, b->used) + 1, i;
    mp_err err;
    mp_digit ac = 1, bc = 1, cc = 1;
-   mp_sign csign = ((a->sign == MP_NEG) || (b->sign == MP_NEG)) ? MP_NEG : MP_ZPOS;
+   bool neg = (mp_isneg(a) || mp_isneg(b));
 
    if ((err = mp_grow(c, used)) != MP_OKAY) {
       return err;
@@ -19,7 +19,7 @@ mp_err mp_or(const mp_int *a, const mp_int *b, mp_int *c)
       mp_digit x, y;
 
       /* convert to two complement if negative */
-      if (a->sign == MP_NEG) {
+      if (mp_isneg(a)) {
          ac += (i >= a->used) ? MP_MASK : (~a->dp[i] & MP_MASK);
          x = ac & MP_MASK;
          ac >>= MP_DIGIT_BIT;
@@ -28,7 +28,7 @@ mp_err mp_or(const mp_int *a, const mp_int *b, mp_int *c)
       }
 
       /* convert to two complement if negative */
-      if (b->sign == MP_NEG) {
+      if (mp_isneg(b)) {
          bc += (i >= b->used) ? MP_MASK : (~b->dp[i] & MP_MASK);
          y = bc & MP_MASK;
          bc >>= MP_DIGIT_BIT;
@@ -39,7 +39,7 @@ mp_err mp_or(const mp_int *a, const mp_int *b, mp_int *c)
       c->dp[i] = x | y;
 
       /* convert to to sign-magnitude if negative */
-      if (csign == MP_NEG) {
+      if (neg) {
          cc += ~c->dp[i] & MP_MASK;
          c->dp[i] = cc & MP_MASK;
          cc >>= MP_DIGIT_BIT;
@@ -47,7 +47,7 @@ mp_err mp_or(const mp_int *a, const mp_int *b, mp_int *c)
    }
 
    c->used = used;
-   c->sign = csign;
+   c->sign = (neg ? MP_NEG : MP_ZPOS);
    mp_clamp(c);
    return MP_OKAY;
 }

--- a/mp_prime_strong_lucas_selfridge.c
+++ b/mp_prime_strong_lucas_selfridge.c
@@ -216,7 +216,7 @@ mp_err mp_prime_strong_lucas_selfridge(const mp_int *a, bool *result)
           */
          oddness = mp_isodd(&Uz);
          if ((err = mp_div_2(&Uz, &Uz)) != MP_OKAY)               goto LBL_LS_ERR;
-         if ((Uz.sign == MP_NEG) && oddness) {
+         if (mp_isneg(&Uz) && oddness) {
             if ((err = mp_sub_d(&Uz, 1uL, &Uz)) != MP_OKAY)       goto LBL_LS_ERR;
          }
          if ((err = mp_add(&T3z, &T4z, &Vz)) != MP_OKAY)          goto LBL_LS_ERR;
@@ -225,7 +225,7 @@ mp_err mp_prime_strong_lucas_selfridge(const mp_int *a, bool *result)
          }
          oddness = mp_isodd(&Vz);
          if ((err = mp_div_2(&Vz, &Vz)) != MP_OKAY)               goto LBL_LS_ERR;
-         if ((Vz.sign == MP_NEG) && oddness) {
+         if (mp_isneg(&Vz) && oddness) {
             if ((err = mp_sub_d(&Vz, 1uL, &Vz)) != MP_OKAY)       goto LBL_LS_ERR;
          }
          if ((err = mp_mod(&Uz, a, &Uz)) != MP_OKAY)              goto LBL_LS_ERR;

--- a/mp_radix_size.c
+++ b/mp_radix_size.c
@@ -27,7 +27,7 @@ mp_err mp_radix_size(const mp_int *a, int radix, size_t *size)
    }
 
    /* mp_ilogb truncates to zero, hence we need one extra put on top and one for `\0`. */
-   *size = (size_t)b + 2U + ((a->sign == MP_NEG) ? 1U : 0U);
+   *size = (size_t)b + 2U + (mp_isneg(a) ? 1U : 0U);
 
 LBL_ERR:
    return err;

--- a/mp_read_radix.c
+++ b/mp_read_radix.c
@@ -7,7 +7,7 @@
 mp_err mp_read_radix(mp_int *a, const char *str, int radix)
 {
    mp_err   err;
-   mp_sign  neg = MP_ZPOS;
+   mp_sign  sign = MP_ZPOS;
 
    /* make sure the radix is ok */
    if ((radix < 2) || (radix > 64)) {
@@ -19,7 +19,7 @@ mp_err mp_read_radix(mp_int *a, const char *str, int radix)
     */
    if (*str == '-') {
       ++str;
-      neg = MP_NEG;
+      sign = MP_NEG;
    }
 
    /* set the integer to the default of zero */
@@ -62,7 +62,7 @@ mp_err mp_read_radix(mp_int *a, const char *str, int radix)
 
    /* set the sign only if a != 0 */
    if (!mp_iszero(a)) {
-      a->sign = neg;
+      a->sign = sign;
    }
    return MP_OKAY;
 }

--- a/mp_reduce_is_2k.c
+++ b/mp_reduce_is_2k.c
@@ -6,7 +6,7 @@
 /* determines if mp_reduce_2k can be used */
 bool mp_reduce_is_2k(const mp_int *a)
 {
-   if (a->used == 0) {
+   if (mp_iszero(a)) {
       return false;
    } else if (a->used == 1) {
       return true;

--- a/mp_reduce_is_2k_l.c
+++ b/mp_reduce_is_2k_l.c
@@ -6,7 +6,7 @@
 /* determines if reduce_2k_l can be used */
 bool mp_reduce_is_2k_l(const mp_int *a)
 {
-   if (a->used == 0) {
+   if (mp_iszero(a)) {
       return false;
    } else if (a->used == 1) {
       return true;

--- a/mp_root_u32.c
+++ b/mp_root_u32.c
@@ -20,7 +20,7 @@ mp_err mp_root_u32(const mp_int *a, uint32_t b, mp_int *c)
    mp_err err;
 
    /* input must be positive if b is even */
-   if (((b & 1u) == 0u) && (a->sign == MP_NEG)) {
+   if (((b & 1u) == 0u) && mp_isneg(a)) {
       return MP_VAL;
    }
 

--- a/mp_signed_rsh.c
+++ b/mp_signed_rsh.c
@@ -7,7 +7,7 @@
 mp_err mp_signed_rsh(const mp_int *a, int b, mp_int *c)
 {
    mp_err err;
-   if (a->sign == MP_ZPOS) {
+   if (!mp_isneg(a)) {
       return mp_div_2d(a, b, c, NULL);
    }
 

--- a/mp_sqrt.c
+++ b/mp_sqrt.c
@@ -10,7 +10,7 @@ mp_err mp_sqrt(const mp_int *arg, mp_int *ret)
    mp_int t1, t2;
 
    /* must be positive */
-   if (arg->sign == MP_NEG) {
+   if (mp_isneg(arg)) {
       return MP_VAL;
    }
 

--- a/mp_sub.c
+++ b/mp_sub.c
@@ -23,7 +23,7 @@ mp_err mp_sub(const mp_int *a, const mp_int *b, mp_int *c)
       /* The second has a larger magnitude */
       /* The result has the *opposite* sign from */
       /* the first number. */
-      c->sign = (a->sign == MP_ZPOS) ? MP_NEG : MP_ZPOS;
+      c->sign = (!mp_isneg(a) ? MP_NEG : MP_ZPOS);
       MP_EXCH(const mp_int *, a, b);
    } else {
       /* The first has a larger or equal magnitude */

--- a/mp_sub_d.c
+++ b/mp_sub_d.c
@@ -46,7 +46,7 @@ mp_err mp_sub_d(const mp_int *a, mp_digit b, mp_int *c)
    oldused = c->used;
 
    /* if a <= b simply fix the single digit */
-   if (((a->used == 1) && (a->dp[0] <= b)) || (a->used == 0)) {
+   if (((a->used == 1) && (a->dp[0] <= b)) || mp_iszero(a)) {
       c->dp[0] = (a->used == 1) ? b - a->dp[0] : b;
 
       /* negative/1digit */

--- a/mp_to_radix.c
+++ b/mp_to_radix.c
@@ -50,7 +50,7 @@ mp_err mp_to_radix(const mp_int *a, char *str, size_t maxlen, size_t *written, i
    }
 
    /* if it is negative output a - */
-   if (t.sign == MP_NEG) {
+   if (mp_isneg(&t)) {
       /* we have to reverse our digits later... but not the - sign!! */
       ++_s;
 
@@ -84,7 +84,7 @@ mp_err mp_to_radix(const mp_int *a, char *str, size_t maxlen, size_t *written, i
    digs++;
 
    if (written != NULL) {
-      *written = (a->sign == MP_NEG) ? (digs + 1u): digs;
+      *written = mp_isneg(a) ? (digs + 1u): digs;
    }
 
 LBL_ERR:

--- a/mp_to_sbin.c
+++ b/mp_to_sbin.c
@@ -16,7 +16,7 @@ mp_err mp_to_sbin(const mp_int *a, uint8_t *buf, size_t maxlen, size_t *written)
    if (written != NULL) {
       (*written)++;
    }
-   buf[0] = (a->sign == MP_ZPOS) ? (uint8_t)0 : (uint8_t)1;
+   buf[0] = mp_isneg(a) ? (uint8_t)1 : (uint8_t)0;
    return MP_OKAY;
 }
 #endif

--- a/mp_xor.c
+++ b/mp_xor.c
@@ -9,7 +9,7 @@ mp_err mp_xor(const mp_int *a, const mp_int *b, mp_int *c)
    int used = MP_MAX(a->used, b->used) + 1, i;
    mp_err err;
    mp_digit ac = 1, bc = 1, cc = 1;
-   mp_sign csign = (a->sign != b->sign) ? MP_NEG : MP_ZPOS;
+   bool neg = (a->sign != b->sign);
 
    if ((err = mp_grow(c, used)) != MP_OKAY) {
       return err;
@@ -19,7 +19,7 @@ mp_err mp_xor(const mp_int *a, const mp_int *b, mp_int *c)
       mp_digit x, y;
 
       /* convert to two complement if negative */
-      if (a->sign == MP_NEG) {
+      if (mp_isneg(a)) {
          ac += (i >= a->used) ? MP_MASK : (~a->dp[i] & MP_MASK);
          x = ac & MP_MASK;
          ac >>= MP_DIGIT_BIT;
@@ -28,7 +28,7 @@ mp_err mp_xor(const mp_int *a, const mp_int *b, mp_int *c)
       }
 
       /* convert to two complement if negative */
-      if (b->sign == MP_NEG) {
+      if (mp_isneg(b)) {
          bc += (i >= b->used) ? MP_MASK : (~b->dp[i] & MP_MASK);
          y = bc & MP_MASK;
          bc >>= MP_DIGIT_BIT;
@@ -39,7 +39,7 @@ mp_err mp_xor(const mp_int *a, const mp_int *b, mp_int *c)
       c->dp[i] = x ^ y;
 
       /* convert to to sign-magnitude if negative */
-      if (csign == MP_NEG) {
+      if (neg) {
          cc += ~c->dp[i] & MP_MASK;
          c->dp[i] = cc & MP_MASK;
          cc >>= MP_DIGIT_BIT;
@@ -47,7 +47,7 @@ mp_err mp_xor(const mp_int *a, const mp_int *b, mp_int *c)
    }
 
    c->used = used;
-   c->sign = csign;
+   c->sign = (neg ? MP_NEG : MP_ZPOS);
    mp_clamp(c);
    return MP_OKAY;
 }

--- a/mtest/mpi.c
+++ b/mtest/mpi.c
@@ -846,7 +846,7 @@ mp_err mp_neg(mp_int *a, mp_int *b)
   if(s_mp_cmp_d(b, 0) == MP_EQ)
     SIGN(b) = MP_ZPOS;
   else
-    SIGN(b) = (SIGN(b) == MP_NEG) ? MP_ZPOS : MP_NEG;
+    SIGN(b) = (SIGN(b) != MP_NEG) ? MP_NEG : MP_ZPOS;
 
   return MP_OKAY;
 
@@ -1055,7 +1055,7 @@ mp_err mp_mul(mp_int *a, mp_int *b, mp_int *c)
 
   ARGCHK(a != NULL && b != NULL && c != NULL, MP_BADARG);
 
-  sgn = (SIGN(a) == SIGN(b)) ? MP_ZPOS : MP_NEG;
+  sgn = (SIGN(a) != SIGN(b)) ? MP_NEG : MP_ZPOS;
 
   if(c == b) {
     if((res = s_mp_mul(c, a)) != MP_OKAY)
@@ -1069,7 +1069,7 @@ mp_err mp_mul(mp_int *a, mp_int *b, mp_int *c)
       return res;
   }
 
-  if(sgn == MP_ZPOS || s_mp_cmp_d(c, 0) == MP_EQ)
+  if(sgn != MP_NEG || s_mp_cmp_d(c, 0) == MP_EQ)
     SIGN(c) = MP_ZPOS;
   else
     SIGN(c) = sgn;
@@ -1821,12 +1821,12 @@ int    mp_cmp(mp_int *a, mp_int *b)
     if((mag = s_mp_cmp(a, b)) == MP_EQ)
       return MP_EQ;
 
-    if(SIGN(a) == MP_ZPOS)
+    if(SIGN(a) != MP_NEG)
       return mag;
     else
       return -mag;
 
-  } else if(SIGN(a) == MP_ZPOS) {
+  } else if(SIGN(a) != MP_NEG) {
     return MP_GT;
   } else {
     return MP_LT;
@@ -1957,7 +1957,7 @@ mp_err mp_gcd(mp_int *a, mp_int *b, mp_int *c)
       goto CLEANUP;
 
     /* t = -v */
-    if(SIGN(&v) == MP_ZPOS)
+    if(SIGN(&v) != MP_NEG)
       SIGN(&t) = MP_NEG;
     else
       SIGN(&t) = MP_ZPOS;
@@ -1982,7 +1982,7 @@ mp_err mp_gcd(mp_int *a, mp_int *b, mp_int *c)
         goto CLEANUP;
 
       /* v = -t */
-      if(SIGN(&t) == MP_ZPOS)
+      if(SIGN(&t) != MP_NEG)
         SIGN(&v) = MP_NEG;
       else
         SIGN(&v) = MP_ZPOS;

--- a/s_mp_div_recursive.c
+++ b/s_mp_div_recursive.c
@@ -83,7 +83,7 @@ mp_err s_mp_div_recursive(const mp_int *a, const mp_int *b, mp_int *q, mp_int *r
 {
    int j, m, n, sigma;
    mp_err err;
-   mp_sign neg;
+   bool neg;
    mp_digit msb_b, msb;
    mp_int A, B, Q, Q1, R, A_div, A_mod;
 
@@ -126,7 +126,7 @@ mp_err s_mp_div_recursive(const mp_int *a, const mp_int *b, mp_int *q, mp_int *r
    }
 
    /* fix the sign */
-   neg = (a->sign == b->sign) ? MP_ZPOS : MP_NEG;
+   neg = (a->sign != b->sign);
    A.sign = B.sign = MP_ZPOS;
 
    /*
@@ -159,11 +159,11 @@ mp_err s_mp_div_recursive(const mp_int *a, const mp_int *b, mp_int *q, mp_int *r
    if ((err = mp_add(&Q, &Q1, &Q)) != MP_OKAY)                                   goto LBL_ERR;
 
    /* get sign before writing to c */
-   Q.sign = (Q.used == 0) ? MP_ZPOS : a->sign;
+   Q.sign = (mp_iszero(&Q) ? MP_ZPOS : a->sign);
 
    if (q != NULL) {
       mp_exch(&Q, q);
-      q->sign = neg;
+      q->sign = (neg ? MP_NEG : MP_ZPOS);
    }
    if (r != NULL) {
       /* de-normalize the remainder */

--- a/s_mp_div_small.c
+++ b/s_mp_div_small.c
@@ -8,7 +8,7 @@ mp_err s_mp_div_small(const mp_int *a, const mp_int *b, mp_int *c, mp_int *d)
 {
    mp_int ta, tb, tq, q;
    int n;
-   mp_sign sign;
+   bool neg;
    mp_err err;
 
    /* init our temps */
@@ -34,14 +34,14 @@ mp_err s_mp_div_small(const mp_int *a, const mp_int *b, mp_int *c, mp_int *d)
 
    /* now q == quotient and ta == remainder */
 
-   sign = (a->sign == b->sign) ? MP_ZPOS : MP_NEG;
+   neg = (a->sign != b->sign);
    if (c != NULL) {
       mp_exch(c, &q);
-      c->sign  = mp_iszero(c) ? MP_ZPOS : sign;
+      c->sign = ((neg && !mp_iszero(c)) ? MP_NEG : MP_ZPOS);
    }
    if (d != NULL) {
       mp_exch(d, &ta);
-      d->sign = mp_iszero(d) ? MP_ZPOS : a->sign;
+      d->sign = (mp_iszero(d) ? MP_ZPOS : a->sign);
    }
 LBL_ERR:
    mp_clear_multi(&ta, &tb, &tq, &q, NULL);

--- a/s_mp_invmod_odd.c
+++ b/s_mp_invmod_odd.c
@@ -12,7 +12,7 @@
 mp_err s_mp_invmod_odd(const mp_int *a, const mp_int *b, mp_int *c)
 {
    mp_int  x, y, u, v, B, D;
-   mp_sign neg;
+   mp_sign sign;
    mp_err  err;
 
    /* 2. [modified] b must be odd   */
@@ -95,8 +95,8 @@ mp_err s_mp_invmod_odd(const mp_int *a, const mp_int *b, mp_int *c)
    }
 
    /* b is now the inverse */
-   neg = a->sign;
-   while (D.sign == MP_NEG) {
+   sign = a->sign;
+   while (mp_isneg(&D)) {
       if ((err = mp_add(&D, b, &D)) != MP_OKAY)                   goto LBL_ERR;
    }
 
@@ -106,7 +106,7 @@ mp_err s_mp_invmod_odd(const mp_int *a, const mp_int *b, mp_int *c)
    }
 
    mp_exch(&D, c);
-   c->sign = neg;
+   c->sign = sign;
    err = MP_OKAY;
 
 LBL_ERR:

--- a/s_mp_log_d.c
+++ b/s_mp_log_d.c
@@ -5,7 +5,7 @@
 
 static mp_word s_pow(mp_word base, mp_word exponent)
 {
-   mp_word result = 1uLL;
+   mp_word result = 1u;
    while (exponent != 0u) {
       if ((exponent & 1u) == 1u) {
          result *= base;
@@ -19,7 +19,7 @@ static mp_word s_pow(mp_word base, mp_word exponent)
 
 mp_digit s_mp_log_d(mp_digit base, mp_digit n)
 {
-   mp_word bracket_low = 1uLL, bracket_mid, bracket_high, N;
+   mp_word bracket_low = 1u, bracket_mid, bracket_high, N;
    mp_digit ret, high = 1uL, low = 0uL, mid;
 
    if (n < base) {

--- a/s_mp_rand_jenkins.c
+++ b/s_mp_rand_jenkins.c
@@ -27,10 +27,10 @@ static uint64_t s_rand_jenkins_val(void)
 
 void s_mp_rand_jenkins_init(uint64_t seed)
 {
-   uint64_t i;
-   jenkins_x.a = 0xf1ea5eedULL;
+   int i;
+   jenkins_x.a = 0xF1EA5EEDuLL;
    jenkins_x.b = jenkins_x.c = jenkins_x.d = seed;
-   for (i = 0uLL; i < 20uLL; ++i) {
+   for (i = 0; i < 20; ++i) {
       (void)s_rand_jenkins_val();
    }
 }

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -261,7 +261,7 @@ extern MP_PRIVATE const mp_digit s_mp_prime_tab[];
     type name(const mp_int* a)                                \
     {                                                         \
         utype res = mag(a);                                   \
-        return (a->sign == MP_NEG) ? (type)-res : (type)res;  \
+        return mp_isneg(a) ? (type)-res : (type)res;          \
     }
 
 #endif


### PR DESCRIPTION
Consistancy in the use of mp_isneg() and mp_iszero().   Many places compare a->sign explicitly with MP_ZPOS or MP_NEG, or compare a->used explictly with 0. Using mp_isneg()/mp_iszero() makes this code much more readable. No difference in functionality.

Also the use of variables (e.g. always using variable name "sign" of type mp_sign, and variable name "neg" of type bool) consistantly.