### PR TITLE
Follow-up of #489

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.gcda
 *.gcno
 *.gcov
+*.dll
+*.exp
+*.pdb
 *.lib
 *.tmp
 [Dd]ebug/

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,13 @@ matrix:
           packages:
             - astyle
 
+    # Check public symbols of dynamic libraries
+    - env: BUILDOPTIONS='--symbols'
+      addons:
+        apt:
+          packages:
+            - libtool-bin
+
     # Run always with valgrind (no sanitizer, but debug info)
     - env: COMPILE_DEBUG=1 BUILDOPTIONS='--with-cc=gcc-4.9 --with-m64 --with-valgrind'
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@
 #                                                                           #
 #############################################################################
 
-# Run the tests based on Ubuntu 16.04
-dist: xenial
+# The Ubuntu version we're going to use to run the tests
+dist: bionic
 
 # Compilation failures are in gcc_errors_*.log
 # Failed tests in test_*.log
@@ -80,21 +80,18 @@ matrix:
             - libtool-bin
 
     # Run always with valgrind (no sanitizer, but debug info)
-    - env: COMPILE_DEBUG=1 BUILDOPTIONS='--with-cc=gcc-4.9 --with-m64 --with-valgrind'
-      addons:
-        apt:
-          packages:
-            - gcc-4.9
+    - env: COMPILE_DEBUG=1 BUILDOPTIONS='--with-cc=gcc --with-m64 --with-valgrind'
 
     # Shared library build
     - env: COMPILE_LTO=1 BUILDOPTIONS='--with-cc=gcc --make-option=-f --make-option=makefile.shared'
       addons:
         apt:
           packages:
+            - gcc-8
             - libtool-bin
 
     # GCC for the 32-bit architecture (no valgrind)
-    - env: BUILDOPTIONS='--with-cc=gcc-5 --with-m32'
+    - env: BUILDOPTIONS='--with-cc=gcc --with-m32'
       addons:
         apt:
           packages:
@@ -122,9 +119,9 @@ matrix:
 
     # GCC for the x86-64 architecture testing against a different Bigint-implementation
     # with 333333 different inputs.
-    #- env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --with-travis-valgrind'
+    #- env: BUILDOPTIONS='--with-cc=gcc --test-vs-mtest=333333 --with-travis-valgrind'
     # ...  and a better random source.
-    - env: BUILDOPTIONS='--with-cc=gcc-5 --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
+    - env: BUILDOPTIONS='--with-cc=gcc --test-vs-mtest=333333 --mtest-real-rand --with-travis-valgrind'
 
     # clang for the x86-64 architecture testing against a different Bigint-implementation
     # with 333333 different inputs
@@ -135,7 +132,7 @@ matrix:
     # GCC for the x64_32 architecture (32-bit longs and 32-bit pointers)
     # TODO: Probably not possible to run anything in x32 in Travis
     #       but needs to be checked to be sure.
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --with-mx32'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc --with-mx32'
       addons:
         apt:
           packages:
@@ -143,12 +140,12 @@ matrix:
             - gcc-multilib
 
     # GCC for the x86-64 architecture (64-bit longs and 64-bit pointers)
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --with-m64 --with-travis-valgrind'
-    - env: BUILDOPTIONS='--with-cc=gcc-4.7 --with-m64 --with-travis-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc --with-m64 --with-travis-valgrind'
+    - env: BUILDOPTIONS='--with-cc=gcc-5 --with-m64 --with-travis-valgrind'
       addons:
         apt:
           packages:
-            - gcc-4.7
+            - gcc-5
     - env: BUILDOPTIONS='--with-cc=gcc-4.8 --with-m64 --with-travis-valgrind'
       addons:
         apt:
@@ -161,6 +158,21 @@ matrix:
     - env: SANITIZER=1 CONV_WARNINGS=strict BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_USE_MEMOPS --with-m64 --with-travis-valgrind'
     - env: SANITIZER=1 CONV_WARNINGS=strict BUILDOPTIONS='--with-cc=clang-7 --c89 --with-m64 --with-travis-valgrind'
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind --cflags=-DMP_PREC=MP_MIN_PREC'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-10 --with-m64 --with-travis-valgrind'
+      addons:
+        apt:
+          packages:
+            - clang-10
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-9 --with-m64 --with-travis-valgrind'
+      addons:
+        apt:
+          packages:
+            - clang-9
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-8 --with-m64 --with-travis-valgrind'
+      addons:
+        apt:
+          packages:
+            - clang-8
     - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-6.0 --with-m64 --with-travis-valgrind'
       addons:
         apt:
@@ -178,18 +190,18 @@ matrix:
             - clang-4.0
 
     # Link time optimization
-    - env: SANITIZER=1 COMPILE_LTO=1 BUILDOPTIONS='--with-cc=gcc-5 --with-m64 --with-travis-valgrind'
+    - env: SANITIZER=1 COMPILE_LTO=1 BUILDOPTIONS='--with-cc=gcc --with-m64 --with-travis-valgrind'
     #- env: SANITIZER=1 COMPILE_LTO=1 BUILDOPTIONS='--with-cc=clang-7 --with-m64 --with-travis-valgrind'
 
     # GCC for the x86-64 architecture with restricted limb sizes
     # formerly started with the option "--with-low-mp" to testme.sh
     # but testing all three in one run took to long and timed out.
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_16BIT --with-travis-valgrind'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc-5 --cflags=-DMP_32BIT --with-travis-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc --cflags=-DMP_16BIT --with-travis-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=gcc --cflags=-DMP_32BIT --with-travis-valgrind'
 
     # clang for the x86-64 architecture with restricted limb sizes
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_16BIT --with-travis-valgrind'
-    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang-7 --cflags=-DMP_32BIT --with-travis-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang --cflags=-DMP_16BIT --with-travis-valgrind'
+    - env: SANITIZER=1 BUILDOPTIONS='--with-cc=clang --cflags=-DMP_32BIT --with-travis-valgrind'
 
 # Notifications go to
 # An email address is also possible.

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,13 @@ matrix:
           packages:
             - gcc-4.9
 
+    # Shared library build
+    - env: COMPILE_LTO=1 BUILDOPTIONS='--with-cc=gcc --make-option=-f --make-option=makefile.shared'
+      addons:
+        apt:
+          packages:
+            - libtool-bin
+
     # GCC for the 32-bit architecture (no valgrind)
     - env: BUILDOPTIONS='--with-cc=gcc-5 --with-m32'
       addons:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ build_script:
         if "Visual Studio 2017"=="%APPVEYOR_BUILD_WORKER_IMAGE%" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
         if "Visual Studio 2015"=="%APPVEYOR_BUILD_WORKER_IMAGE%" call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
         if "Visual Studio 2015"=="%APPVEYOR_BUILD_WORKER_IMAGE%" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
-        nmake -f makefile.msvc all
+        nmake -f makefile.msvc all CFLAGS="/Ox /MD"
 test_script:
 - cmd: test.exe
+- cmd: test_dll.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,9 @@ build_script:
         if "Visual Studio 2017"=="%APPVEYOR_BUILD_WORKER_IMAGE%" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
         if "Visual Studio 2015"=="%APPVEYOR_BUILD_WORKER_IMAGE%" call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
         if "Visual Studio 2015"=="%APPVEYOR_BUILD_WORKER_IMAGE%" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
