### PR TITLE
Build+test bn_mp_set_double.c on more platforms

### DIFF
--- a/demo/test.c
+++ b/demo/test.c
@@ -522,7 +522,7 @@ LBL_ERR:
 
 }
 
-#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559) || defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64) || defined(__i386__) || defined(_M_X86) || defined(__aarch64__) || defined(__arm__)
+#if defined(MP_HAS_SET_DOUBLE)
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -2172,7 +2172,7 @@ static int unit_tests(int argc, char **argv)
       T1(mp_reduce_2k_l, MP_REDUCE_2K_L),
       T1(mp_radix_size, MP_RADIX_SIZE),
       T1(s_mp_radix_size_overestimate, S_MP_RADIX_SIZE_OVERESTIMATE),
-#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559)
+#if defined(MP_HAS_SET_DOUBLE)
       T1(mp_set_double, MP_SET_DOUBLE),
 #endif
       T1(mp_signed_rsh, MP_SIGNED_RSH),

--- a/demo/test.c
+++ b/demo/test.c
@@ -523,18 +523,23 @@ LBL_ERR:
 }
 
 #if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559) || defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64) || defined(__i386__) || defined(_M_X86) || defined(__aarch64__) || defined(__arm__)
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4723) /* potential divide by 0 */
+#endif
 static int test_mp_set_double(void)
 {
    int i;
+   double dbl_zero = 0.0;
 
    mp_int a, b;
    DOR(mp_init_multi(&a, &b, NULL));
-
    /* test mp_get_double/mp_set_double */
-   EXPECT(mp_set_double(&a, +1.0/0.0) == MP_VAL);
-   EXPECT(mp_set_double(&a, -1.0/0.0) == MP_VAL);
-   EXPECT(mp_set_double(&a, +0.0/0.0) == MP_VAL);
-   EXPECT(mp_set_double(&a, -0.0/0.0) == MP_VAL);
+   EXPECT(mp_set_double(&a, +1.0/dbl_zero) == MP_VAL);
+   EXPECT(mp_set_double(&a, -1.0/dbl_zero) == MP_VAL);
+   EXPECT(mp_set_double(&a, +0.0/dbl_zero) == MP_VAL);
+   EXPECT(mp_set_double(&a, -0.0/dbl_zero) == MP_VAL);
 
    for (i = 0; i < 1000; ++i) {
       int tmp = rand_int();
@@ -552,6 +557,9 @@ LBL_ERR:
    return EXIT_FAILURE;
 
 }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 #endif
 
 static int test_mp_get_u32(void)

--- a/demo/test.c
+++ b/demo/test.c
@@ -522,7 +522,7 @@ LBL_ERR:
 
 }
 
-#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559)
+#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559) || defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64) || defined(__i386__) || defined(_M_X86) || defined(__aarch64__) || defined(__arm__)
 static int test_mp_set_double(void)
 {
    int i;

--- a/mp_set_double.c
+++ b/mp_set_double.c
@@ -3,7 +3,7 @@
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
-#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559)
+#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559) || defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64) || defined(__i386__) || defined(_M_X86) || defined(__aarch64__) || defined(__arm__)
 mp_err mp_set_double(mp_int *a, double b)
 {
    uint64_t frac;

--- a/mp_set_double.c
+++ b/mp_set_double.c
@@ -3,7 +3,7 @@
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
-#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559) || defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64) || defined(__i386__) || defined(_M_X86) || defined(__aarch64__) || defined(__arm__)
+#if defined(MP_HAS_SET_DOUBLE)
 mp_err mp_set_double(mp_int *a, double b)
 {
    uint64_t frac;

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -164,6 +164,13 @@ MP_STATIC_ASSERT(prec_geq_min_prec, MP_DEFAULT_DIGIT_COUNT >= MP_MIN_DIGIT_COUNT
  */
 #define MP_MAX_DIGIT_COUNT ((INT_MAX - 2) / MP_DIGIT_BIT)
 
+#if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559) \
+   || defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64) \
+   || defined(__i386__) || defined(_M_X86) \
+   || defined(__aarch64__) || defined(__arm__)
+#define MP_HAS_SET_DOUBLE
+#endif
+
 /* random number source */
 extern MP_PRIVATE mp_err(*s_mp_rand_source)(void *out, size_t size);
 


### PR DESCRIPTION
Not all platforms/environments/architectures that support enough of
IEEE 754 for the purposes of mp_set_double() actually support enough
to legitimately define __STDC_IEC_559__, so only relying on that is
too strict. Fixes https://github.com/libtom/libtommath/issues/159