### PR TITLE
Add _M_IX86 for testing for MSVC x86

### DIFF
--- a/tommath_private.h
+++ b/tommath_private.h
@@ -166,7 +166,7 @@ MP_STATIC_ASSERT(prec_geq_min_prec, MP_DEFAULT_DIGIT_COUNT >= MP_MIN_DIGIT_COUNT
 
 #if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559) \
    || defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64) \
-   || defined(__i386__) || defined(_M_X86) \
+   || defined(__i386__) || defined(_M_X86) || defined(_M_IX86) \
    || defined(__aarch64__) || defined(__arm__)
 #define MP_HAS_SET_DOUBLE
 #endif


### PR DESCRIPTION
This PR fixes using mp_set_double with MSVC x86 since the compiler complains: `error LNK2001: unresolved external symbol _mp_set_double`.

By looking at the source code I see that `_M_X86` is used, but this macro doesn't seem to available anymore according to VS2019 documentation at [here](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019). You may want to use `_M_IX86` in addition for testing x86 targets.
 