### PR TITLE
Use preprocessor guards to select available random functions

### DIFF
--- a/s_mp_rand_platform.c
+++ b/s_mp_rand_platform.c
@@ -112,10 +112,18 @@ static mp_err s_read_urandom(void *p, size_t n)
 }
 #endif
 
+#ifdef S_READ_ARC4RANDOM_C
 mp_err s_read_arc4random(void *p, size_t n);
+#endif
+#ifdef S_READ_WINCSP_C
 mp_err s_read_wincsp(void *p, size_t n);
+#endif
+#ifdef S_READ_GETRANDOM_C
 mp_err s_read_getrandom(void *p, size_t n);
+#endif
+#ifdef S_READ_URANDOM_C
 mp_err s_read_urandom(void *p, size_t n);
+#endif
 
 /*
  * Note: libtommath relies on dead code elimination
@@ -139,10 +147,18 @@ mp_err s_read_urandom(void *p, size_t n);
 mp_err s_mp_rand_platform(void *p, size_t n)
 {
    mp_err err = MP_ERR;
+#ifdef S_READ_ARC4RANDOM_C
    if ((err != MP_OKAY) && MP_HAS(S_READ_ARC4RANDOM)) err = s_read_arc4random(p, n);
+#endif
+#ifdef S_READ_WINCSP_C
    if ((err != MP_OKAY) && MP_HAS(S_READ_WINCSP))     err = s_read_wincsp(p, n);
+#endif
+#ifdef S_READ_GETRANDOM_C
    if ((err != MP_OKAY) && MP_HAS(S_READ_GETRANDOM))  err = s_read_getrandom(p, n);
+#endif
+#ifdef S_READ_URANDOM_C
    if ((err != MP_OKAY) && MP_HAS(S_READ_URANDOM))    err = s_read_urandom(p, n);
+#endif
    return err;
 }
 


### PR DESCRIPTION
Linking fails on some platforms because not all platform random functions are available. Use preprocessor guards to only call the ones that are available.