### PR TITLE
Reduce stack usage for embedded targets

### DIFF
--- a/mp_prime_strong_lucas_selfridge.c
+++ b/mp_prime_strong_lucas_selfridge.c
@@ -52,7 +52,8 @@ mp_err mp_prime_strong_lucas_selfridge(const mp_int *a, bool *result)
 {
    /* CZ TODO: choose better variable names! */
    mp_int Dz, gcd, Np1, Uz, Vz, U2mz, V2mz, Qmz, Q2mz, Qkdz, T1z, T2z, T3z, T4z, Q2kdz;
-   int32_t D, Ds, J, sign, P, Q, r, s, u, Nbits;
+   int J;
+   int32_t D, Ds, sign, P, Q, r, s, u, Nbits;
    mp_err err;
    bool oddness;
 

--- a/s_mp_exptmod.c
+++ b/s_mp_exptmod.c
@@ -13,7 +13,7 @@
 
 mp_err s_mp_exptmod(const mp_int *G, const mp_int *X, const mp_int *P, mp_int *Y, int redmode)
 {
-   mp_int  M[TAB_SIZE], res, mu;
+   mp_int  *M, res, mu;
    mp_digit buf;
    mp_err   err;
    int      bitbuf, bitcpy, bitcnt, mode, digidx, x, y, winsize;
@@ -40,6 +40,11 @@ mp_err s_mp_exptmod(const mp_int *G, const mp_int *X, const mp_int *P, mp_int *Y
    winsize = MAX_WINSIZE ? MP_MIN(MAX_WINSIZE, winsize) : winsize;
 
    /* init M array */
+   M=MP_MALLOC(sizeof(mp_int) * TAB_SIZE);
+   if (!M) {
+      return MP_MEM;
+   }
+
    /* init first cell */
    if ((err = mp_init(&M[1])) != MP_OKAY) {
       return err;
@@ -52,6 +57,7 @@ mp_err s_mp_exptmod(const mp_int *G, const mp_int *X, const mp_int *P, mp_int *Y
             mp_clear(&M[y]);
          }
          mp_clear(&M[1]);
+         MP_FREE(M, sizeof(mp_int) * TAB_SIZE);
          return err;
       }
    }
@@ -193,6 +199,8 @@ LBL_M:
    for (x = 1<<(winsize-1); x < (1 << winsize); x++) {
       mp_clear(&M[x]);
    }
+
+   MP_FREE(M, sizeof(mp_int) * TAB_SIZE);
    return err;
 }
 #endif

--- a/s_mp_exptmod_fast.c
+++ b/s_mp_exptmod_fast.c
@@ -21,7 +21,7 @@
 
 mp_err s_mp_exptmod_fast(const mp_int *G, const mp_int *X, const mp_int *P, mp_int *Y, int redmode)
 {
-   mp_int  M[TAB_SIZE], res;
+   mp_int  *M, res;
    mp_digit buf, mp;
    int     bitbuf, bitcpy, bitcnt, mode, digidx, x, y, winsize;
    mp_err   err;
@@ -53,8 +53,14 @@ mp_err s_mp_exptmod_fast(const mp_int *G, const mp_int *X, const mp_int *P, mp_i
    winsize = MAX_WINSIZE ? MP_MIN(MAX_WINSIZE, winsize) : winsize;
 
    /* init M array */
+   M=MP_MALLOC(sizeof(mp_int) * TAB_SIZE);
+   if (!M) {
+      return MP_MEM;
+   }
+
    /* init first cell */
    if ((err = mp_init_size(&M[1], P->alloc)) != MP_OKAY) {
+      MP_FREE(M, sizeof(mp_int) * TAB_SIZE);
       return err;
    }
 
@@ -65,6 +71,7 @@ mp_err s_mp_exptmod_fast(const mp_int *G, const mp_int *X, const mp_int *P, mp_i
             mp_clear(&M[y]);
          }
          mp_clear(&M[1]);
+         MP_FREE(M, sizeof(mp_int) * TAB_SIZE);
          return err;
       }
    }
@@ -249,6 +256,8 @@ LBL_M:
    for (x = 1<<(winsize-1); x < (1 << winsize); x++) {
       mp_clear(&M[x]);
    }
+
+   MP_FREE(M, sizeof(mp_int) * TAB_SIZE);
    return err;
 }
 #endif

