### PR TITLE
Proposal: Remove long long support

### DIFF
--- a/doc/bn.tex
+++ b/doc/bn.tex
@@ -978,30 +978,6 @@ unsigned long mp_get_mag_ul (const mp_int *a);
 This will return the least significant bits of the big integer $a$ that fit into the native data
 type \texttt{long}.
 
-\subsection{Long Long Constants - platform dependant}
-
-\index{mp\_set\_ll} \index{mp\_set\_ull}
-\begin{alltt}
-void mp_set_ll (mp_int *a, long long b);
-void mp_set_ull (mp_int *a, unsigned long long b);
-\end{alltt}
-
-This will assign the value of the platform--dependent sized variable $b$ to the big integer $a$.
-
-To retrieve the value, the following functions can be used.
-
-\index{mp\_get\_ll}
-\index{mp\_get\_ull}
-\index{mp\_get\_mag\_ull}
-\begin{alltt}
-long long mp_get_ll (const mp_int *a);
-unsigned long long mp_get_ull (const mp_int *a);
-unsigned long long mp_get_mag_ull (const mp_int *a);
-\end{alltt}
-
-This will return the least significant bits of $a$ that fit into the native data type \texttt{long
-  long}.
-
 \subsection{Floating Point Constants - platform dependant}
 
 \index{mp\_set\_double}
@@ -1023,7 +999,7 @@ double mp_get_double(const mp_int *a);
 \subsection{Initialize and Setting Constants}
 To both initialize and set small constants the following nine functions are available.
 \index{mp\_init\_set} \index{mp\_init\_i32} \index{mp\_init\_i64} \index{mp\_init\_u32} \index{mp\_init\_u64}
-\index{mp\_init\_l} \index{mp\_init\_ll} \index{mp\_init\_ul} \index{mp\_init\_ull}
+\index{mp\_init\_l} \index{mp\_init\_ul}
 \begin{alltt}
 mp_err mp_init_set (mp_int *a, mp_digit b);
 mp_err mp_init_i32 (mp_int *a, int32_t b);
@@ -1032,8 +1008,6 @@ mp_err mp_init_i64 (mp_int *a, int64_t b);
 mp_err mp_init_u64 (mp_int *a, uint64_t b);
 mp_err mp_init_l   (mp_int *a, long b);
 mp_err mp_init_ul  (mp_int *a, unsigned long b);
-mp_err mp_init_ll  (mp_int *a, long long b);
-mp_err mp_init_ull (mp_int *a, unsigned long long b);
 \end{alltt}
 
 Both functions work like the previous counterparts except they first initialize $a$ with the

--- a/libtommath_VS2008.vcproj
+++ b/libtommath_VS2008.vcproj
@@ -465,10 +465,6 @@
 			>
 		</File>
 		<File
-			RelativePath="mp_get_ll.c"
-			>
-		</File>
-		<File
 			RelativePath="mp_get_mag_u32.c"
 			>
 		</File>
@@ -478,10 +474,6 @@
 		</File>
 		<File
 			RelativePath="mp_get_mag_ul.c"
-			>
-		</File>
-		<File
-			RelativePath="mp_get_mag_ull.c"
 			>
 		</File>
 		<File
@@ -509,10 +501,6 @@
 			>
 		</File>
 		<File
-			RelativePath="mp_init_ll.c"
-			>
-		</File>
-		<File
 			RelativePath="mp_init_multi.c"
 			>
 		</File>
@@ -534,10 +522,6 @@
 		</File>
 		<File
 			RelativePath="mp_init_ul.c"
-			>
-		</File>
-		<File
-			RelativePath="mp_init_ull.c"
 			>
 		</File>
 		<File
@@ -729,10 +713,6 @@
 			>
 		</File>
 		<File
-			RelativePath="mp_set_ll.c"
-			>
-		</File>
-		<File
 			RelativePath="mp_set_u32.c"
 			>
 		</File>
@@ -742,10 +722,6 @@
 		</File>
 		<File
 			RelativePath="mp_set_ul.c"
-			>
-		</File>
-		<File
-			RelativePath="mp_set_ull.c"
 			>
 		</File>
 		<File

--- a/makefile
+++ b/makefile
@@ -30,26 +30,25 @@ OBJECTS=mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o mp_clamp.o 
 mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o mp_copy.o mp_count_bits.o mp_cutoffs.o \
 mp_div.o mp_div_2.o mp_div_2d.o mp_div_d.o mp_dr_is_modulus.o mp_dr_reduce.o mp_dr_setup.o \
 mp_error_to_string.o mp_exch.o mp_expt_n.o mp_exptmod.o mp_exteuclid.o mp_fread.o mp_from_sbin.o \
-mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o mp_get_ll.o \
-mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o mp_grow.o mp_init.o mp_init_copy.o \
-mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o mp_init_multi.o mp_init_set.o mp_init_size.o \
-mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o mp_invmod.o mp_is_square.o mp_kronecker.o mp_lcm.o \
-mp_log_n.o mp_lshd.o mp_mod.o mp_mod_2d.o mp_montgomery_calc_normalization.o mp_montgomery_reduce.o \
-mp_montgomery_setup.o mp_mul.o mp_mul_2.o mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o \
-mp_pack_count.o mp_prime_fermat.o mp_prime_frobenius_underwood.o mp_prime_is_prime.o \
-mp_prime_miller_rabin.o mp_prime_next_prime.o mp_prime_rabin_miller_trials.o mp_prime_rand.o \
-mp_prime_strong_lucas_selfridge.o mp_radix_size.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
-mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
-mp_reduce_setup.o mp_root_n.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
-mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o \
-mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
-mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_copy_digs.o s_mp_div_3.o \
-s_mp_div_recursive.o s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o \
-s_mp_invmod.o s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o \
-s_mp_mul.o s_mp_mul_balance.o s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o \
-s_mp_mul_toom.o s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o s_mp_rand_jenkins.o \
-s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o \
-s_mp_zero_buf.o s_mp_zero_digs.o
+mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o mp_get_mag_u32.o \
+mp_get_mag_u64.o mp_get_mag_ul.o mp_grow.o mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o \
+mp_init_multi.o mp_init_set.o mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_invmod.o \
+mp_is_square.o mp_kronecker.o mp_lcm.o mp_log_n.o mp_lshd.o mp_mod.o mp_mod_2d.o \
+mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o mp_mul.o mp_mul_2.o \
+mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
+mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
+mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_radix_size.o \
+mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o mp_reduce_2k_l.o mp_reduce_2k_setup.o \
+mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o mp_reduce_setup.o mp_root_n.o mp_rshd.o \
+mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o mp_set_l.o mp_set_u32.o mp_set_u64.o \
+mp_set_ul.o mp_shrink.o mp_signed_rsh.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o \
+mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o \
+s_mp_copy_digs.o s_mp_div_3.o s_mp_div_recursive.o s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o \
+s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod.o s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o \
+s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o s_mp_mul_balance.o s_mp_mul_comba.o \
+s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o s_mp_mul_toom.o s_mp_prime_is_divisible.o \
+s_mp_prime_tab.o s_mp_radix_map.o s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o \
+s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
 
 #END_INS
 

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -32,26 +32,25 @@ OBJECTS=mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o mp_clamp.o 
 mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o mp_copy.o mp_count_bits.o mp_cutoffs.o \
 mp_div.o mp_div_2.o mp_div_2d.o mp_div_d.o mp_dr_is_modulus.o mp_dr_reduce.o mp_dr_setup.o \
 mp_error_to_string.o mp_exch.o mp_expt_n.o mp_exptmod.o mp_exteuclid.o mp_fread.o mp_from_sbin.o \
-mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o mp_get_ll.o \
-mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o mp_grow.o mp_init.o mp_init_copy.o \
-mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o mp_init_multi.o mp_init_set.o mp_init_size.o \
-mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o mp_invmod.o mp_is_square.o mp_kronecker.o mp_lcm.o \
-mp_log_n.o mp_lshd.o mp_mod.o mp_mod_2d.o mp_montgomery_calc_normalization.o mp_montgomery_reduce.o \
-mp_montgomery_setup.o mp_mul.o mp_mul_2.o mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o \
-mp_pack_count.o mp_prime_fermat.o mp_prime_frobenius_underwood.o mp_prime_is_prime.o \
-mp_prime_miller_rabin.o mp_prime_next_prime.o mp_prime_rabin_miller_trials.o mp_prime_rand.o \
-mp_prime_strong_lucas_selfridge.o mp_radix_size.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
-mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
-mp_reduce_setup.o mp_root_n.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
-mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o \
-mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
-mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_copy_digs.o s_mp_div_3.o \
-s_mp_div_recursive.o s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o \
-s_mp_invmod.o s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o \
-s_mp_mul.o s_mp_mul_balance.o s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o \
-s_mp_mul_toom.o s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o s_mp_rand_jenkins.o \
-s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o \
-s_mp_zero_buf.o s_mp_zero_digs.o
+mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o mp_get_mag_u32.o \
+mp_get_mag_u64.o mp_get_mag_ul.o mp_grow.o mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o \
+mp_init_multi.o mp_init_set.o mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_invmod.o \
+mp_is_square.o mp_kronecker.o mp_lcm.o mp_log_n.o mp_lshd.o mp_mod.o mp_mod_2d.o \
+mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o mp_mul.o mp_mul_2.o \
+mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
+mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
+mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_radix_size.o \
+mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o mp_reduce_2k_l.o mp_reduce_2k_setup.o \
+mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o mp_reduce_setup.o mp_root_n.o mp_rshd.o \
+mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o mp_set_l.o mp_set_u32.o mp_set_u64.o \
+mp_set_ul.o mp_shrink.o mp_signed_rsh.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o \
+mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o \
+s_mp_copy_digs.o s_mp_div_3.o s_mp_div_recursive.o s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o \
+s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod.o s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o \
+s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o s_mp_mul_balance.o s_mp_mul_comba.o \
+s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o s_mp_mul_toom.o s_mp_prime_is_divisible.o \
+s_mp_prime_tab.o s_mp_radix_map.o s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o \
+s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h tommath_cutoffs.h $(HEADERS_PUB)

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -25,26 +25,25 @@ OBJECTS=mp_2expt.obj mp_abs.obj mp_add.obj mp_add_d.obj mp_addmod.obj mp_and.obj
 mp_cmp.obj mp_cmp_d.obj mp_cmp_mag.obj mp_cnt_lsb.obj mp_complement.obj mp_copy.obj mp_count_bits.obj mp_cutoffs.obj \
 mp_div.obj mp_div_2.obj mp_div_2d.obj mp_div_d.obj mp_dr_is_modulus.obj mp_dr_reduce.obj mp_dr_setup.obj \
 mp_error_to_string.obj mp_exch.obj mp_expt_n.obj mp_exptmod.obj mp_exteuclid.obj mp_fread.obj mp_from_sbin.obj \
