### PR TITLE
enable building dll's using makefile.msvc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.gcda
 *.gcno
 *.gcov
+*.dll
+*.exp
+*.pdb
 *.lib
 *.tmp
 [Dd]ebug/

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -12,13 +12,16 @@
 #The following can be overridden from command line e.g. make -f makefile.msvc CC=gcc ARFLAGS=rcs
 PREFIX    = c:\devel
 CFLAGS    = /Ox
+LDFLAGS   =
 
 #Compilation flags
 LTM_CFLAGS  = /nologo /I./ /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D__STDC_WANT_SECURE_LIB__=1 /D_CRT_HAS_CXX17=0 /Wall /wd4146 /wd4127 /wd4668 /wd4710 /wd4711 /wd4820 /wd5045 /WX $(CFLAGS)
-LTM_LDFLAGS = advapi32.lib
+LTM_LDFLAGS = $(LDFLAGS) advapi32.lib
 
-#Libraries to be created (this makefile builds only static libraries)
-LIBMAIN_S =tommath.lib
+#Libraries to be created
+LIBMAIN_S = tommath.lib
+LIBMAIN_I = tommath.dll.lib
+LIBMAIN_D = tommath.dll
 
 #List of objects to compile (all goes to tommath.lib)
 OBJECTS=mp_2expt.obj mp_abs.obj mp_add.obj mp_add_d.obj mp_addmod.obj mp_and.obj mp_clamp.obj mp_clear.obj mp_clear_multi.obj \
@@ -62,12 +65,16 @@ $(OBJECTS): $(HEADERS)
 $(LIBMAIN_S): $(OBJECTS)
 	lib /out:$(LIBMAIN_S) $(OBJECTS)
 
+#Create DLL + import library tommath.dll.lib
+$(LIBMAIN_D) $(LIBMAIN_I): $(OBJECTS) tommath.def
+	link /dll /out:$(LIBMAIN_D) /implib:$(LIBMAIN_I) /def:tommath.def $(LTM_LDFLAGS) $(OBJECTS)
+
 #Build test suite
 test.exe: $(LIBMAIN_S) demo/shared.obj demo/test.obj
 	cl $(LTM_CFLAGS) $(TOBJECTS) $(LIBMAIN_S) $(LTM_LDFLAGS) demo/shared.c demo/test.c /Fe$@
 	@echo NOTICE: start the tests by launching test.exe
 
-all: $(LIBMAIN_S) test.exe
+all: $(LIBMAIN_S) test.exe $(LIBMAIN_D)
 
 tune: $(LIBMAIN_S)
 	$(MAKE) -C etc tune
@@ -77,9 +84,11 @@ clean:
 	@-cmd /c del /Q /S *.OBJ *.LIB *.EXE *.DLL 2>nul
 
 #Install the library + headers
-install: $(LIBMAIN_S)
+install: $(LIBMAIN_S) $(LIBMAIN_I) $(LIBMAIN_D)
 	cmd /c if not exist "$(PREFIX)\bin" mkdir "$(PREFIX)\bin"
 	cmd /c if not exist "$(PREFIX)\lib" mkdir "$(PREFIX)\lib"
 	cmd /c if not exist "$(PREFIX)\include" mkdir "$(PREFIX)\include"
 	copy /Y $(LIBMAIN_S) "$(PREFIX)\lib"
+	copy /Y $(LIBMAIN_I) "$(PREFIX)\lib"
+	copy /Y $(LIBMAIN_D) "$(PREFIX)\bin"
 	copy /Y tommath*.h "$(PREFIX)\include"

--- a/s_mp_rand_platform.c
+++ b/s_mp_rand_platform.c
@@ -14,6 +14,13 @@ static mp_err s_read_arc4random(void *p, size_t n)
    arc4random_buf(p, n);
    return MP_OKAY;
 }
+#else
+static mp_err s_read_arc4random(void *p, size_t n)
+{
+   (void)p;
+   (void)n;
+   return MP_ERR;
+}
 #endif
 
 #if defined(_WIN32)
@@ -72,6 +79,15 @@ static mp_err s_read_getrandom(void *p, size_t n)
 #endif
 #endif
 
+#ifndef S_READ_GETRANDOM_C
+static mp_err s_read_getrandom(void *p, size_t n)
+{
+   (void)p;
+   (void)n;
+   return MP_ERR;
+}
+#endif
+
 /* We assume all platforms besides windows provide "/dev/urandom".
  * In case yours doesn't, define MP_NO_DEV_URANDOM at compile-time.
  */
@@ -109,6 +125,13 @@ static mp_err s_read_urandom(void *p, size_t n)
 
    close(fd);
    return MP_OKAY;
+}
+#else
+static mp_err s_read_urandom(void *p, size_t n)
+{
+   (void)p;
+   (void)n;
+   return MP_ERR;
 }
 #endif
 

--- a/tommath.def
+++ b/tommath.def
@@ -89,6 +89,7 @@ EXPORTS
     mp_radix_size
     mp_radix_size_overestimate
     mp_rand
+    mp_rand_source
     mp_read_radix
     mp_reduce
     mp_reduce_2k
@@ -124,3 +125,7 @@ EXPORTS
     mp_unpack
     mp_xor
     mp_zero
+    MP_MUL_KARATSUBA_CUTOFF
+    MP_SQR_KARATSUBA_CUTOFF
+    MP_MUL_TOOM_CUTOFF
+    MP_SQR_TOOM_CUTOFF


### PR DESCRIPTION
- This pr enables building a dll with `makefile.msvc`
- the dll + static library are built
- the tests are **not** built for the shared libraries, because the tests use private symbols (that are not exported)
See https://github.com/libtom/libtommath/issues/488#issuecomment-691113893 for the link error.


@sjaeckel @nijtmans