--- a/s_mp_montgomery_reduce_comba.c
+++ b/s_mp_montgomery_reduce_comba.c
@@ -15,7 +15,7 @@ mp_err s_mp_montgomery_reduce_comba(mp_int *x, const mp_int *n, mp_digit rho)
 {
    int     ix, oldused;
    mp_err  err;
-   mp_word W[MP_WARRAY];
+   mp_word *W;
 
    if (x->used > MP_WARRAY) {
       return MP_VAL;
@@ -32,6 +32,11 @@ mp_err s_mp_montgomery_reduce_comba(mp_int *x, const mp_int *n, mp_digit rho)
    /* first we have to get the digits of the input into
     * an array of double precision words W[...]
     */
+
+   W=MP_MALLOC(MP_WARRAY * sizeof(mp_word));
+   if (!W) {
+      return MP_MEM;
+   }
 
    /* copy the digits of a into W[0..a->used-1] */
    for (ix = 0; ix < x->used; ix++) {
@@ -99,6 +104,8 @@ mp_err s_mp_montgomery_reduce_comba(mp_int *x, const mp_int *n, mp_digit rho)
    for (ix = 0; ix < (n->used + 1); ix++) {
       x->dp[ix] = W[n->used + ix] & (mp_word)MP_MASK;
    }
+
+   MP_FREE(W, MP_WARRAY * sizeof(mp_word));
 
    /* set the max used */
    x->used = n->used + 1;

--- a/s_mp_mul_comba.c
+++ b/s_mp_mul_comba.c
@@ -23,7 +23,7 @@ mp_err s_mp_mul_comba(const mp_int *a, const mp_int *b, mp_int *c, int digs)
 {
    int      oldused, pa, ix;
    mp_err   err;
-   mp_digit W[MP_WARRAY];
+   mp_digit *W;
    mp_word  _W;
 
    /* grow the destination as required */
@@ -33,6 +33,11 @@ mp_err s_mp_mul_comba(const mp_int *a, const mp_int *b, mp_int *c, int digs)
 
    /* number of output digits to produce */
    pa = MP_MIN(digs, a->used + b->used);
+
+   W=MP_MALLOC(MP_WARRAY * sizeof(mp_digit));
+   if (!W) {
+      return MP_MEM;
+   }
 
    /* clear the carry */
    _W = 0;
@@ -68,6 +73,8 @@ mp_err s_mp_mul_comba(const mp_int *a, const mp_int *b, mp_int *c, int digs)
       /* now extract the previous digit [below the carry] */
       c->dp[ix] = W[ix];
    }
+
+   MP_FREE(W, MP_WARRAY * sizeof(mp_digit));
 
    /* clear unused digits [that existed in the old copy of c] */
    s_mp_zero_digs(c->dp + c->used, oldused - c->used);

--- a/s_mp_mul_high_comba.c
+++ b/s_mp_mul_high_comba.c
@@ -16,13 +16,18 @@ mp_err s_mp_mul_high_comba(const mp_int *a, const mp_int *b, mp_int *c, int digs
 {
    int     oldused, pa, ix;
    mp_err   err;
-   mp_digit W[MP_WARRAY];
+   mp_digit *W;
    mp_word  _W;
 
    /* grow the destination as required */
    pa = a->used + b->used;
    if ((err = mp_grow(c, pa)) != MP_OKAY) {
       return err;
+   }
+
+   W=MP_MALLOC(MP_WARRAY * sizeof(mp_digit));
+   if (!W) {
+      return MP_MEM;
    }
 
    /* number of output digits to produce */
@@ -60,6 +65,8 @@ mp_err s_mp_mul_high_comba(const mp_int *a, const mp_int *b, mp_int *c, int digs
       /* now extract the previous digit [below the carry] */
       c->dp[ix] = W[ix];
    }
+
+   MP_FREE(W, MP_WARRAY * sizeof(mp_digit));
 
    /* clear unused digits [that existed in the old copy of c] */
    s_mp_zero_digs(c->dp + c->used, oldused - c->used);

--- a/s_mp_sqr_comba.c
+++ b/s_mp_sqr_comba.c
@@ -16,7 +16,7 @@ After that loop you do the squares and add them in.
 mp_err s_mp_sqr_comba(const mp_int *a, mp_int *b)
 {
    int       oldused, pa, ix;
-   mp_digit  W[MP_WARRAY];
+   mp_digit  *W;
    mp_word   W1;
    mp_err err;
 
@@ -24,6 +24,11 @@ mp_err s_mp_sqr_comba(const mp_int *a, mp_int *b)
    pa = a->used + a->used;
    if ((err = mp_grow(b, pa)) != MP_OKAY) {
       return err;
+   }
+
+   W=MP_MALLOC(MP_WARRAY * sizeof(mp_digit));
+   if (!W) {
+      return MP_MEM;
    }
 
    /* number of output digits to produce */
@@ -77,6 +82,8 @@ mp_err s_mp_sqr_comba(const mp_int *a, mp_int *b)
    for (ix = 0; ix < pa; ix++) {
       b->dp[ix] = W[ix] & MP_MASK;
    }
+
+   MP_FREE(W, MP_WARRAY * sizeof(mp_digit));
 
    /* clear unused digits [that existed in the old copy of c] */
    s_mp_zero_digs(b->dp + b->used, oldused - b->used);


### PR DESCRIPTION
Hi,

I was using libtomcrypt on an embedded target (pixhawk 4 autopilot), and found out that in order to do RSA2048 encryption, I had to increase stack size for my calling thread to ridiculously big.

In order to make it more usable I decided to allocate some large arrays from heap instead of stack in libtommath. I decided to also post the change in here as a PR, in case it is seen usable for others as well.

---------

In s_mp_exptmod*.c and s_mp*comba.c, allocate large arrays from
heap instead of stack. In targets where stack sizes are
typically fixed at task creation time, this is more efficient memory usage

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>