-mp_from_ubin.obj mp_fwrite.obj mp_gcd.obj mp_get_double.obj mp_get_i32.obj mp_get_i64.obj mp_get_l.obj mp_get_ll.obj \
-mp_get_mag_u32.obj mp_get_mag_u64.obj mp_get_mag_ul.obj mp_get_mag_ull.obj mp_grow.obj mp_init.obj mp_init_copy.obj \
-mp_init_i32.obj mp_init_i64.obj mp_init_l.obj mp_init_ll.obj mp_init_multi.obj mp_init_set.obj mp_init_size.obj \
-mp_init_u32.obj mp_init_u64.obj mp_init_ul.obj mp_init_ull.obj mp_invmod.obj mp_is_square.obj mp_kronecker.obj mp_lcm.obj \
-mp_log_n.obj mp_lshd.obj mp_mod.obj mp_mod_2d.obj mp_montgomery_calc_normalization.obj mp_montgomery_reduce.obj \
-mp_montgomery_setup.obj mp_mul.obj mp_mul_2.obj mp_mul_2d.obj mp_mul_d.obj mp_mulmod.obj mp_neg.obj mp_or.obj mp_pack.obj \
-mp_pack_count.obj mp_prime_fermat.obj mp_prime_frobenius_underwood.obj mp_prime_is_prime.obj \
-mp_prime_miller_rabin.obj mp_prime_next_prime.obj mp_prime_rabin_miller_trials.obj mp_prime_rand.obj \
-mp_prime_strong_lucas_selfridge.obj mp_radix_size.obj mp_rand.obj mp_read_radix.obj mp_reduce.obj mp_reduce_2k.obj \
-mp_reduce_2k_l.obj mp_reduce_2k_setup.obj mp_reduce_2k_setup_l.obj mp_reduce_is_2k.obj mp_reduce_is_2k_l.obj \
-mp_reduce_setup.obj mp_root_n.obj mp_rshd.obj mp_sbin_size.obj mp_set.obj mp_set_double.obj mp_set_i32.obj mp_set_i64.obj \
-mp_set_l.obj mp_set_ll.obj mp_set_u32.obj mp_set_u64.obj mp_set_ul.obj mp_set_ull.obj mp_shrink.obj mp_signed_rsh.obj \
-mp_sqrmod.obj mp_sqrt.obj mp_sqrtmod_prime.obj mp_sub.obj mp_sub_d.obj mp_submod.obj mp_to_radix.obj mp_to_sbin.obj \
-mp_to_ubin.obj mp_ubin_size.obj mp_unpack.obj mp_xor.obj mp_zero.obj s_mp_add.obj s_mp_copy_digs.obj s_mp_div_3.obj \
-s_mp_div_recursive.obj s_mp_div_school.obj s_mp_div_small.obj s_mp_exptmod.obj s_mp_exptmod_fast.obj s_mp_get_bit.obj \
-s_mp_invmod.obj s_mp_invmod_odd.obj s_mp_log.obj s_mp_log_2expt.obj s_mp_log_d.obj s_mp_montgomery_reduce_comba.obj \
-s_mp_mul.obj s_mp_mul_balance.obj s_mp_mul_comba.obj s_mp_mul_high.obj s_mp_mul_high_comba.obj s_mp_mul_karatsuba.obj \
-s_mp_mul_toom.obj s_mp_prime_is_divisible.obj s_mp_prime_tab.obj s_mp_radix_map.obj s_mp_rand_jenkins.obj \
-s_mp_rand_platform.obj s_mp_sqr.obj s_mp_sqr_comba.obj s_mp_sqr_karatsuba.obj s_mp_sqr_toom.obj s_mp_sub.obj \
-s_mp_zero_buf.obj s_mp_zero_digs.obj
+mp_from_ubin.obj mp_fwrite.obj mp_gcd.obj mp_get_double.obj mp_get_i32.obj mp_get_i64.obj mp_get_l.obj mp_get_mag_u32.obj \
+mp_get_mag_u64.obj mp_get_mag_ul.obj mp_grow.obj mp_init.obj mp_init_copy.obj mp_init_i32.obj mp_init_i64.obj mp_init_l.obj \
+mp_init_multi.obj mp_init_set.obj mp_init_size.obj mp_init_u32.obj mp_init_u64.obj mp_init_ul.obj mp_invmod.obj \
+mp_is_square.obj mp_kronecker.obj mp_lcm.obj mp_log_n.obj mp_lshd.obj mp_mod.obj mp_mod_2d.obj \
+mp_montgomery_calc_normalization.obj mp_montgomery_reduce.obj mp_montgomery_setup.obj mp_mul.obj mp_mul_2.obj \
+mp_mul_2d.obj mp_mul_d.obj mp_mulmod.obj mp_neg.obj mp_or.obj mp_pack.obj mp_pack_count.obj mp_prime_fermat.obj \
+mp_prime_frobenius_underwood.obj mp_prime_is_prime.obj mp_prime_miller_rabin.obj mp_prime_next_prime.obj \
+mp_prime_rabin_miller_trials.obj mp_prime_rand.obj mp_prime_strong_lucas_selfridge.obj mp_radix_size.obj \
+mp_rand.obj mp_read_radix.obj mp_reduce.obj mp_reduce_2k.obj mp_reduce_2k_l.obj mp_reduce_2k_setup.obj \
+mp_reduce_2k_setup_l.obj mp_reduce_is_2k.obj mp_reduce_is_2k_l.obj mp_reduce_setup.obj mp_root_n.obj mp_rshd.obj \
+mp_sbin_size.obj mp_set.obj mp_set_double.obj mp_set_i32.obj mp_set_i64.obj mp_set_l.obj mp_set_u32.obj mp_set_u64.obj \
+mp_set_ul.obj mp_shrink.obj mp_signed_rsh.obj mp_sqrmod.obj mp_sqrt.obj mp_sqrtmod_prime.obj mp_sub.obj mp_sub_d.obj \
+mp_submod.obj mp_to_radix.obj mp_to_sbin.obj mp_to_ubin.obj mp_ubin_size.obj mp_unpack.obj mp_xor.obj mp_zero.obj s_mp_add.obj \
+s_mp_copy_digs.obj s_mp_div_3.obj s_mp_div_recursive.obj s_mp_div_school.obj s_mp_div_small.obj s_mp_exptmod.obj \
+s_mp_exptmod_fast.obj s_mp_get_bit.obj s_mp_invmod.obj s_mp_invmod_odd.obj s_mp_log.obj s_mp_log_2expt.obj \
+s_mp_log_d.obj s_mp_montgomery_reduce_comba.obj s_mp_mul.obj s_mp_mul_balance.obj s_mp_mul_comba.obj \
+s_mp_mul_high.obj s_mp_mul_high_comba.obj s_mp_mul_karatsuba.obj s_mp_mul_toom.obj s_mp_prime_is_divisible.obj \
+s_mp_prime_tab.obj s_mp_radix_map.obj s_mp_rand_jenkins.obj s_mp_rand_platform.obj s_mp_sqr.obj s_mp_sqr_comba.obj \
+s_mp_sqr_karatsuba.obj s_mp_sqr_toom.obj s_mp_sub.obj s_mp_zero_buf.obj s_mp_zero_digs.obj
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h tommath_cutoffs.h $(HEADERS_PUB)

