### PR TITLE
Fix clang detection when cross-compiling.

### DIFF
--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -26,7 +26,7 @@ ifeq ($(PLATFORM),FreeBSD)
   # XXX: FreeBSD needs extra escaping for some reason
   CSTR := $$$(CSTR)
 endif
-ifneq (,$(shell echo $(CSTR) | $(CC) -E - | grep CLANG))
+ifneq (,$(shell printf $(CSTR) | $(CC) -E - | grep CLANG))
   CC := $(CROSS_COMPILE)clang
 else
   CC := $(CROSS_COMPILE)gcc


### PR DESCRIPTION
`echo` needs -e to output newlines, without the switch make complains:
```
    <stdin>:1:17: warning: extra tokens at end of #ifdef directive
    <stdin>:1: error: unterminated #ifdef
```
and does not detect clang properly when cross-compiling.