### PR TITLE
Resolve conflict with tcl.h

### DIFF
--- a/tommath.h
+++ b/tommath.h
@@ -259,11 +259,15 @@ TOOM_SQR_CUTOFF;
 #define SIGN(m)     (MP_DEPRECATED_PRAGMA("SIGN macro is deprecated, use z->sign instead") (m)->sign)
 
 /* the infamous mp_int structure */
-typedef struct  {
+#ifndef MP_INT_DECLARED
+#define MP_INT_DECLARED
+typedef struct mp_int mp_int;
+#endif
+struct mp_int {
    int used, alloc;
    mp_sign sign;
    mp_digit *dp;
-} mp_int;
+};
 
 /* callback for mp_prime_random, should fill dst with random bytes and return how many read [upto len] */
 typedef int private_mp_prime_callback(unsigned char *dst, int len, void *dat);


### PR DESCRIPTION
Resolve possible conflict with tcl.h, allowing <tcl.h> and <tommath.h> to be #included in any order.

The problem is that Tcl has a few API's which are using the "mp_int" structure from tommath.h. For Tcl, the internal structure of mp_int is transparant, that's supposed to come from <tommat.h> But tcl.h contains the following code fragment now:

<pre>
#ifndef MP_INT_DECLARED
#define MP_INT_DECLARED
typedef struct mp_int mp_int;
#endif
</pre>

This allows Tcl to use mp_int in it's own API, without defining how it looks like: that's up to libtommath. The first header-file included - either tcl.h or tommath.h - will typedef "mp_int" as an anonymous struct, while tommath has full freedom to specify how it looks like.

So, I ask that tommath.h does the same: If another header file already typdefs mp_int as a anonymous struct, <tommath.h> doesn't need to do that again, just add the exact structure definition. This way the two header files can cooperate without conflicts.

At this moment, Tcl contains a modified <tommat.h> with this change. But it would be great if Tcl could include an unmodified <tommat.h> in the near future.

Thanks!
       Jan Nijtmans