--- a/makefile.shared
+++ b/makefile.shared
@@ -27,26 +27,25 @@ OBJECTS=mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o mp_clamp.o 
 mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o mp_copy.o mp_count_bits.o mp_cutoffs.o \
 mp_div.o mp_div_2.o mp_div_2d.o mp_div_d.o mp_dr_is_modulus.o mp_dr_reduce.o mp_dr_setup.o \
 mp_error_to_string.o mp_exch.o mp_expt_n.o mp_exptmod.o mp_exteuclid.o mp_fread.o mp_from_sbin.o \
-mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o mp_get_ll.o \
-mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o mp_grow.o mp_init.o mp_init_copy.o \
-mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o mp_init_multi.o mp_init_set.o mp_init_size.o \
-mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o mp_invmod.o mp_is_square.o mp_kronecker.o mp_lcm.o \
-mp_log_n.o mp_lshd.o mp_mod.o mp_mod_2d.o mp_montgomery_calc_normalization.o mp_montgomery_reduce.o \
-mp_montgomery_setup.o mp_mul.o mp_mul_2.o mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o \
-mp_pack_count.o mp_prime_fermat.o mp_prime_frobenius_underwood.o mp_prime_is_prime.o \
-mp_prime_miller_rabin.o mp_prime_next_prime.o mp_prime_rabin_miller_trials.o mp_prime_rand.o \
-mp_prime_strong_lucas_selfridge.o mp_radix_size.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
-mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
-mp_reduce_setup.o mp_root_n.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
-mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o \
-mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
-mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_copy_digs.o s_mp_div_3.o \
-s_mp_div_recursive.o s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o \
-s_mp_invmod.o s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o \
-s_mp_mul.o s_mp_mul_balance.o s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o \
-s_mp_mul_toom.o s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o s_mp_rand_jenkins.o \
-s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o \
-s_mp_zero_buf.o s_mp_zero_digs.o
+mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o mp_get_mag_u32.o \
+mp_get_mag_u64.o mp_get_mag_ul.o mp_grow.o mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o \
+mp_init_multi.o mp_init_set.o mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_invmod.o \
+mp_is_square.o mp_kronecker.o mp_lcm.o mp_log_n.o mp_lshd.o mp_mod.o mp_mod_2d.o \
+mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o mp_mul.o mp_mul_2.o \
+mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
+mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
+mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_radix_size.o \
+mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o mp_reduce_2k_l.o mp_reduce_2k_setup.o \
+mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o mp_reduce_setup.o mp_root_n.o mp_rshd.o \
+mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o mp_set_l.o mp_set_u32.o mp_set_u64.o \
+mp_set_ul.o mp_shrink.o mp_signed_rsh.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o \
+mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o \
+s_mp_copy_digs.o s_mp_div_3.o s_mp_div_recursive.o s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o \
+s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod.o s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o \
+s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o s_mp_mul_balance.o s_mp_mul_comba.o \
+s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o s_mp_mul_toom.o s_mp_prime_is_divisible.o \
+s_mp_prime_tab.o s_mp_radix_map.o s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o \
+s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
 
 #END_INS
 

--- a/makefile.unix
+++ b/makefile.unix
@@ -33,26 +33,25 @@ OBJECTS=mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o mp_clamp.o 
 mp_cmp.o mp_cmp_d.o mp_cmp_mag.o mp_cnt_lsb.o mp_complement.o mp_copy.o mp_count_bits.o mp_cutoffs.o \
 mp_div.o mp_div_2.o mp_div_2d.o mp_div_d.o mp_dr_is_modulus.o mp_dr_reduce.o mp_dr_setup.o \
 mp_error_to_string.o mp_exch.o mp_expt_n.o mp_exptmod.o mp_exteuclid.o mp_fread.o mp_from_sbin.o \
-mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o mp_get_ll.o \
-mp_get_mag_u32.o mp_get_mag_u64.o mp_get_mag_ul.o mp_get_mag_ull.o mp_grow.o mp_init.o mp_init_copy.o \
-mp_init_i32.o mp_init_i64.o mp_init_l.o mp_init_ll.o mp_init_multi.o mp_init_set.o mp_init_size.o \
-mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_init_ull.o mp_invmod.o mp_is_square.o mp_kronecker.o mp_lcm.o \
-mp_log_n.o mp_lshd.o mp_mod.o mp_mod_2d.o mp_montgomery_calc_normalization.o mp_montgomery_reduce.o \
-mp_montgomery_setup.o mp_mul.o mp_mul_2.o mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o \
-mp_pack_count.o mp_prime_fermat.o mp_prime_frobenius_underwood.o mp_prime_is_prime.o \
-mp_prime_miller_rabin.o mp_prime_next_prime.o mp_prime_rabin_miller_trials.o mp_prime_rand.o \
-mp_prime_strong_lucas_selfridge.o mp_radix_size.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
-mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
-mp_reduce_setup.o mp_root_n.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
-mp_set_l.o mp_set_ll.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_set_ull.o mp_shrink.o mp_signed_rsh.o \
-mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o \
-mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_copy_digs.o s_mp_div_3.o \
-s_mp_div_recursive.o s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o \
-s_mp_invmod.o s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o \
-s_mp_mul.o s_mp_mul_balance.o s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o \
-s_mp_mul_toom.o s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o s_mp_rand_jenkins.o \
-s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o \
-s_mp_zero_buf.o s_mp_zero_digs.o
+mp_from_ubin.o mp_fwrite.o mp_gcd.o mp_get_double.o mp_get_i32.o mp_get_i64.o mp_get_l.o mp_get_mag_u32.o \
+mp_get_mag_u64.o mp_get_mag_ul.o mp_grow.o mp_init.o mp_init_copy.o mp_init_i32.o mp_init_i64.o mp_init_l.o \
+mp_init_multi.o mp_init_set.o mp_init_size.o mp_init_u32.o mp_init_u64.o mp_init_ul.o mp_invmod.o \
+mp_is_square.o mp_kronecker.o mp_lcm.o mp_log_n.o mp_lshd.o mp_mod.o mp_mod_2d.o \
+mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o mp_mul.o mp_mul_2.o \
+mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
+mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
+mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_radix_size.o \
+mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o mp_reduce_2k_l.o mp_reduce_2k_setup.o \
+mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o mp_reduce_setup.o mp_root_n.o mp_rshd.o \
+mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o mp_set_l.o mp_set_u32.o mp_set_u64.o \
+mp_set_ul.o mp_shrink.o mp_signed_rsh.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o \
+mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o \
+s_mp_copy_digs.o s_mp_div_3.o s_mp_div_recursive.o s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o \
+s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod.o s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o \
+s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o s_mp_mul_balance.o s_mp_mul_comba.o \
+s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o s_mp_mul_toom.o s_mp_prime_is_divisible.o \
+s_mp_prime_tab.o s_mp_radix_map.o s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o \
+s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h tommath_cutoffs.h $(HEADERS_PUB)

--- a/mp_get_ll.c
+++ b/mp_get_ll.c
@@ -1,7 +1,0 @@
-#include "tommath_private.h"
-#ifdef MP_GET_LL_C
-/* LibTomMath, multiple-precision integer library -- Tom St Denis */
-/* SPDX-License-Identifier: Unlicense */
-
-MP_GET_SIGNED(mp_get_ll, mp_get_mag_ull, long long, unsigned long long)
-#endif

--- a/mp_get_mag_ull.c
+++ b/mp_get_mag_ull.c
@@ -1,7 +1,0 @@
-#include "tommath_private.h"
-#ifdef MP_GET_MAG_ULL_C
-/* LibTomMath, multiple-precision integer library -- Tom St Denis */
-/* SPDX-License-Identifier: Unlicense */
-
-MP_GET_MAG(mp_get_mag_ull, unsigned long long)
-#endif

--- a/mp_init_ll.c
+++ b/mp_init_ll.c
@@ -1,7 +1,0 @@
-#include "tommath_private.h"
-#ifdef MP_INIT_LL_C
-/* LibTomMath, multiple-precision integer library -- Tom St Denis */
-/* SPDX-License-Identifier: Unlicense */
-
-MP_INIT_INT(mp_init_ll, mp_set_ll, long long)
-#endif

