### PR TITLE
Added checks for input in mp_sqrtmod_prime that caused infinite loops

### DIFF
--- a/demo/test.c
+++ b/demo/test.c
@@ -707,9 +707,9 @@ static int test_mp_sqrtmod_prime(void)
    };
 
    static struct mp_sqrtmod_prime_st sqrtmod_prime[] = {
-      { 5, 14, 3 },
-      { 7, 9, 4 },
-      { 113, 2, 62 }
+      { 5, 14, 3 },   /* 5 \cong 1 (mod 4) */
+      { 7, 9, 4 },    /* 7 \cong 3 (mod 4) */
+      { 113, 2, 62 }  /* 113 \cong 1 (mod 4) */
    };
    int i;
 
@@ -723,6 +723,14 @@ static int test_mp_sqrtmod_prime(void)
       DO(mp_sqrtmod_prime(&b, &a, &c));
       EXPECT(mp_cmp_d(&c, sqrtmod_prime[i].r) == MP_EQ);
    }
+   /* Check handling of wrong input (here: modulus is square and cong. 1 mod 4,24 ) */
+   mp_set_ul(&a, 25);
+   mp_set_ul(&b, 2);
+   EXPECT(mp_sqrtmod_prime(&b, &a, &c) == MP_VAL);
+   /* b \cong 0 (mod a) */
+   mp_set_ul(&a, 45);
+   mp_set_ul(&b, 3);
+   EXPECT(mp_sqrtmod_prime(&b, &a, &c) == MP_VAL);
 
    mp_clear_multi(&a, &b, &c, NULL);
    return EXIT_SUCCESS;

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -872,12 +872,12 @@
 #   define MP_CMP_D_C
 #   define MP_COPY_C
 #   define MP_DIV_2_C
-#   define MP_DIV_D_C
 #   define MP_EXPTMOD_C
 #   define MP_INIT_MULTI_C
 #   define MP_KRONECKER_C
 #   define MP_MULMOD_C
 #   define MP_SET_C
+#   define MP_SET_I32_C
 #   define MP_SQRMOD_C
 #   define MP_SUB_D_C
 #   define MP_ZERO_C


### PR DESCRIPTION
Bugfix regarding issue #486.

I cannot imagine how that issue might be exploited but because I cannot imagine it doesn't mean there is *no* way at all.

 - check that parameter `prime` is odd and `> 2`
 - the check if parameter `prime` is congruent to 3 mod 4 is done at bit-level now (which makes that check constant time, too)
 - variables `M`, `s`, and `i` changed to native signed integer `int` (values cannot exceed `INT_MAX` )
 - ( #486 ) check for `(Z|prime) == 0` in the first loop and return `MP_VAL` in that case. Although if `prime` (p) is an odd prime `Jacobi(Z|p) == 0` for `Z \cong 0 (mod p)` there is at least one non-quadratic residue before `Z>=p` if `p` is an odd prime, hence no false positives. 
 - ( #486 )  check condition `M < i` in the loop searching for smallest `0 < i < M` for  `t^(2^i)`

The extra checks are cheap and the function itself should even be a little bit faster together with less need for stack and heap with the other changes.

I did not pick any reviewer explicitly because of the current situation and its accompanying mess but I would appreciate it highly if somebody would take a look. Thank's!