-        nmake -f makefile.msvc all CFLAGS="/Ox /MD"
+        nmake -f makefile.msvc test.exe
+        nmake -f makefile.msvc clean-obj
+        nmake -f makefile.msvc test_dll.exe CFLAGS="/Ox /MD /DLTM_TEST_DYNAMIC"
 test_script:
 - cmd: test.exe
 - cmd: test_dll.exe

--- a/demo/s_mp_rand_jenkins.c
+++ b/demo/s_mp_rand_jenkins.c
@@ -5,6 +5,9 @@
 
 /* Bob Jenkins' http://burtleburtle.net/bob/rand/smallprng.html */
 /* Chosen for speed and a good "mix" */
+
+/* TODO: jenkins prng is not thread safe as of now */
+
 typedef struct {
    uint64_t a;
    uint64_t b;
@@ -25,7 +28,7 @@ static uint64_t s_rand_jenkins_val(void)
    return jenkins_x.d;
 }
 
-void s_mp_rand_jenkins_init(uint64_t seed)
+static void s_mp_rand_jenkins_init(uint64_t seed)
 {
    int i;
    jenkins_x.a = 0xF1EA5EEDuL;
@@ -35,7 +38,7 @@ void s_mp_rand_jenkins_init(uint64_t seed)
    }
 }
 