--- a/mp_init_ull.c
+++ b/mp_init_ull.c
@@ -1,7 +1,0 @@
-#include "tommath_private.h"
-#ifdef MP_INIT_ULL_C
-/* LibTomMath, multiple-precision integer library -- Tom St Denis */
-/* SPDX-License-Identifier: Unlicense */
-
-MP_INIT_INT(mp_init_ull, mp_set_ull, unsigned long long)
-#endif

--- a/mp_set_ll.c
+++ b/mp_set_ll.c
@@ -1,7 +1,0 @@
-#include "tommath_private.h"
-#ifdef MP_SET_LL_C
-/* LibTomMath, multiple-precision integer library -- Tom St Denis */
-/* SPDX-License-Identifier: Unlicense */
-
-MP_SET_SIGNED(mp_set_ll, mp_set_ull, long long, unsigned long long)
-#endif

--- a/mp_set_ull.c
+++ b/mp_set_ull.c
@@ -1,7 +1,0 @@
-#include "tommath_private.h"
-#ifdef MP_SET_ULL_C
-/* LibTomMath, multiple-precision integer library -- Tom St Denis */
-/* SPDX-License-Identifier: Unlicense */
-
-MP_SET_UNSIGNED(mp_set_ull, unsigned long long)
-#endif

--- a/tommath.def
+++ b/tommath.def
@@ -43,25 +43,21 @@ EXPORTS
     mp_get_i32
     mp_get_i64
     mp_get_l
-    mp_get_ll
     mp_get_mag_u32
     mp_get_mag_u64
     mp_get_mag_ul
-    mp_get_mag_ull
     mp_grow
     mp_init
     mp_init_copy
     mp_init_i32
     mp_init_i64
     mp_init_l
-    mp_init_ll
     mp_init_multi
     mp_init_set
     mp_init_size
     mp_init_u32
     mp_init_u64
     mp_init_ul
-    mp_init_ull
     mp_invmod
     mp_is_square
     mp_kronecker
@@ -109,11 +105,9 @@ EXPORTS
     mp_set_i32
     mp_set_i64
     mp_set_l
-    mp_set_ll
     mp_set_u32
     mp_set_u64
     mp_set_ul
-    mp_set_ull
     mp_shrink
     mp_signed_rsh
     mp_sqrmod

--- a/tommath.h
+++ b/tommath.h
@@ -242,7 +242,6 @@ mp_err mp_init_u64(mp_int *a, uint64_t b) MP_WUR;
 uint32_t mp_get_mag_u32(const mp_int *a) MP_WUR;
 uint64_t mp_get_mag_u64(const mp_int *a) MP_WUR;
 unsigned long mp_get_mag_ul(const mp_int *a) MP_WUR;
-unsigned long long mp_get_mag_ull(const mp_int *a) MP_WUR;
 
 /* get integer, set integer (long) */
 long mp_get_l(const mp_int *a) MP_WUR;
@@ -253,16 +252,6 @@ mp_err mp_init_l(mp_int *a, long b) MP_WUR;
 #define mp_get_ul(a) ((unsigned long)mp_get_l(a))
 void mp_set_ul(mp_int *a, unsigned long b);
 mp_err mp_init_ul(mp_int *a, unsigned long b) MP_WUR;
-
-/* get integer, set integer (long long) */
-long long mp_get_ll(const mp_int *a) MP_WUR;
-void mp_set_ll(mp_int *a, long long b);
-mp_err mp_init_ll(mp_int *a, long long b) MP_WUR;
-
-/* get integer, set integer (unsigned long long) */
-#define mp_get_ull(a) ((unsigned long long)mp_get_ll(a))
-void mp_set_ull(mp_int *a, unsigned long long b);
-mp_err mp_init_ull(mp_int *a, unsigned long long b) MP_WUR;
 
 /* set to single unsigned digit, up to MP_DIGIT_MAX */
 void mp_set(mp_int *a, mp_digit b);

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -49,25 +49,21 @@
 #   define MP_GET_I32_C
 #   define MP_GET_I64_C
 #   define MP_GET_L_C
-#   define MP_GET_LL_C
 #   define MP_GET_MAG_U32_C
 #   define MP_GET_MAG_U64_C
 #   define MP_GET_MAG_UL_C
-#   define MP_GET_MAG_ULL_C
 #   define MP_GROW_C
 #   define MP_INIT_C
 #   define MP_INIT_COPY_C
 #   define MP_INIT_I32_C
 #   define MP_INIT_I64_C
 #   define MP_INIT_L_C
