### PR TITLE
Makefile: Fix shared library build in MinGW.

### DIFF
--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -102,7 +102,7 @@ endif
 ifeq ($(PLATFORM), Darwin)
 LTM_CFLAGS += -Wno-nullability-completeness
 endif
-ifeq ($(PLATFORM), CYGWIN)
+ifneq ($(findstring $(PLATFORM),CYGWIN MINGW32 MINGW64 MSYS),)
 LIBTOOLFLAGS += -no-undefined
 endif
 


### PR DESCRIPTION
This enables -no-undefined linker flag in mingw toolchain.
Previous related commit 4b850954056943be03452c9a2b4bb621d663e40b