### PR TITLE
docs: fix simple typo, exluding -> excluding

### DIFF
--- a/mp_to_radix.c
+++ b/mp_to_radix.c
@@ -75,7 +75,7 @@ mp_err mp_to_radix(const mp_int *a, char *str, size_t maxlen, size_t *written, i
       ++digs;
    }
    /* reverse the digits of the string.  In this case _s points
-    * to the first digit [exluding the sign] of the number
+    * to the first digit [excluding the sign] of the number
     */
    s_reverse(_s, digs);
 


### PR DESCRIPTION
There is a small typo in mp_to_radix.c.

Should read `excluding` rather than `exluding`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md