-#   define MP_INIT_LL_C
 #   define MP_INIT_MULTI_C
 #   define MP_INIT_SET_C
 #   define MP_INIT_SIZE_C
 #   define MP_INIT_U32_C
 #   define MP_INIT_U64_C
 #   define MP_INIT_UL_C
-#   define MP_INIT_ULL_C
 #   define MP_INVMOD_C
 #   define MP_IS_SQUARE_C
 #   define MP_KRONECKER_C
@@ -115,11 +111,9 @@
 #   define MP_SET_I32_C
 #   define MP_SET_I64_C
 #   define MP_SET_L_C
-#   define MP_SET_LL_C
 #   define MP_SET_U32_C
 #   define MP_SET_U64_C
 #   define MP_SET_UL_C
-#   define MP_SET_ULL_C
 #   define MP_SHRINK_C
 #   define MP_SIGNED_RSH_C
 #   define MP_SQRMOD_C
@@ -377,10 +371,6 @@
 #   define MP_GET_MAG_UL_C
 #endif
 
-#if defined(MP_GET_LL_C)
-#   define MP_GET_MAG_ULL_C
-#endif
-
 #if defined(MP_GET_MAG_U32_C)
 #endif
 
@@ -388,9 +378,6 @@
 #endif
 
 #if defined(MP_GET_MAG_UL_C)
-#endif
-
-#if defined(MP_GET_MAG_ULL_C)
 #endif
 
 #if defined(MP_GROW_C)
@@ -421,11 +408,6 @@
 #   define MP_SET_L_C
 #endif
 
-#if defined(MP_INIT_LL_C)
-#   define MP_INIT_C
-#   define MP_SET_LL_C
-#endif
-
 #if defined(MP_INIT_MULTI_C)
 #   define MP_CLEAR_C
 #   define MP_INIT_C
@@ -452,11 +434,6 @@
 #if defined(MP_INIT_UL_C)
 #   define MP_INIT_C
 #   define MP_SET_UL_C
-#endif
-
-#if defined(MP_INIT_ULL_C)
-#   define MP_INIT_C
-#   define MP_SET_ULL_C
 #endif
 
 #if defined(MP_INVMOD_C)
@@ -842,10 +819,6 @@
 #   define MP_SET_UL_C
 #endif
 
-#if defined(MP_SET_LL_C)
-#   define MP_SET_ULL_C
-#endif
-
 #if defined(MP_SET_U32_C)
 #   define S_MP_ZERO_DIGS_C
 #endif
@@ -855,10 +828,6 @@
 #endif
 
 #if defined(MP_SET_UL_C)
-#   define S_MP_ZERO_DIGS_C
-#endif
-
-#if defined(MP_SET_ULL_C)
 #   define S_MP_ZERO_DIGS_C
 #endif
 

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -151,9 +151,10 @@ MP_STATIC_ASSERT(correct_word_size, sizeof(mp_word) == (2u * sizeof(mp_digit)))
 
 /* Minimum number of available digits in mp_int, MP_PREC >= MP_MIN_PREC
  * - Must be at least 3 for s_mp_div_school.
- * - Must be large enough such that uint64_t can be stored in mp_int without growing
+ * - Must be large enough such that the mp_set_u64 setter can
+ *   store uint64_t in the mp_int without growing
  */
-#define MP_MIN_PREC MP_MAX(3, (((int)MP_SIZEOF_BITS(long long) + MP_DIGIT_BIT) - 1) / MP_DIGIT_BIT)
+#define MP_MIN_PREC MP_MAX(3, (((int)MP_SIZEOF_BITS(uint64_t) + MP_DIGIT_BIT) - 1) / MP_DIGIT_BIT)
 MP_STATIC_ASSERT(prec_geq_min_prec, MP_PREC >= MP_MIN_PREC)
 
 /* random number source */


### PR DESCRIPTION
I propose to simply remove long long functions, since it is not c89 and u64/i64 can be used instead everywhere. I think that would work for most people. See also the table https://de.wikipedia.org/wiki/Datentypen_in_C#Datenmodell

These functions have been originally added in 2014 by @sjaeckel with the name mp_get_long_long etc.
Then I turned them in a macro in #285, which I think would still be an acceptable solution. Afterwards they were made explicit symbols by @nijtmans in #321. Now it seems @nijtmans needs some MSC_VER ifdef guards around these functions.

Would that work for you @nijtmans?