### PR TITLE
Introduced 0 (zero) to mp_is_square as a perfect square

### DIFF
--- a/demo/test.c
+++ b/demo/test.c
@@ -677,6 +677,17 @@ static int test_mp_is_square(void)
 
    DOR(mp_init_multi(&a, &b, NULL));
 
+
+   /* Domain is {x \in \mathbb{Z} : x \le 0}  */
+   mp_set_l(&a, -1);
+   EXPECT(mp_is_square(&a, &res) == MP_VAL);
+   EXPECT(!res);
+
+   /* Zero is a perfect square, too */
+   mp_zero(&a);
+   DO(mp_is_square(&a, &res));
+   EXPECT(res);
+
    for (i = 0; i < 1000; ++i) {
       printf("%6d\r", i);
       fflush(stdout);

--- a/mp_is_square.c
+++ b/mp_is_square.c
@@ -41,6 +41,7 @@ mp_err mp_is_square(const mp_int *arg, bool *ret)
    }
 
    if (mp_iszero(arg)) {
+      *ret = true;
       return MP_OKAY;
    }
 


### PR DESCRIPTION
Instead of just adding some documentation regarding issue #521 I decided to fix that bug.

 - changed definition of `0` (zero) from not-a-square to is-a-square.
 - test added to check `0` (zero)
 - additional test added to check negative numbers

Does not seem to conflict with LibTomCrypt but that needs a proper check, I just grep'd for `is_square`.

Changes API and hence might conflict with other software that uses LTM but on the other side: it *was* a bug that gets fixed with this patch.
