### PR TITLE
s_mp_rand_platform.c: s_read_urandom: correctly handle split read

### DIFF
--- a/s_mp_rand_platform.c
+++ b/s_mp_rand_platform.c
@@ -95,7 +95,7 @@ static mp_err s_read_urandom(void *p, size_t n)
    if (fd == -1) return MP_ERR;
 
    while (n > 0u) {
-      ssize_t ret = read(fd, p, n);
+      ssize_t ret = read(fd, q, n);
       if (ret < 0) {
          if (errno == EINTR) {
             continue;


### PR DESCRIPTION
s_read_urandom has a while loop to handle read() that returns less
than the full buffer (either due to EINTR or because more than the
atomic guarantee from urandom was requested). However, the target
of the read was always the base pointer p instead of the updated
pointer q, so in the end less than the requested randomness is returned.

Use q instead of p in the read() call.
