### PR TITLE
Change version numbers before 2.0 release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.2.0-{build}
+version: 2.0.0-{build}
 branches:
   only:
   - master

--- a/doc/bn.tex
+++ b/doc/bn.tex
@@ -51,7 +51,7 @@
 \begin{document}
 \frontmatter
 \pagestyle{empty}
-\title{LibTomMath User Manual \\ v1.2.0}
+\title{LibTomMath User Manual \\ v2.0.0}
 \author{LibTom Projects \\ www.libtom.net}
 \maketitle
 This text, the library and the accompanying textbook are all hereby placed in the public domain.

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -25,7 +25,7 @@ LTM_LDFLAGS = $(LDFLAGS) -static-libgcc
 #Libraries to be created
 LIBMAIN_S =libtommath.a
 LIBMAIN_I =libtommath.dll.a
-LIBMAIN_D =libtommath.dll
+LIBMAIN_D =tommath2.dll
 
 #List of objects to compile (all goes to libtommath.a)
 OBJECTS=mp_2expt.o mp_abs.o mp_add.o mp_add_d.o mp_addmod.o mp_and.o mp_clamp.o mp_clear.o mp_clear_multi.o \

--- a/makefile.unix
+++ b/makefile.unix
@@ -20,7 +20,7 @@ ARFLAGS   = rcs
 CFLAGS    = -O2
 LDFLAGS   =
 
-VERSION   = 1.2.0
+VERSION   = 2.0.0
 
 #Compilation flags
 LTM_CFLAGS  = -I. $(CFLAGS)

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -3,9 +3,9 @@
 #
 
 #version of library
-VERSION=1.2.0-develop
-VERSION_PC=1.2.0
-VERSION_SO=3:0:2
+VERSION=2.0.0-develop
+VERSION_PC=2.0.0
+VERSION_SO=4:0:0
 
 PLATFORM := $(shell uname | sed -e 's/_.*//')
 


### PR DESCRIPTION
The (microsoft) convension for dll's doesn't start with "lib" as on UNIX. So I suggest to use "tommath2.dll" as dll name. Also I made the other necessary corresponding makefile-related changes for the major upgrade.