-mp_err s_mp_rand_jenkins(void *p, size_t n)
+static mp_err s_mp_rand_jenkins(void *p, size_t n)
 {
    char *q = (char *)p;
    while (n > 0u) {

--- a/demo/test.c
+++ b/demo/test.c
@@ -1,10 +1,13 @@
 #include <inttypes.h>
 #include "shared.h"
 
+#define S_MP_RAND_JENKINS_C
+#include "s_mp_rand_jenkins.c"
+
 static long rand_long(void)
 {
    long x;
-   if (s_mp_rand_source(&x, sizeof(x)) != MP_OKAY) {
+   if (s_mp_rand_jenkins(&x, sizeof(x)) != MP_OKAY) {
       fprintf(stderr, "s_mp_rand_source failed\n");
       exit(EXIT_FAILURE);
    }
@@ -14,7 +17,7 @@ static long rand_long(void)
 static int rand_int(void)
 {
    int x;
-   if (s_mp_rand_source(&x, sizeof(x)) != MP_OKAY) {
+   if (s_mp_rand_jenkins(&x, sizeof(x)) != MP_OKAY) {
       fprintf(stderr, "s_mp_rand_source failed\n");
       exit(EXIT_FAILURE);
    }
@@ -24,7 +27,7 @@ static int rand_int(void)
 static int32_t rand_int32(void)
 {
    int32_t x;
-   if (s_mp_rand_source(&x, sizeof(x)) != MP_OKAY) {
+   if (s_mp_rand_jenkins(&x, sizeof(x)) != MP_OKAY) {
       fprintf(stderr, "s_mp_rand_source failed\n");
       exit(EXIT_FAILURE);
    }
@@ -34,7 +37,7 @@ static int32_t rand_int32(void)
 static int64_t rand_int64(void)
 {
    int64_t x;
-   if (s_mp_rand_source(&x, sizeof(x)) != MP_OKAY) {
+   if (s_mp_rand_jenkins(&x, sizeof(x)) != MP_OKAY) {
       fprintf(stderr, "s_mp_rand_source failed\n");
       exit(EXIT_FAILURE);
    }
@@ -2134,15 +2137,20 @@ LBL_ERR:
    return EXIT_FAILURE;
 }
 
+#ifndef LTM_TEST_DYNAMIC
+#define ONLY_PUBLIC_API_C
+#endif
+
 static int unit_tests(int argc, char **argv)
 {
    static const struct {
       const char *name;
       int (*fn)(void);
    } test[] = {
-#define T0(n)           { #n, test_##n }
-#define T1(n, o)        { #n, MP_HAS(o) ? test_##n : NULL }
-#define T2(n, o1, o2)   { #n, (MP_HAS(o1) && MP_HAS(o2)) ? test_##n : NULL }
+#define T0(n)              { #n, test_##n }
+#define T1(n, o)           { #n, MP_HAS(o) ? test_##n : NULL }
+#define T2(n, o1, o2)      { #n, (MP_HAS(o1) && MP_HAS(o2)) ? test_##n : NULL }
+#define T3(n, o1, o2, o3)  { #n, (MP_HAS(o1) && MP_HAS(o2) && MP_HAS(o3)) ? test_##n : NULL }
       T0(feature_detection),
       T0(trivial_stuff),
       T2(mp_get_set_i32, MP_GET_I32, MP_GET_MAG_U32),
@@ -2151,7 +2159,7 @@ static int unit_tests(int argc, char **argv)
       T1(mp_cnt_lsb, MP_CNT_LSB),
       T1(mp_complement, MP_COMPLEMENT),
       T1(mp_decr, MP_SUB_D),
-      T1(s_mp_div_3, S_MP_DIV_3),
+      T2(s_mp_div_3, ONLY_PUBLIC_API, S_MP_DIV_3),
       T1(mp_dr_reduce, MP_DR_REDUCE),
       T2(mp_pack_unpack,MP_PACK, MP_UNPACK),
       T2(mp_fread_fwrite, MP_FREAD, MP_FWRITE),
@@ -2176,7 +2184,7 @@ static int unit_tests(int argc, char **argv)
       T1(mp_reduce_2k, MP_REDUCE_2K),
       T1(mp_reduce_2k_l, MP_REDUCE_2K_L),
       T1(mp_radix_size, MP_RADIX_SIZE),
-      T1(s_mp_radix_size_overestimate, S_MP_RADIX_SIZE_OVERESTIMATE),
+      T2(s_mp_radix_size_overestimate, ONLY_PUBLIC_API, S_MP_RADIX_SIZE_OVERESTIMATE),
 #if defined(MP_HAS_SET_DOUBLE)
       T1(mp_set_double, MP_SET_DOUBLE),
 #endif
@@ -2184,13 +2192,14 @@ static int unit_tests(int argc, char **argv)
       T2(mp_sqrt, MP_SQRT, MP_ROOT_N),
       T1(mp_sqrtmod_prime, MP_SQRTMOD_PRIME),
       T1(mp_xor, MP_XOR),
-      T2(s_mp_div_recursive, S_MP_DIV_RECURSIVE, S_MP_DIV_SCHOOL),
-      T2(s_mp_div_small, S_MP_DIV_SMALL, S_MP_DIV_SCHOOL),
-      T1(s_mp_mul_balance, S_MP_MUL_BALANCE),
-      T1(s_mp_mul_karatsuba, S_MP_MUL_KARATSUBA),
-      T1(s_mp_sqr_karatsuba, S_MP_SQR_KARATSUBA),
-      T1(s_mp_mul_toom, S_MP_MUL_TOOM),
-      T1(s_mp_sqr_toom, S_MP_SQR_TOOM)
+      T3(s_mp_div_recursive, ONLY_PUBLIC_API, S_MP_DIV_RECURSIVE, S_MP_DIV_SCHOOL),
+      T3(s_mp_div_small, ONLY_PUBLIC_API, S_MP_DIV_SMALL, S_MP_DIV_SCHOOL),
+      T2(s_mp_mul_balance, ONLY_PUBLIC_API, S_MP_MUL_BALANCE),
+      T2(s_mp_mul_karatsuba, ONLY_PUBLIC_API, S_MP_MUL_KARATSUBA),
+      T2(s_mp_sqr_karatsuba, ONLY_PUBLIC_API, S_MP_SQR_KARATSUBA),
+      T2(s_mp_mul_toom, ONLY_PUBLIC_API, S_MP_MUL_TOOM),
+      T2(s_mp_sqr_toom, ONLY_PUBLIC_API, S_MP_SQR_TOOM)
+#undef T3
 #undef T2
 #undef T1
    };

--- a/etc/makefile
+++ b/etc/makefile
@@ -1,5 +1,4 @@
-LTM_CFLAGS += -Wall -W -Wextra -Wshadow -O3 -I../
-LTM_CFLAGS += $(CFLAGS)
+LTM_TUNE_CFLAGS = $(CFLAGS) $(LTM_CFLAGS) -Wall -W -Wextra -Wshadow -O3 -I../
 
 # default lib name (requires install with root)
 # LIBNAME=-ltommath
@@ -9,31 +8,31 @@ LIBNAME=../libtommath.a
 
 #provable primes
 pprime: pprime.o
-	$(CC) $(LTM_CFLAGS) pprime.o $(LIBNAME) -o pprime
+	$(CC) $(LTM_TUNE_CFLAGS) pprime.o $(LIBNAME) -o pprime
 
 # portable [well requires clock()] tuning app
 tune: tune.o
-	$(CC) $(LTM_CFLAGS) tune.o $(LIBNAME) -o tune
+	$(CC) $(LTM_TUNE_CFLAGS) tune.o $(LIBNAME) -o tune
 	./tune_it.sh
 
 test_standalone: tune.o
 	# The benchmark program works as a testtool, too
-	$(CC) $(LTM_CFLAGS) tune.o $(LIBNAME) -o test
+	$(CC) $(LTM_TUNE_CFLAGS) tune.o $(LIBNAME) -o test
 
 # spits out mersenne primes
 mersenne: mersenne.o
-	$(CC) $(LTM_CFLAGS) mersenne.o $(LIBNAME) -o mersenne
+	$(CC) $(LTM_TUNE_CFLAGS) mersenne.o $(LIBNAME) -o mersenne
 
 # finds DR safe primes for the given config
 drprime: drprime.o
-	$(CC) $(LTM_CFLAGS) drprime.o $(LIBNAME) -o drprime
+	$(CC) $(LTM_TUNE_CFLAGS) drprime.o $(LIBNAME) -o drprime
 
 # finds 2k safe primes for the given config
 2kprime: 2kprime.o
-	$(CC) $(LTM_CFLAGS) 2kprime.o $(LIBNAME) -o 2kprime
+	$(CC) $(LTM_TUNE_CFLAGS) 2kprime.o $(LIBNAME) -o 2kprime
 
 mont: mont.o
-	$(CC) $(LTM_CFLAGS) mont.o $(LIBNAME) -o mont
+	$(CC) $(LTM_TUNE_CFLAGS) mont.o $(LIBNAME) -o mont
 
 
 clean:

--- a/etc/tune.c
+++ b/etc/tune.c
@@ -2,11 +2,13 @@
  *
  * Tom St Denis, tstdenis82@gmail.com
  */
-#include "../tommath.h"
-#include "../tommath_private.h"
+#include "tommath_private.h"
 #include <time.h>
 #include <inttypes.h>
 #include <errno.h>
+
+#define S_MP_RAND_JENKINS_C
+#include "../demo/s_mp_rand_jenkins.c"
 
 /*
    Please take in mind that both multiplicands are of the same size. The balancing

--- a/helper.pl
+++ b/helper.pl
@@ -436,6 +436,10 @@ sub generate_def {
 ;
 EXPORTS
     $files
+    MP_MUL_KARATSUBA_CUTOFF
+    MP_SQR_KARATSUBA_CUTOFF
+    MP_MUL_TOOM_CUTOFF
+    MP_SQR_TOOM_CUTOFF
 ";
     return 0;
 }

--- a/libtommath_VS2008.vcproj
+++ b/libtommath_VS2008.vcproj
@@ -897,10 +897,6 @@
 			>
 		</File>
 		<File
-			RelativePath="s_mp_rand_jenkins.c"
-			>
-		</File>
-		<File
 			RelativePath="s_mp_rand_platform.c"
 			>
 		</File>

--- a/libtommath_VS2008.vcproj
+++ b/libtommath_VS2008.vcproj
@@ -649,6 +649,10 @@
 			>
 		</File>
 		<File
+			RelativePath="mp_rand_source.c"
+			>
+		</File>
+		<File
 			RelativePath="mp_read_radix.c"
 			>
 		</File>

--- a/makefile
+++ b/makefile
@@ -48,8 +48,8 @@ s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_b
 s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o \
 s_mp_mul_balance.o s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o \
 s_mp_mul_toom.o s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o \
-s_mp_radix_size_overestimate.o s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o \
-s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
+s_mp_radix_size_overestimate.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o s_mp_sqr_karatsuba.o \
+s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
 
 #END_INS
 
@@ -104,7 +104,7 @@ timing: demo/timing.c $(LIBNAME)
 	$(CC) $(LTM_CFLAGS) $^ $(LTM_LFLAGS) -o timing
 
 tune: $(LIBNAME)
-	$(MAKE) -C etc tune CFLAGS="$(LTM_CFLAGS)"
+	$(MAKE) -C etc tune CFLAGS="$(LTM_CFLAGS) -I../"
 	$(MAKE)
 
 # You have to create a file .coveralls.yml with the content "repo_token: <the token>"

--- a/makefile
+++ b/makefile
@@ -38,18 +38,18 @@ mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o 
 mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
 mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
 mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_radix_size.o \
-mp_radix_size_overestimate.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o mp_reduce_2k_l.o \
-mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o mp_reduce_setup.o \
-mp_root_n.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o mp_set_l.o \
-mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_shrink.o mp_signed_rsh.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o \
-mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o \
-mp_zero.o s_mp_add.o s_mp_copy_digs.o s_mp_div_3.o s_mp_div_recursive.o s_mp_div_school.o s_mp_div_small.o \
-s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod.o s_mp_invmod_odd.o s_mp_log.o \
-s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o s_mp_mul_balance.o \
-s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o s_mp_mul_toom.o \
-s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o s_mp_radix_size_overestimate.o \
-s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o s_mp_sqr_karatsuba.o s_mp_sqr_toom.o \
-s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
+mp_radix_size_overestimate.o mp_rand.o mp_rand_source.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
+mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
+mp_reduce_setup.o mp_root_n.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
+mp_set_l.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_shrink.o mp_signed_rsh.o mp_sqrmod.o mp_sqrt.o \
+mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o \
+mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_copy_digs.o s_mp_div_3.o s_mp_div_recursive.o \
+s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod.o \
+s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o \
+s_mp_mul_balance.o s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o \
+s_mp_mul_toom.o s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o \
+s_mp_radix_size_overestimate.o s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o \
+s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
 
 #END_INS
 

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -40,18 +40,18 @@ mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o 
 mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
 mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
 mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_radix_size.o \
-mp_radix_size_overestimate.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o mp_reduce_2k_l.o \
-mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o mp_reduce_setup.o \
-mp_root_n.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o mp_set_l.o \
-mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_shrink.o mp_signed_rsh.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o \
-mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o \
-mp_zero.o s_mp_add.o s_mp_copy_digs.o s_mp_div_3.o s_mp_div_recursive.o s_mp_div_school.o s_mp_div_small.o \
-s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod.o s_mp_invmod_odd.o s_mp_log.o \
-s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o s_mp_mul_balance.o \
-s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o s_mp_mul_toom.o \
-s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o s_mp_radix_size_overestimate.o \
-s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o s_mp_sqr_karatsuba.o s_mp_sqr_toom.o \
-s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
+mp_radix_size_overestimate.o mp_rand.o mp_rand_source.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
+mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
+mp_reduce_setup.o mp_root_n.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
+mp_set_l.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_shrink.o mp_signed_rsh.o mp_sqrmod.o mp_sqrt.o \
+mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o \
+mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_copy_digs.o s_mp_div_3.o s_mp_div_recursive.o \
+s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod.o \
+s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o \
+s_mp_mul_balance.o s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o \
+s_mp_mul_toom.o s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o \
+s_mp_radix_size_overestimate.o s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o \
+s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h tommath_cutoffs.h $(HEADERS_PUB)

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -50,8 +50,8 @@ s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_b
 s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o \
 s_mp_mul_balance.o s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o \
 s_mp_mul_toom.o s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o \
-s_mp_radix_size_overestimate.o s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o \
-s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
+s_mp_radix_size_overestimate.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o s_mp_sqr_karatsuba.o \
+s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h tommath_cutoffs.h $(HEADERS_PUB)

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -71,13 +71,13 @@ $(LIBMAIN_D) $(LIBMAIN_I): $(OBJECTS) tommath.def
 
 #Build test suite
 test.exe: $(LIBMAIN_S) demo/shared.obj demo/test.obj
-       link $(TOBJECTS) $(LTM_LDFLAGS) $? /out:$@
+	link $(TOBJECTS) $(LTM_LDFLAGS) $? /out:$@
 	@echo NOTICE: start the tests by launching test.exe
 
 #Build test suite for dll
 test_dll.exe: $(LIBMAIN_I) demo/shared.obj demo/test.obj
-       link $(TOBJECTS) $(LTM_LDFLAGS) $? /out:$@
-       @echo NOTICE: start the tests by launching test_dll.exe
+	link $(TOBJECTS) $(LTM_LDFLAGS) $? /out:$@
+	@echo NOTICE: start the tests by launching test_dll.exe
 
 all: $(LIBMAIN_S) test.exe $(LIBMAIN_D) test_dll.exe
 
@@ -85,8 +85,11 @@ tune: $(LIBMAIN_S)
 	$(MAKE) -C etc tune
 	$(MAKE)
 
-clean:
-	@-cmd /c del /Q /S *.OBJ *.LIB *.EXE *.DLL 2>nul
+clean-obj:
+	@-cmd /c del /Q /S *.OBJ 2>nul
+
+clean: clean-obj
+	@-cmd /c del /Q /S *.LIB *.EXE *.DLL 2>nul
 
 #Install the library + headers
 install: $(LIBMAIN_S) $(LIBMAIN_I) $(LIBMAIN_D)

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -36,18 +36,18 @@ mp_montgomery_calc_normalization.obj mp_montgomery_reduce.obj mp_montgomery_setu
 mp_mul_2d.obj mp_mul_d.obj mp_mulmod.obj mp_neg.obj mp_or.obj mp_pack.obj mp_pack_count.obj mp_prime_fermat.obj \
 mp_prime_frobenius_underwood.obj mp_prime_is_prime.obj mp_prime_miller_rabin.obj mp_prime_next_prime.obj \
 mp_prime_rabin_miller_trials.obj mp_prime_rand.obj mp_prime_strong_lucas_selfridge.obj mp_radix_size.obj \
-mp_radix_size_overestimate.obj mp_rand.obj mp_read_radix.obj mp_reduce.obj mp_reduce_2k.obj mp_reduce_2k_l.obj \
-mp_reduce_2k_setup.obj mp_reduce_2k_setup_l.obj mp_reduce_is_2k.obj mp_reduce_is_2k_l.obj mp_reduce_setup.obj \
-mp_root_n.obj mp_rshd.obj mp_sbin_size.obj mp_set.obj mp_set_double.obj mp_set_i32.obj mp_set_i64.obj mp_set_l.obj \
-mp_set_u32.obj mp_set_u64.obj mp_set_ul.obj mp_shrink.obj mp_signed_rsh.obj mp_sqrmod.obj mp_sqrt.obj mp_sqrtmod_prime.obj \
-mp_sub.obj mp_sub_d.obj mp_submod.obj mp_to_radix.obj mp_to_sbin.obj mp_to_ubin.obj mp_ubin_size.obj mp_unpack.obj mp_xor.obj \
-mp_zero.obj s_mp_add.obj s_mp_copy_digs.obj s_mp_div_3.obj s_mp_div_recursive.obj s_mp_div_school.obj s_mp_div_small.obj \
-s_mp_exptmod.obj s_mp_exptmod_fast.obj s_mp_get_bit.obj s_mp_invmod.obj s_mp_invmod_odd.obj s_mp_log.obj \
-s_mp_log_2expt.obj s_mp_log_d.obj s_mp_montgomery_reduce_comba.obj s_mp_mul.obj s_mp_mul_balance.obj \
-s_mp_mul_comba.obj s_mp_mul_high.obj s_mp_mul_high_comba.obj s_mp_mul_karatsuba.obj s_mp_mul_toom.obj \
-s_mp_prime_is_divisible.obj s_mp_prime_tab.obj s_mp_radix_map.obj s_mp_radix_size_overestimate.obj \
-s_mp_rand_jenkins.obj s_mp_rand_platform.obj s_mp_sqr.obj s_mp_sqr_comba.obj s_mp_sqr_karatsuba.obj s_mp_sqr_toom.obj \
-s_mp_sub.obj s_mp_zero_buf.obj s_mp_zero_digs.obj
+mp_radix_size_overestimate.obj mp_rand.obj mp_rand_source.obj mp_read_radix.obj mp_reduce.obj mp_reduce_2k.obj \
+mp_reduce_2k_l.obj mp_reduce_2k_setup.obj mp_reduce_2k_setup_l.obj mp_reduce_is_2k.obj mp_reduce_is_2k_l.obj \
+mp_reduce_setup.obj mp_root_n.obj mp_rshd.obj mp_sbin_size.obj mp_set.obj mp_set_double.obj mp_set_i32.obj mp_set_i64.obj \
+mp_set_l.obj mp_set_u32.obj mp_set_u64.obj mp_set_ul.obj mp_shrink.obj mp_signed_rsh.obj mp_sqrmod.obj mp_sqrt.obj \
+mp_sqrtmod_prime.obj mp_sub.obj mp_sub_d.obj mp_submod.obj mp_to_radix.obj mp_to_sbin.obj mp_to_ubin.obj mp_ubin_size.obj \
+mp_unpack.obj mp_xor.obj mp_zero.obj s_mp_add.obj s_mp_copy_digs.obj s_mp_div_3.obj s_mp_div_recursive.obj \
+s_mp_div_school.obj s_mp_div_small.obj s_mp_exptmod.obj s_mp_exptmod_fast.obj s_mp_get_bit.obj s_mp_invmod.obj \
+s_mp_invmod_odd.obj s_mp_log.obj s_mp_log_2expt.obj s_mp_log_d.obj s_mp_montgomery_reduce_comba.obj s_mp_mul.obj \
+s_mp_mul_balance.obj s_mp_mul_comba.obj s_mp_mul_high.obj s_mp_mul_high_comba.obj s_mp_mul_karatsuba.obj \
+s_mp_mul_toom.obj s_mp_prime_is_divisible.obj s_mp_prime_tab.obj s_mp_radix_map.obj \
+s_mp_radix_size_overestimate.obj s_mp_rand_jenkins.obj s_mp_rand_platform.obj s_mp_sqr.obj s_mp_sqr_comba.obj \
+s_mp_sqr_karatsuba.obj s_mp_sqr_toom.obj s_mp_sub.obj s_mp_zero_buf.obj s_mp_zero_digs.obj
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h tommath_cutoffs.h $(HEADERS_PUB)

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -46,8 +46,8 @@ s_mp_div_school.obj s_mp_div_small.obj s_mp_exptmod.obj s_mp_exptmod_fast.obj s_
 s_mp_invmod_odd.obj s_mp_log.obj s_mp_log_2expt.obj s_mp_log_d.obj s_mp_montgomery_reduce_comba.obj s_mp_mul.obj \
 s_mp_mul_balance.obj s_mp_mul_comba.obj s_mp_mul_high.obj s_mp_mul_high_comba.obj s_mp_mul_karatsuba.obj \
 s_mp_mul_toom.obj s_mp_prime_is_divisible.obj s_mp_prime_tab.obj s_mp_radix_map.obj \
-s_mp_radix_size_overestimate.obj s_mp_rand_jenkins.obj s_mp_rand_platform.obj s_mp_sqr.obj s_mp_sqr_comba.obj \
-s_mp_sqr_karatsuba.obj s_mp_sqr_toom.obj s_mp_sub.obj s_mp_zero_buf.obj s_mp_zero_digs.obj
+s_mp_radix_size_overestimate.obj s_mp_rand_platform.obj s_mp_sqr.obj s_mp_sqr_comba.obj s_mp_sqr_karatsuba.obj \
+s_mp_sqr_toom.obj s_mp_sub.obj s_mp_zero_buf.obj s_mp_zero_digs.obj
 
 HEADERS_PUB=tommath.h
 HEADERS=tommath_private.h tommath_class.h tommath_superclass.h tommath_cutoffs.h $(HEADERS_PUB)

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -71,10 +71,15 @@ $(LIBMAIN_D) $(LIBMAIN_I): $(OBJECTS) tommath.def
 
 #Build test suite
 test.exe: $(LIBMAIN_S) demo/shared.obj demo/test.obj
-	cl $(LTM_CFLAGS) $(TOBJECTS) $(LIBMAIN_S) $(LTM_LDFLAGS) demo/shared.c demo/test.c /Fe$@
+       link $(TOBJECTS) $(LTM_LDFLAGS) $? /out:$@
 	@echo NOTICE: start the tests by launching test.exe
 
-all: $(LIBMAIN_S) test.exe $(LIBMAIN_D)
+#Build test suite for dll
+test_dll.exe: $(LIBMAIN_I) demo/shared.obj demo/test.obj
+       link $(TOBJECTS) $(LTM_LDFLAGS) $? /out:$@
+       @echo NOTICE: start the tests by launching test_dll.exe
+
+all: $(LIBMAIN_S) test.exe $(LIBMAIN_D) test_dll.exe
 
 tune: $(LIBMAIN_S)
 	$(MAKE) -C etc tune

--- a/makefile.msvc
+++ b/makefile.msvc
@@ -12,13 +12,16 @@
 #The following can be overridden from command line e.g. make -f makefile.msvc CC=gcc ARFLAGS=rcs
 PREFIX    = c:\devel
 CFLAGS    = /Ox
+LDFLAGS   =
 
 #Compilation flags
 LTM_CFLAGS  = /nologo /I./ /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D__STDC_WANT_SECURE_LIB__=1 /D_CRT_HAS_CXX17=0 /Wall /wd4146 /wd4127 /wd4668 /wd4710 /wd4711 /wd4820 /wd5045 /WX $(CFLAGS)
-LTM_LDFLAGS = advapi32.lib
+LTM_LDFLAGS = $(LDFLAGS) advapi32.lib
 
-#Libraries to be created (this makefile builds only static libraries)
-LIBMAIN_S =tommath.lib
+#Libraries to be created
+LIBMAIN_S = tommath.lib
+LIBMAIN_I = tommath.dll.lib
+LIBMAIN_D = tommath.dll
 
 #List of objects to compile (all goes to tommath.lib)
 OBJECTS=mp_2expt.obj mp_abs.obj mp_add.obj mp_add_d.obj mp_addmod.obj mp_and.obj mp_clamp.obj mp_clear.obj mp_clear_multi.obj \
@@ -62,12 +65,16 @@ $(OBJECTS): $(HEADERS)
 $(LIBMAIN_S): $(OBJECTS)
 	lib /out:$(LIBMAIN_S) $(OBJECTS)
 
+#Create DLL + import library tommath.dll.lib
+$(LIBMAIN_D) $(LIBMAIN_I): $(OBJECTS) tommath.def
+	link /dll /out:$(LIBMAIN_D) /implib:$(LIBMAIN_I) /def:tommath.def $(LTM_LDFLAGS) $(OBJECTS)
+
 #Build test suite
 test.exe: $(LIBMAIN_S) demo/shared.obj demo/test.obj
 	cl $(LTM_CFLAGS) $(TOBJECTS) $(LIBMAIN_S) $(LTM_LDFLAGS) demo/shared.c demo/test.c /Fe$@
 	@echo NOTICE: start the tests by launching test.exe
 
-all: $(LIBMAIN_S) test.exe
+all: $(LIBMAIN_S) test.exe $(LIBMAIN_D)
 
 tune: $(LIBMAIN_S)
 	$(MAKE) -C etc tune
@@ -77,9 +84,11 @@ clean:
 	@-cmd /c del /Q /S *.OBJ *.LIB *.EXE *.DLL 2>nul
 
 #Install the library + headers
-install: $(LIBMAIN_S)
+install: $(LIBMAIN_S) $(LIBMAIN_I) $(LIBMAIN_D)
 	cmd /c if not exist "$(PREFIX)\bin" mkdir "$(PREFIX)\bin"
 	cmd /c if not exist "$(PREFIX)\lib" mkdir "$(PREFIX)\lib"
 	cmd /c if not exist "$(PREFIX)\include" mkdir "$(PREFIX)\include"
 	copy /Y $(LIBMAIN_S) "$(PREFIX)\lib"
+	copy /Y $(LIBMAIN_I) "$(PREFIX)\lib"
+	copy /Y $(LIBMAIN_D) "$(PREFIX)\bin"
 	copy /Y tommath*.h "$(PREFIX)\include"

--- a/makefile.shared
+++ b/makefile.shared
@@ -35,18 +35,18 @@ mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o 
 mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
 mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
 mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_radix_size.o \
-mp_radix_size_overestimate.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o mp_reduce_2k_l.o \
-mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o mp_reduce_setup.o \
-mp_root_n.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o mp_set_l.o \
-mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_shrink.o mp_signed_rsh.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o \
-mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o \
-mp_zero.o s_mp_add.o s_mp_copy_digs.o s_mp_div_3.o s_mp_div_recursive.o s_mp_div_school.o s_mp_div_small.o \
-s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod.o s_mp_invmod_odd.o s_mp_log.o \
-s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o s_mp_mul_balance.o \
-s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o s_mp_mul_toom.o \
-s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o s_mp_radix_size_overestimate.o \
-s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o s_mp_sqr_karatsuba.o s_mp_sqr_toom.o \
-s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
+mp_radix_size_overestimate.o mp_rand.o mp_rand_source.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
+mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
+mp_reduce_setup.o mp_root_n.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
+mp_set_l.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_shrink.o mp_signed_rsh.o mp_sqrmod.o mp_sqrt.o \
+mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o \
+mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_copy_digs.o s_mp_div_3.o s_mp_div_recursive.o \
+s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod.o \
+s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o \
+s_mp_mul_balance.o s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o \
+s_mp_mul_toom.o s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o \
+s_mp_radix_size_overestimate.o s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o \
+s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
 
 #END_INS
 

--- a/makefile.shared
+++ b/makefile.shared
@@ -45,8 +45,8 @@ s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_b
 s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o \
 s_mp_mul_balance.o s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o \
 s_mp_mul_toom.o s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o \
-s_mp_radix_size_overestimate.o s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o \
-s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
+s_mp_radix_size_overestimate.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o s_mp_sqr_karatsuba.o \
+s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
 
 #END_INS
 
@@ -75,7 +75,7 @@ uninstall:
 	rm $(DESTDIR)$(LIBPATH)/pkgconfig/libtommath.pc
 
 test mtest_opponent: demo/shared.o $(LIBNAME) | demo/test.o demo/mtest_opponent.o
-	$(LTLINK) $(LTM_LDFLAGS) demo/$@.o $^ -o $@
+	$(LTLINK) $(LTM_LDFLAGS) -DLTM_TEST_DYNAMIC demo/$@.o $^ -o $@
 
 .PHONY: mtest
 mtest:

--- a/makefile.shared
+++ b/makefile.shared
@@ -74,15 +74,23 @@ uninstall:
 	rm $(HEADERS_PUB:%=$(DESTDIR)$(INCPATH)/%)
 	rm $(DESTDIR)$(LIBPATH)/pkgconfig/libtommath.pc
 
-test mtest_opponent: demo/shared.o $(LIBNAME) | demo/test.o demo/mtest_opponent.o
-	$(LTLINK) $(LTM_LDFLAGS) -DLTM_TEST_DYNAMIC demo/$@.o $^ -o $@
+DEMOS=mtest_opponent test timing
+test: LTM_LDFLAGS+=-DLTM_TEST_DYNAMIC
+
+# build the demos from a template
+define DEMO_template
+$(1): $(call print-help,$(1),Builds the library and the '$(1)' demo) demo/$(1).o demo/shared.o $$(LIBNAME)
+ifneq ($V,1)
+	@echo "   * $${CC} $$@" ${silent_echo}
+endif
+	$(LTLINK) $(LTM_CFLAGS) $(LTM_LDFLAGS) $$^ -o $(1)
+endef
+
+$(foreach demo, $(strip $(DEMOS)), $(eval $(call DEMO_template,$(demo))))
 
 .PHONY: mtest
 mtest:
 	cd mtest ; $(CC) $(LTM_CFLAGS) -O0 mtest.c $(LTM_LDFLAGS) -o mtest
-
-timing: $(LIBNAME) demo/timing.c
-	$(LTLINK) $(LTM_CFLAGS) $(LTM_LDFLAGS) -DTIMER demo/timing.c $(LIBNAME) -o timing
 
 tune: $(LIBNAME)
 	$(LTCOMPILE) $(LTM_CFLAGS) -c etc/tune.c -o etc/tune.o

--- a/makefile.unix
+++ b/makefile.unix
@@ -41,18 +41,18 @@ mp_montgomery_calc_normalization.o mp_montgomery_reduce.o mp_montgomery_setup.o 
 mp_mul_2d.o mp_mul_d.o mp_mulmod.o mp_neg.o mp_or.o mp_pack.o mp_pack_count.o mp_prime_fermat.o \
 mp_prime_frobenius_underwood.o mp_prime_is_prime.o mp_prime_miller_rabin.o mp_prime_next_prime.o \
 mp_prime_rabin_miller_trials.o mp_prime_rand.o mp_prime_strong_lucas_selfridge.o mp_radix_size.o \
-mp_radix_size_overestimate.o mp_rand.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o mp_reduce_2k_l.o \
-mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o mp_reduce_setup.o \
-mp_root_n.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o mp_set_l.o \
-mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_shrink.o mp_signed_rsh.o mp_sqrmod.o mp_sqrt.o mp_sqrtmod_prime.o \
-mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o mp_unpack.o mp_xor.o \
-mp_zero.o s_mp_add.o s_mp_copy_digs.o s_mp_div_3.o s_mp_div_recursive.o s_mp_div_school.o s_mp_div_small.o \
-s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod.o s_mp_invmod_odd.o s_mp_log.o \
-s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o s_mp_mul_balance.o \
-s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o s_mp_mul_toom.o \
-s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o s_mp_radix_size_overestimate.o \
-s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o s_mp_sqr_karatsuba.o s_mp_sqr_toom.o \
-s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
+mp_radix_size_overestimate.o mp_rand.o mp_rand_source.o mp_read_radix.o mp_reduce.o mp_reduce_2k.o \
+mp_reduce_2k_l.o mp_reduce_2k_setup.o mp_reduce_2k_setup_l.o mp_reduce_is_2k.o mp_reduce_is_2k_l.o \
+mp_reduce_setup.o mp_root_n.o mp_rshd.o mp_sbin_size.o mp_set.o mp_set_double.o mp_set_i32.o mp_set_i64.o \
+mp_set_l.o mp_set_u32.o mp_set_u64.o mp_set_ul.o mp_shrink.o mp_signed_rsh.o mp_sqrmod.o mp_sqrt.o \
+mp_sqrtmod_prime.o mp_sub.o mp_sub_d.o mp_submod.o mp_to_radix.o mp_to_sbin.o mp_to_ubin.o mp_ubin_size.o \
+mp_unpack.o mp_xor.o mp_zero.o s_mp_add.o s_mp_copy_digs.o s_mp_div_3.o s_mp_div_recursive.o \
+s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_bit.o s_mp_invmod.o \
+s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o \
+s_mp_mul_balance.o s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o \
+s_mp_mul_toom.o s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o \
+s_mp_radix_size_overestimate.o s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o \
+s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
 
 
 HEADERS_PUB=tommath.h

--- a/makefile.unix
+++ b/makefile.unix
@@ -51,8 +51,8 @@ s_mp_div_school.o s_mp_div_small.o s_mp_exptmod.o s_mp_exptmod_fast.o s_mp_get_b
 s_mp_invmod_odd.o s_mp_log.o s_mp_log_2expt.o s_mp_log_d.o s_mp_montgomery_reduce_comba.o s_mp_mul.o \
 s_mp_mul_balance.o s_mp_mul_comba.o s_mp_mul_high.o s_mp_mul_high_comba.o s_mp_mul_karatsuba.o \
 s_mp_mul_toom.o s_mp_prime_is_divisible.o s_mp_prime_tab.o s_mp_radix_map.o \
-s_mp_radix_size_overestimate.o s_mp_rand_jenkins.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o \
-s_mp_sqr_karatsuba.o s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
+s_mp_radix_size_overestimate.o s_mp_rand_platform.o s_mp_sqr.o s_mp_sqr_comba.o s_mp_sqr_karatsuba.o \
+s_mp_sqr_toom.o s_mp_sub.o s_mp_zero_buf.o s_mp_zero_digs.o
 
 
 HEADERS_PUB=tommath.h

--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -87,6 +87,7 @@ endif
 
 ifdef COMPILE_LTO
 LTM_CFLAGS += -flto
+LTM_LDFLAGS += -flto
 AR = $(subst clang,llvm-ar,$(subst gcc,gcc-ar,$(CC)))
 endif
 

--- a/mp_rand.c
+++ b/mp_rand.c
@@ -3,13 +3,6 @@
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 
-mp_err(*s_mp_rand_source)(void *out, size_t size) = s_mp_rand_platform;
-
-void mp_rand_source(mp_err(*source)(void *out, size_t size))
-{
-   s_mp_rand_source = (source == NULL) ? s_mp_rand_platform : source;
-}
-
 mp_err mp_rand(mp_int *a, int digits)
 {
    int i;

--- a/mp_rand_source.c
+++ b/mp_rand_source.c
@@ -1,0 +1,12 @@
+#include "tommath_private.h"
+#ifdef MP_RAND_C
+/* LibTomMath, multiple-precision integer library -- Tom St Denis */
+/* SPDX-License-Identifier: Unlicense */
+
+mp_err(*s_mp_rand_source)(void *out, size_t size) = s_mp_rand_platform;
+
+void mp_rand_source(mp_err(*source)(void *out, size_t size))
+{
+   s_mp_rand_source = (source == NULL) ? s_mp_rand_platform : source;
+}
+#endif

--- a/s_mp_rand_platform.c
+++ b/s_mp_rand_platform.c
@@ -14,13 +14,6 @@ static mp_err s_read_arc4random(void *p, size_t n)
    arc4random_buf(p, n);
    return MP_OKAY;
 }
-#else
-static mp_err s_read_arc4random(void *p, size_t n)
-{
-   (void)p;
-   (void)n;
-   return MP_ERR;
-}
 #endif
 
 #if defined(_WIN32)
@@ -79,15 +72,6 @@ static mp_err s_read_getrandom(void *p, size_t n)
 #endif
 #endif
 
-#ifndef S_READ_GETRANDOM_C
-static mp_err s_read_getrandom(void *p, size_t n)
-{
-   (void)p;
-   (void)n;
-   return MP_ERR;
-}
-#endif
-
 /* We assume all platforms besides windows provide "/dev/urandom".
  * In case yours doesn't, define MP_NO_DEV_URANDOM at compile-time.
  */
@@ -125,13 +109,6 @@ static mp_err s_read_urandom(void *p, size_t n)
 
    close(fd);
    return MP_OKAY;
-}
-#else
-static mp_err s_read_urandom(void *p, size_t n)
-{
-   (void)p;
-   (void)n;
-   return MP_ERR;
 }
 #endif
 

--- a/s_mp_rand_platform.c
+++ b/s_mp_rand_platform.c
@@ -14,6 +14,13 @@ static mp_err s_read_arc4random(void *p, size_t n)
    arc4random_buf(p, n);
    return MP_OKAY;
 }
+#else
+static mp_err s_read_arc4random(void *p, size_t n)
+{
+   (void)p;
+   (void)n;
+   return MP_ERR;
+}
 #endif
 
 #if defined(_WIN32)
@@ -72,6 +79,15 @@ static mp_err s_read_getrandom(void *p, size_t n)
 #endif
 #endif
 
+#ifndef S_READ_GETRANDOM_C
+static mp_err s_read_getrandom(void *p, size_t n)
+{
+   (void)p;
+   (void)n;
+   return MP_ERR;
+}
+#endif
+
 /* We assume all platforms besides windows provide "/dev/urandom".
  * In case yours doesn't, define MP_NO_DEV_URANDOM at compile-time.
  */
@@ -109,6 +125,13 @@ static mp_err s_read_urandom(void *p, size_t n)
 
    close(fd);
    return MP_OKAY;
+}
+#else
+static mp_err s_read_urandom(void *p, size_t n)
+{
+   (void)p;
+   (void)n;
+   return MP_ERR;
 }
 #endif
 

--- a/testme.sh
+++ b/testme.sh
@@ -348,7 +348,7 @@ fi
 # default to CC environment variable if no compiler is defined but some other options
 if [[ "$COMPILERS" == "" ]] && [[ "$ARCHFLAGS$MAKE_OPTIONS$CFLAGS" != "" ]]
 then
-   COMPILERS="$CC"
+   COMPILERS="${CC:-cc}"
 # default to CC environment variable and run only default config if no option is given
 elif [[ "$COMPILERS" == "" ]]
 then

--- a/testme.sh
+++ b/testme.sh
@@ -20,71 +20,73 @@ TEST_CFLAGS=""
 
 _help()
 {
-  echo "Usage options for $(basename $0) [--with-cc=arg [other options]]"
-  echo
-  echo "Executing this script without any parameter will only run the default"
-  echo "configuration that has automatically been determined for the"
-  echo "architecture you're running."
-  echo
-  echo "    --with-cc=*             The compiler(s) to use for the tests"
-  echo "                            This is an option that will be iterated."
-  echo
-  echo "    --test-vs-mtest=*       Run test vs. mtest for '*' operations."
-  echo "                            Only the first of each options will be"
-  echo "                            taken into account."
-  echo
-  echo "To be able to specify options a compiler has to be given with"
-  echo "the option --with-cc=compilername"
-  echo "All other options will be tested with all MP_xBIT configurations."
-  echo
-  echo "    --with-{m64,m32,mx32}   The architecture(s) to build and test"
-  echo "                            for, e.g. --with-mx32."
-  echo "                            This is an option that will be iterated,"
-  echo "                            multiple selections are possible."
-  echo "                            The mx32 architecture is not supported"
-  echo "                            by clang and will not be executed."
-  echo
-  echo "    --cflags=*              Give an option to the compiler,"
-  echo "                            e.g. --cflags=-g"
-  echo "                            This is an option that will always be"
-  echo "                            passed as parameter to CC."
-  echo
-  echo "    --make-option=*         Give an option to make,"
-  echo "                            e.g. --make-option=\"-f makefile.shared\""
-  echo "                            This is an option that will always be"
-  echo "                            passed as parameter to make."
-  echo
-  echo "    --with-low-mp           Also build&run tests with -DMP_{8,16,32}BIT."
-  echo
-  echo "    --mtest-real-rand       Use real random data when running mtest."
-  echo
-  echo "    --with-valgrind"
-  echo "    --with-valgrind=*       Run in valgrind (slow!)."
-  echo
-  echo "    --with-travis-valgrind  Run with valgrind on Travis on specific branches."
-  echo
-  echo "    --valgrind-options      Additional Valgrind options"
-  echo "                            Some of the options like e.g.:"
-  echo "                            --track-origins=yes add a lot of extra"
-  echo "                            runtime and may trigger the 30 minutes"
-  echo "                            timeout."
-  echo
-  echo "Godmode:"
-  echo
-  echo "    --all                   Choose all architectures and gcc and clang"
-  echo "                            as compilers but does not run valgrind."
-  echo
-  echo "    --format                Runs the various source-code formatters"
-  echo "                            and generators and checks if the sources"
-  echo "                            are clean."
-  echo
-  echo "    -h"
-  echo "    --help                  This message"
-  echo
-  echo "    -v"
-  echo "    --version               Prints the version. It is just the number"
-  echo "                            of git commits to this file, no deeper"
-  echo "                            meaning attached"
+  cat << EOF
+Usage options for $(basename $0) [--with-cc=arg [other options]]
+
+Executing this script without any parameter will only run the default
+configuration that has automatically been determined for the
+architecture you're running.
+
+    --with-cc=*             The compiler(s) to use for the tests
+                            This is an option that will be iterated.
+
+    --test-vs-mtest=*       Run test vs. mtest for '*' operations.
+                            Only the first of each options will be
+                            taken into account.
+
+To be able to specify options a compiler has to be given with
+the option --with-cc=compilername
+All other options will be tested with all MP_xBIT configurations.
+
+    --with-{m64,m32,mx32}   The architecture(s) to build and test
+                            for, e.g. --with-mx32.
+                            This is an option that will be iterated,
+                            multiple selections are possible.
+                            The mx32 architecture is not supported
+                            by clang and will not be executed.
+
+    --cflags=*              Give an option to the compiler,
+                            e.g. --cflags=-g
+                            This is an option that will always be
+                            passed as parameter to CC.
+
+    --make-option=*         Give an option to make,
+                            e.g. --make-option="-f makefile.shared"
+                            This is an option that will always be
+                            passed as parameter to make.
+
+    --with-low-mp           Also build&run tests with -DMP_{8,16,32}BIT.
+
+    --mtest-real-rand       Use real random data when running mtest.
+
+    --with-valgrind
+    --with-valgrind=*       Run in valgrind (slow!).
+
+    --with-travis-valgrind  Run with valgrind on Travis on specific branches.
+
+    --valgrind-options      Additional Valgrind options
+                            Some of the options like e.g.:
+                            --track-origins=yes add a lot of extra
+                            runtime and may trigger the 30 minutes
+                            timeout.
+
+Godmode:
+
+    --all                   Choose all architectures and gcc and clang
+                            as compilers but does not run valgrind.
+
+    --format                Runs the various source-code formatters
+                            and generators and checks if the sources
+                            are clean.
+
+    -h
+    --help                  This message
+
+    -v
+    --version               Prints the version. It is just the number
+                            of git commits to this file, no deeper
+                            meaning attached
+EOF
   exit 0
 }
 

--- a/tommath.def
+++ b/tommath.def
@@ -89,6 +89,7 @@ EXPORTS
     mp_radix_size
     mp_radix_size_overestimate
     mp_rand
+    mp_rand_source
     mp_read_radix
     mp_reduce
     mp_reduce_2k
@@ -124,3 +125,7 @@ EXPORTS
     mp_unpack
     mp_xor
     mp_zero
+    MP_MUL_KARATSUBA_CUTOFF
+    MP_SQR_KARATSUBA_CUTOFF
+    MP_MUL_TOOM_CUTOFF
+    MP_SQR_TOOM_CUTOFF

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -95,6 +95,7 @@
 #   define MP_RADIX_SIZE_C
 #   define MP_RADIX_SIZE_OVERESTIMATE_C
 #   define MP_RAND_C
+#   define MP_RAND_SOURCE_C
 #   define MP_READ_RADIX_C
 #   define MP_REDUCE_C
 #   define MP_REDUCE_2K_C
@@ -698,10 +699,12 @@
 
 #if defined(MP_RAND_C)
 #   define MP_GROW_C
-#   define MP_RAND_SOURCE_C
 #   define MP_ZERO_C
-#   define S_MP_RAND_PLATFORM_C
 #   define S_MP_RAND_SOURCE_C
+#endif
+
+#if defined(MP_RAND_SOURCE_C)
+#   define S_MP_RAND_PLATFORM_C
 #endif
 
 #if defined(MP_READ_RADIX_C)

--- a/tommath_class.h
+++ b/tommath_class.h
@@ -157,7 +157,6 @@
 #   define S_MP_PRIME_TAB_C
 #   define S_MP_RADIX_MAP_C
 #   define S_MP_RADIX_SIZE_OVERESTIMATE_C
-#   define S_MP_RAND_JENKINS_C
 #   define S_MP_RAND_PLATFORM_C
 #   define S_MP_SQR_C
 #   define S_MP_SQR_COMBA_C
@@ -1192,10 +1191,6 @@
 #   define MP_MUL_C
 #   define MP_SET_U32_C
 #   define S_MP_LOG_2EXPT_C
-#endif
-
-#if defined(S_MP_RAND_JENKINS_C)
-#   define S_MP_RAND_JENKINS_INIT_C
 #endif
 
 #if defined(S_MP_RAND_PLATFORM_C)

--- a/tommath_private.h
+++ b/tommath_private.h
@@ -208,10 +208,6 @@ MP_PRIVATE void s_mp_zero_buf(void *mem, size_t size);
 MP_PRIVATE void s_mp_zero_digs(mp_digit *d, int digits);
 MP_PRIVATE mp_err s_mp_radix_size_overestimate(const mp_int *a, const int radix, size_t *size);
 
-/* TODO: jenkins prng is not thread safe as of now */
-MP_PRIVATE mp_err s_mp_rand_jenkins(void *p, size_t n) MP_WUR;
-MP_PRIVATE void s_mp_rand_jenkins_init(uint64_t seed);
-
 #define MP_RADIX_MAP_REVERSE_SIZE 80u
 extern MP_PRIVATE const char s_mp_radix_map[];
 extern MP_PRIVATE const uint8_t s_mp_radix_map_reverse[];


### PR DESCRIPTION
This is a follow-up of #489 

It adds "automation" of the modifications to `tommath.def` and a travis job to check for this.

Additionally the proposed split-up of `mp_rand.c` is done and the modifications to `s_mp_rand_platform.c` are reverted.