### PR TITLE
Added check for __SIZEOF_INT128__ to avoid some problems with a 64-bit arch. and 32-bit userspace

### DIFF
--- a/tommath.h
+++ b/tommath.h
@@ -29,7 +29,7 @@ extern "C" {
     defined(__ia64) || defined(__ia64__) || defined(__itanium__) || defined(_M_IA64) || \
     defined(__LP64__) || defined(_LP64) || defined(__64BIT__)
 #   if !(defined(MP_64BIT) || defined(MP_32BIT) || defined(MP_16BIT))
-#      if defined(__GNUC__) && !defined(__hppa)
+#      if defined(__GNUC__) && defined(__SIZEOF_INT128__) && !defined(__hppa)
 /* we support 128bit integers only via: __attribute__((mode(TI))) */
 #         define MP_64BIT
 #      else


### PR DESCRIPTION
Regarding issue #509 

The macro `__SIZEOF_INT128__` is in GCC >= 4.6, CLANG >= 3.3, and ICC >= 16 (probably earlier but I don't have them), I do not know if anybody uses older compilers.