### PR TITLE
Initialized "cmd" (and "buf" for symmetry) to sooth clang >= 8

### DIFF
--- a/demo/mtest_opponent.c
+++ b/demo/mtest_opponent.c
@@ -59,8 +59,8 @@ static int s_mp_get_token(char *s, int size, FILE *stream)
 
 static int mtest_opponent(void)
 {
-   char cmd[4096];
-   char buf[4096];
+   char cmd[4096] = {0};
+   char buf[4096] = {0};
    int ix;
    unsigned rr;
    mp_int a, b, c, d, e, f;


### PR DESCRIPTION
Picked up work at #499 after merging of #500 and found out that a newer clang compiler (somewhere between 7.0.0 and 8.0.0) caused problems that show up with valgrind. GCC up to version 9.1.0 caused no trouble.

(Last good commit was 1b3792b228dc97ee9a42c3d5579366c382bd4be2 so it was something I did)

Commandline : `
LTM_CFLAGS=" -g3 " ./testme.sh --with-cc=clang-8 --test-vs-mtest=333  --with-valgrind --valgrind-options="--track-origins=yes"`

Result in `test_vs_mtest_err.log`

```
==1350== Memcheck, a memory error detector
==1350== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1350== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==1350== Command: ./mtest_opponent
==1350== 
==1350== Conditional jump or move depends on uninitialised value(s)
==1350==    at 0x4014FC: mtest_opponent (mtest_opponent.c:336)
==1350==    by 0x4E5FBF6: (below main) (libc-start.c:310)
==1350==  Uninitialised value was created by a stack allocation
==1350==    at 0x400B86: mtest_opponent (mtest_opponent.c:70)
==1350== 
==1350== 
==1350== HEAP SUMMARY:
==1350==     in use at exit: 0 bytes in 0 blocks
==1350==   total heap usage: 67,008 allocs, 67,008 frees, 7,175,992 bytes allocated
==1350== 
==1350== All heap blocks were freed -- no leaks are possible
==1350== 
==1350== For counts of detected and suppressed errors, rerun with: -v
==1350== ERROR SUMMARY: 4 errors from 1 contexts (suppressed: 0 from 0)
```

Line 70 is `srand(LTM_MTEST_RAND_SEED);`
Line 336 is `} else if (strcmp(cmd, "invmod") == 0) {`

Difference of assembler dumps (left column with `cmd = {0};` right as it was):
```.Ltmp2:                                                                         .Ltmp2:
        #DEBUG_VALUE: s_mp_get_token:s <- [DW_OP_plus_uconst 4368] $rs    |             #DEBUG_VALUE: s_mp_get_token:s_bar <- undef
        #DEBUG_VALUE: s_mp_get_token:s_bar <- [DW_OP_plus_uconst 4368]    <
        .loc    5 62 9 prologue_end     # demo/mtest_opponent.c:62:9      <
        movl    $4096, %edx             # imm = 0x1000                    <
        xorl    %esi, %esi                                                <
        callq   memset                                                    <
.Ltmp3:                                                                   <
        #DEBUG_VALUE: s_mp_get_token:s <- undef                                         #DEBUG_VALUE: s_mp_get_token:s <- undef
        #DEBUG_VALUE: s_mp_get_token:s_bar <- undef                                     #DEBUG_VALUE: s_mp_get_token:s_bar <- undef
        #DEBUG_VALUE: s_mp_get_token:s <- undef                                         #DEBUG_VALUE: s_mp_get_token:s <- undef
        #DEBUG_VALUE: s_mp_get_token:s_bar <- undef                                     #DEBUG_VALUE: s_mp_get_token:s_bar <- undef

                                                                             ...

        #DEBUG_VALUE: s_mp_get_token:s_bar <- undef                                     #DEBUG_VALUE: s_mp_get_token:s_bar <- undef
        #DEBUG_VALUE: s_mp_get_token:s <- undef                                         #DEBUG_VALUE: s_mp_get_token:s <- undef
        #DEBUG_VALUE: s_mp_get_token:s_bar <- undef                                     #DEBUG_VALUE: s_mp_get_token:s_bar <- undef
        .loc    5 70 4                  # demo/mtest_opponent.c:70:4      |             #DEBUG_VALUE: s_mp_get_token:s <- undef
                                                                          >             .loc    5 70 4 prologue_end     # demo/mtest_opponent.c:70:4
        movl    $23, %edi                                                               movl    $23, %edi
        callq   srand                                                                   callq   srand
```

Difference between Clang 7.0.0 and Clang 8.0.0, no initialisation of `cmd`

```
        .cfi_offset %r15, -24                                                           .cfi_offset %r15, -24
        .cfi_offset %rbp, -16                                                           .cfi_offset %rbp, -16
                                                                          >     .Ltmp2:
                                                                          >             #DEBUG_VALUE: s_mp_get_token:s_bar <- undef
                                                                          >             #DEBUG_VALUE: s_mp_get_token:s <- undef
                                                                          >             #DEBUG_VALUE: s_mp_get_token:s_bar <- undef

                                                                ...

                                                                          >             #DEBUG_VALUE: s_mp_get_token:s <- undef
                                                                          >             #DEBUG_VALUE: s_mp_get_token:s_bar <- undef
                                                                          >             #DEBUG_VALUE: s_mp_get_token:s <- undef
        .loc    5 70 4 prologue_end     # demo/mtest_opponent.c:70:4                    .loc    5 70 4 prologue_end     # demo/mtest_opponent.c:70:4
        movl    $23, %edi                                                               movl    $23, %edi
        callq   srand                                                                   callq   srand
.Ltmp2:                                                                   |     .Ltmp3:
        .loc    5 72 8                  # demo/mtest_opponent.c:72:8                    .loc    5 72 8                  # demo/mtest_opponent.c:72:8

```

Well, Clang is correct, technically, no doubt.
Mmh&hellip;is initializing`cmd` enough here?

(I just saw that I initialized the buffers with `0` instead of `\0`. To late for now, have to go.)