### PR TITLE
Don't use long long where not necessary, some platforms lack it

### DIFF
--- a/mtest/mtest.c
+++ b/mtest/mtest.c
@@ -95,7 +95,7 @@ void rand_num2(mp_int *a)
 int main(int argc, char *argv[])
 {
    int n, tmp;
-   long long max;
+   long max;
    mp_int a, b, c, d, e;
 #ifdef MTEST_NO_FULLSPEED
    clock_t t1;


### PR DESCRIPTION
In mtest.c, "long long" is used while "long" suffices. proof: see strtol() call.

Since - according to the comment - "uint64_t can be stored in mp_int without growing", and MP_SIZEOF_BITS(uint64_t) == 64 (by definition), "long long" should be eliminated here too