### PR TITLE
Adding premake4.lua and glue for old MSVC versions

### DIFF
--- a/old_msvc_glue.h
+++ b/old_msvc_glue.h
@@ -1,0 +1,234 @@
+/* SPDX-License-Identifier: Unlicense */
+/**
+ * This file has no copyright assigned and is placed in the Public Domain.
+ * This file was originally part of the w64 mingw-runtime package.
+ * From there it was borrowed by libusb_aah into the Android source tree,
+ * from where it was picked up for libtommath.
+ */
+/* ISO C9x  7.18  Integer types <stdint.h>
+ * Based on ISO/IEC SC22/WG14 9899 Committee draft (SC22 N2794)
+ *
+ *  THIS SOFTWARE IS NOT COPYRIGHTED
+ *
+ *  Contributor: Danny Smith <danny_r_smith_2001@yahoo.co.nz>
+ *  Modified for libusb/MSVC: Pete Batard <pbatard@gmail.com>
+ *
+ *  This source code is offered for use in the public domain. You may
+ *  use, modify or distribute it freely.
+ *
+ *  This code is distributed in the hope that it will be useful but
+ *  WITHOUT ANY WARRANTY. ALL WARRANTIES, EXPRESS OR IMPLIED ARE HEREBY
+ *  DISCLAIMED. This includes but is not limited to warranties of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ *  Date: 2010-04-02
+ */
+#if !defined(_MSC_VER) || (_MSC_VER >= 1600)
+#error This header should only be used with Microsoft compilers before 16.0 (VS2010)
+#endif
+#ifndef _STDINT_H
+#define _STDINT_H
+#ifndef _INTPTR_T_DEFINED
+#define _INTPTR_T_DEFINED
+#ifndef __intptr_t_defined
+#define __intptr_t_defined
+#undef intptr_t
+#ifdef _WIN64
+  typedef __int64 intptr_t;
+#else
+  typedef int intptr_t;
+#endif /* _WIN64 */
+#endif /* __intptr_t_defined */
+#endif /* _INTPTR_T_DEFINED */
+#ifndef _UINTPTR_T_DEFINED
+#define _UINTPTR_T_DEFINED
+#ifndef __uintptr_t_defined
+#define __uintptr_t_defined
+#undef uintptr_t
+#ifdef _WIN64
+  typedef unsigned __int64 uintptr_t;
+#else
+  typedef unsigned int uintptr_t;
+#endif /* _WIN64 */
+#endif /* __uintptr_t_defined */
+#endif /* _UINTPTR_T_DEFINED */
+#ifndef _PTRDIFF_T_DEFINED
+#define _PTRDIFF_T_DEFINED
+#ifndef _PTRDIFF_T_
+#define _PTRDIFF_T_
+#undef ptrdiff_t
+#ifdef _WIN64
+  typedef __int64 ptrdiff_t;
+#else
+  typedef int ptrdiff_t;
+#endif /* _WIN64 */
+#endif /* _PTRDIFF_T_ */
+#endif /* _PTRDIFF_T_DEFINED */
+#ifndef _WCHAR_T_DEFINED
+#define _WCHAR_T_DEFINED
+#ifndef __cplusplus
+  typedef unsigned short wchar_t;
+#endif /* C++ */
+#endif /* _WCHAR_T_DEFINED */
+#ifndef _WCTYPE_T_DEFINED
+#define _WCTYPE_T_DEFINED
+#ifndef _WINT_T
+#define _WINT_T
+  typedef unsigned short wint_t;
+  typedef unsigned short wctype_t;
+#endif /* _WINT_T */
+#endif /* _WCTYPE_T_DEFINED */
+/* 7.18.1.1  Exact-width integer types */
+typedef __int8 int8_t;
+typedef unsigned __int8   uint8_t;
+typedef __int16  int16_t;
+typedef unsigned __int16  uint16_t;
+typedef __int32  int32_t;
+typedef unsigned __int32  uint32_t;
+typedef __int64  int64_t;
+typedef unsigned __int64   uint64_t;
+/* 7.18.1.2  Minimum-width integer types */
+typedef signed char int_least8_t;
+typedef unsigned char   uint_least8_t;
+typedef short  int_least16_t;
+typedef unsigned short  uint_least16_t;
+typedef int  int_least32_t;
+typedef unsigned   uint_least32_t;
+typedef __int64  int_least64_t;
+typedef unsigned __int64   uint_least64_t;
+/*  7.18.1.3  Fastest minimum-width integer types
+ *  Not actually guaranteed to be fastest for all purposes
+ *  Here we use the exact-width types for 8 and 16-bit ints.
+ */
+typedef __int8 int_fast8_t;
+typedef unsigned __int8 uint_fast8_t;
+typedef __int16  int_fast16_t;
+typedef unsigned __int16  uint_fast16_t;
+typedef __int32  int_fast32_t;
+typedef unsigned  __int32  uint_fast32_t;
+typedef __int64  int_fast64_t;
+typedef unsigned __int64   uint_fast64_t;
+/* 7.18.1.5  Greatest-width integer types */
+typedef __int64  intmax_t;
+typedef unsigned __int64   uintmax_t;
+/* 7.18.2  Limits of specified-width integer types */
+/* 7.18.2.1  Limits of exact-width integer types */
+#define INT8_MIN (-128)
+#define INT16_MIN (-32768)
+#define INT32_MIN (-2147483647 - 1)
+#define INT64_MIN  (-9223372036854775807LL - 1)
+#define INT8_MAX 127
+#define INT16_MAX 32767
+#define INT32_MAX 2147483647
+#define INT64_MAX 9223372036854775807LL
+#define UINT8_MAX 255
+#define UINT16_MAX 65535
+#define UINT32_MAX 0xffffffffU  /* 4294967295U */
+#define UINT64_MAX 0xffffffffffffffffULL /* 18446744073709551615ULL */
+/* 7.18.2.2  Limits of minimum-width integer types */
+#define INT_LEAST8_MIN INT8_MIN
+#define INT_LEAST16_MIN INT16_MIN
+#define INT_LEAST32_MIN INT32_MIN
+#define INT_LEAST64_MIN INT64_MIN
+#define INT_LEAST8_MAX INT8_MAX
+#define INT_LEAST16_MAX INT16_MAX
+#define INT_LEAST32_MAX INT32_MAX
+#define INT_LEAST64_MAX INT64_MAX
+#define UINT_LEAST8_MAX UINT8_MAX
+#define UINT_LEAST16_MAX UINT16_MAX
+#define UINT_LEAST32_MAX UINT32_MAX
+#define UINT_LEAST64_MAX UINT64_MAX
+/* 7.18.2.3  Limits of fastest minimum-width integer types */
+#define INT_FAST8_MIN INT8_MIN
+#define INT_FAST16_MIN INT16_MIN
+#define INT_FAST32_MIN INT32_MIN
+#define INT_FAST64_MIN INT64_MIN
+#define INT_FAST8_MAX INT8_MAX
+#define INT_FAST16_MAX INT16_MAX
+#define INT_FAST32_MAX INT32_MAX
+#define INT_FAST64_MAX INT64_MAX
+#define UINT_FAST8_MAX UINT8_MAX
+#define UINT_FAST16_MAX UINT16_MAX
+#define UINT_FAST32_MAX UINT32_MAX
+#define UINT_FAST64_MAX UINT64_MAX
+/* 7.18.2.4  Limits of integer types capable of holding
+    object pointers */
+#ifdef _WIN64
+#define INTPTR_MIN INT64_MIN
+#define INTPTR_MAX INT64_MAX
+#define UINTPTR_MAX UINT64_MAX
+#else
+#define INTPTR_MIN INT32_MIN
+#define INTPTR_MAX INT32_MAX
+#define UINTPTR_MAX UINT32_MAX
+#endif
+/* 7.18.2.5  Limits of greatest-width integer types */
+#define INTMAX_MIN INT64_MIN
+#define INTMAX_MAX INT64_MAX
+#define UINTMAX_MAX UINT64_MAX
+/* 7.18.3  Limits of other integer types */
+#ifdef _WIN64
+#define PTRDIFF_MIN INT64_MIN
+#define PTRDIFF_MAX INT64_MAX
+#else
+#define PTRDIFF_MIN INT32_MIN
+#define PTRDIFF_MAX INT32_MAX
+#endif
+#define SIG_ATOMIC_MIN INT32_MIN
+#define SIG_ATOMIC_MAX INT32_MAX
+#ifndef SIZE_MAX
+#ifdef _WIN64
+#define SIZE_MAX UINT64_MAX
+#else
+#define SIZE_MAX UINT32_MAX
+#endif
+#endif
+#ifndef WCHAR_MIN  /* also in wchar.h */
+#define WCHAR_MIN 0U
+#define WCHAR_MAX 0xffffU
+#endif
+/*
+ * wint_t is unsigned short for compatibility with MS runtime
+ */
+#define WINT_MIN 0U
+#define WINT_MAX 0xffffU
+/* 7.18.4  Macros for integer constants */
+/* 7.18.4.1  Macros for minimum-width integer constants
+    Accoding to Douglas Gwyn <gwyn@arl.mil>:
+	"This spec was changed in ISO/IEC 9899:1999 TC1; in ISO/IEC
+	9899:1999 as initially published, the expansion was required
+	to be an integer constant of precisely matching type, which
+	is impossible to accomplish for the shorter types on most
+	platforms, because C99 provides no standard way to designate
+	an integer constant with width less than that of type int.
+	TC1 changed this to require just an integer constant
+	*expression* with *promoted* type."
+	The trick used here is from Clive D W Feather.
+*/
+#define INT8_C(val) (INT_LEAST8_MAX-INT_LEAST8_MAX+(val))
+#define INT16_C(val) (INT_LEAST16_MAX-INT_LEAST16_MAX+(val))
+#define INT32_C(val) (INT_LEAST32_MAX-INT_LEAST32_MAX+(val))
+/*  The 'trick' doesn't work in C89 for long long because, without
+    suffix, (val) will be evaluated as int, not intmax_t */
+#define INT64_C(val) val##i64
+#define UINT8_C(val) (val)
+#define UINT16_C(val) (val)
+#define UINT32_C(val) (val##i32)
+#define UINT64_C(val) val##ui64
+/* 7.18.4.2  Macros for greatest-width integer constants */
+#define INTMAX_C(val) val##i64
+#define UINTMAX_C(val) val##ui64
+#endif
+
+/* This part is a standing for stdbool.h, which MSVC versions < 1600 also seem to lack  */ 
+#ifndef _STDBOOL_H
+#define _STDBOOL_H
+#ifndef __cplusplus
+typedef char _Bool;
+#endif
+#define bool _Bool
+#define false 0
+#define true 1
+
+#define __bool_true_false_are_defined 1
+#endif /* _STDBOOL_H */

--- a/premake4.lua
+++ b/premake4.lua
@@ -1,0 +1,371 @@
+--[[
+    This premake4.lua in conjunction with premake4 will enable you to generate
+    projects and solutions for a range of Visual Studio (2003 through 2022).
+
+    Simply have premake4 in your PATH and run (adjust the version as needed):
+
+        premake4 vs2022
+
+    You can get a code-signed Windows binary of premake4 from:
+    * https://sourceforge.net/projects/windirstat/files/premake-stable/
+    * https://osdn.net/projects/windirstat/storage/historical/premake-stable/
+    * https://github.com/windirstat/premake-stable/releases/
+]]
+-- SPDX-License-Identifier: Unlicense
+
+local action = _ACTION or ""
+local tgtname = "tommath"
+local transformMN = function (input) -- transform the macro names for older Visual Studio versions
+    local new_map   = { vs2003 = 0, vs2005 = 0, vs2008 = 0 }
+    local replacements = { Platform = "PlatformName", Configuration = "ConfigurationName" }
+    if new_map[action] ~= nil then
+        for k,v in pairs(replacements) do
+            if input:find(k) then
+                input = input:gsub(k, v)
+            end
+        end
+    end
+    return input
+end
+
+solution ("lib" .. tgtname)
+    configurations  {"Debug", "Release"}
+    platforms       (iif(action < "vs2005", {"x32"}, {"x32", "x64"}))
+    location        ('.')
+
+    project (tgtname)
+        local outdir   = "MSVC_" .. action .. "\\$(" .. transformMN("Configuration") .. ")_$(" .. transformMN("Platform") .. ")"
+        uuid            ("47726E76-07B8-433D-A9AF-01111EB92825")
+        language        ("C")
+        kind            ("StaticLib")
+        targetname      (tgtname)
+        flags           {"Unicode", "NativeWChar", "FatalWarnings"}
+        targetdir       (outdir)
+        objdir          (outdir .. "\\Intermediate")
+        libdirs         {"$(IntDir)"}
+        includedirs     {"."} -- not really needed, but we try to stay true to makefile.msvc
+        defines         {"WIN32_LEAN_AND_MEAN", "WINVER=0x0501", "_CRT_SECURE_NO_WARNINGS", "_CRT_NONSTDC_NO_DEPRECATE",}
+        buildoptions    {"/Z7", "/Wall", "/wd4146", "/wd4127", "/wd4668", "/wd4710", "/wd4711", "/wd4820",}
+        -- /Z7 for a static lib includes all debug symbols inside the object files, meaning there is no need to distribute PDB _and_ .lib file
+
+        excludes
+        {
+            "Backup*.*",
+        }
+
+        files
+        {
+            "*mp_*.c",
+            "*.h",
+            "*.md", "*.rst", "premake4.lua",
+        }
+
+        vpaths
+        {
+            ["Header Files/*"] = { "**.h", },
+            ["Source Files/*"] = { "**.c", },
+            ["Special Files/*"] = { "premake4.lua", },
+        }
+
+        configuration {"Debug"}
+            defines         {"_DEBUG"}
+
+        configuration {"Release"}
+            defines         {"NDEBUG"}
+            flags           {"Optimize", "NoMinimalRebuild", "NoIncrementalLink", "NoEditAndContinue"}
+            buildoptions    {"/Ox"}
+
+        configuration {"Debug", "x32"}
+            targetsuffix    ("32D")
+
+        configuration {"Debug", "x64"}
+            targetsuffix    ("64D")
+
+        configuration {"Release", "x32"}
+            targetsuffix    ("32")
+
+        configuration {"Release", "x64"}
+            targetsuffix    ("64")
+
+        configuration("vs2003 or vs2005")
+            buildoptions    {"/wd4242", "/wd4244",}
+
+        configuration("vs2003 or vs2005 or vs2008")
+            buildoptions    {"/wd4255",}
+
+        configuration("vs2019 or vs2022")
+            buildoptions    {"/wd5045",}
+
+        configuration("vs2017 or vs2019 or vs2022")
+            buildoptions    {"/permissive-",}
+
+--[[
+    This part of the premake4.lua modifies the core premake4 behavior a little.
+
+    It does the following (in order of appearence below):
+
+    - New option --sdkver to override <WindowsTargetPlatformVersion> on modern VS
+    - New option --clang to request ClangCL toolset on modern VS
+    - New option --xp to request XP-compatible toolset on modern VS
+    - On older premake4 versions it will provide a premake.project.getbasename
+      function, furthermore two other functions get patched to make use of it
+    - premake.project.getbasename() gets overridden to insert a marker into the
+      created file name, based on the chosen action
+      Example: foobar.vcxproj becomes foobar.vs2022.vcxproj etc ...
+      The purpose of this exercise is to allow for projects/solutions of several
+      Visual Studio versions to reside in the same folder
+    - Options "dotnet" gets removed
+    - The "platform" option has some allowed values removed
+    - The "os" option has some allowed values removed
+    - The actions are trimmed to what we know can work
+]]
+
+newoption { trigger = "sdkver", value = "SDKVER", description = "Allows to override SDK version (VS2015 through VS2022)" }
+newoption { trigger = "clang", description = "Allows to use clang-cl as compiler and lld-link as linker (VS2019 and VS2022)" }
+newoption { trigger = "xp", description = "Allows to use a supported XP toolset for some VS versions" }
+
+do
+    -- This is mainly to support older premake4 builds
+    if not premake.project.getbasename then
+        print "Magic happens for old premake4 versions without premake.project.getbasename() ..."
+        -- override the function to establish the behavior we'd get after patching Premake to have premake.project.getbasename
+        premake.project.getbasename = function(prjname, pattern)
+            return pattern:gsub("%%%%", prjname)
+        end
+        -- obviously we also need to overwrite the following to generate functioning VS solution files
+        premake.vstudio.projectfile = function(prj)
+            local pattern
+            if prj.language == "C#" then
+                pattern = "%%.csproj"
+            else
+                pattern = iif(_ACTION > "vs2008", "%%.vcxproj", "%%.vcproj")
+            end
+
+            local fname = premake.project.getbasename(prj.name, pattern)
+            fname = path.join(prj.location, fname)
+            return fname
+        end
+        -- we simply overwrite the original function on older Premake versions
+        premake.project.getfilename = function(prj, pattern)
+            local fname = premake.project.getbasename(prj.name, pattern)
+            fname = path.join(prj.location, fname)
+            return path.getrelative(os.getcwd(), fname)
+        end
+    end
+    -- Make UUID generation for filters deterministic
+    if os.str2uuid ~= nil then
+        local vc2010 = premake.vstudio.vc2010
+        vc2010.filteridgroup = function(prj)
+            local filters = { }
+            local filterfound = false
+
+            for file in premake.project.eachfile(prj) do
+                -- split the path into its component parts
+                local folders = string.explode(file.vpath, "/", true)
+                local path = ""
+                for i = 1, #folders - 1 do
+                    -- element is only written if there *are* filters
+                    if not filterfound then
+                        filterfound = true
+                        _p(1,"<ItemGroup>")
+                    end
+
+                    path = path .. folders[i]
+
+                    -- have I seen this path before?
+                    if not filters[path] then
+                        local seed = path .. (prj.uuid or "")
+                        local deterministic_uuid = os.str2uuid(seed)
+                        filters[path] = true
+                        _p(2, '<Filter Include="%s">', path)
+                        _p(3, "<UniqueIdentifier>{%s}</UniqueIdentifier>", deterministic_uuid)
+                        _p(2, "</Filter>")
+                    end
+
+                    -- prepare for the next subfolder
+                    path = path .. "\\"
+                end
+            end
+
+            if filterfound then
+                _p(1,"</ItemGroup>")
+            end
+        end
+    end
+    -- Name the project files after their VS version
+    local orig_getbasename = premake.project.getbasename
+    premake.project.getbasename = function(prjname, pattern)
+        -- The below is used to insert the .vs(8|9|10|11|12|14|15|16|17) into the file names for projects and solutions
+        if _ACTION then
+            name_map = {vs2005 = "vs8", vs2008 = "vs9", vs2010 = "vs10", vs2012 = "vs11", vs2013 = "vs12", vs2015 = "vs14", vs2017 = "vs15", vs2019 = "vs16", vs2022 = "vs17"}
+            if name_map[_ACTION] then
+                pattern = pattern:gsub("%%%%", "%%%%." .. name_map[_ACTION])
+            else
+                pattern = pattern:gsub("%%%%", "%%%%." .. _ACTION)
+            end
+        end
+        return orig_getbasename(prjname, pattern)
+    end
+    -- Premake4 sets the PDB file name for the compiler's PDB to the default
+    -- value used by the linker's PDB. This causes error C1052 on VS2017. Fix it.
+    -- But this also fixes up certain other areas of the generated project. The idea
+    -- here is to catch the original _p() invocations, evaluate the arguments and
+    -- then act based on those, using orig_p() as a standin during a call to the
+    -- underlying premake.vs2010_vcxproj() function ;-)
+    local orig_premake_vs2010_vcxproj = premake.vs2010_vcxproj
+    premake.vs2010_vcxproj = function(prj)
+        -- The whole stunt below is necessary in order to modify the resource_compile()
+        -- output. Given it's a local function we have to go through hoops.
+        local orig_p = _G._p
+        local besilent = false
+        -- We patch the global _p() function
+        _G._p = function(indent, msg, first, ...)
+            -- Look for non-empty messages and narrow it down by the indent values
+            if msg ~= nil then
+                -- Allow this logic to be hooked and the hook to preempt any action hardcoded below
+                if (_G.override_vcxproj ~= nil) and (type(_G.override_vcxproj) == 'function') then
+                    if _G.override_vcxproj(prj, orig_p, indent, msg, first, ...) then
+                        return -- suppress further output
+                    end
+                end
+                if msg:match("<ProgramDataBaseFileName>[^<]+</ProgramDataBaseFileName>") then
+                    return -- we want to suppress these
+                end
+                if indent == 2 then
+                    if msg == "<RootNamespace>%s</RootNamespace>" then
+                        local sdkmap = {vs2015 = "8.1", vs2017 = "10.0.17763.0", vs2019 = "10.0", vs2022 = "10.0"}
+                        if (not _ACTION) or (not sdkmap[_ACTION]) then -- should not happen, but tread carefully anyway
+                            orig_p(indent, msg, first, ...) -- what was originally supposed to be output
+                            return
+                        end
+                        local sdkver = _OPTIONS["sdkver"] or sdkmap[_ACTION]
+                        orig_p(indent, msg, first, ...) -- what was originally supposed to be output
+                        orig_p(indent, "<WindowsTargetPlatformVersion>%s</WindowsTargetPlatformVersion>", sdkver)
+                        return
+                    end
+                    if msg == "<PlatformToolset>%s</PlatformToolset>" then
+                        if (_OPTIONS["clang"] ~= nil) and (_ACTION == "vs2017") then
+                            if _OPTIONS["xp"] ~= nil then
+                                print "WARNING: The --clang option takes precedence over --xp, therefore picking v141_clang_c2 toolset."
+                            end
+                            print "WARNING: If you are used to Clang support from VS2019 and newer, be sure to review your choice. It's not the same on older VS versions."
+                            orig_p(indent, msg, "v141_clang_c2")
+                            return
+                        elseif (_OPTIONS["clang"] ~= nil) and (_ACTION >= "vs2019") then
+                            if _OPTIONS["xp"] ~= nil then
+                                print "WARNING: The --clang option takes precedence over --xp, therefore picking ClangCL toolset."
+                            end
+                            orig_p(indent, msg, "ClangCL")
+                            return
+                        elseif _OPTIONS["xp"] ~= nil then
+                            local toolsets = { vs2012 = "v110", vs2013 = "v120", vs2015 = "v140", vs2017 = "v141", vs2019 = "v142", vs2022 = "v143" }
+                            local toolset = toolsets[_ACTION]
+                            if toolset then
+                                if _OPTIONS["xp"] and toolset >= "v141" then
+                                    toolset = "v141" -- everything falls back to the VS2017 XP toolset for more recent VS
+                                end
+                                orig_p(indent,"<PlatformToolset>%s_xp</PlatformToolset>", toolset)
+                                return
+                            end
+                        end
+                    end
+                elseif indent == 3 then
+                    -- This is what vanilla VS would output it as, so let's try to align with that
+                    if msg == "<PrecompiledHeader></PrecompiledHeader>" then
+                        orig_p(indent, "<PrecompiledHeader>")
+                        orig_p(indent, "</PrecompiledHeader>")
+                        return
+                    end
+                end
+            end
+            if not besilent then -- should we be silent (i.e. suppress default output)?
+                orig_p(indent, msg, first, ...)
+            end
+        end
+        orig_premake_vs2010_vcxproj(prj)
+        _G._p = orig_p -- restore in any case
+    end
+    -- ... same as above but for VS200x this time
+    local function wrap_remove_pdb_attribute(origfunc)
+        local fct = function(cfg)
+            local old_captured = io.captured -- save io.captured state
+            io.capture() -- this sets io.captured = ""
+            origfunc(cfg)
+            local captured = io.endcapture()
+            assert(captured ~= nil)
+            captured = captured:gsub('%s+ProgramDataBaseFileName=\"[^"]+\"', "")
+            if old_captured ~= nil then
+                io.captured = old_captured .. captured -- restore outer captured state, if any
+            else
+                io.write(captured)
+            end
+        end
+        return fct
+    end
+    premake.vstudio.vc200x.VCLinkerTool = wrap_remove_pdb_attribute(premake.vstudio.vc200x.VCLinkerTool)
+    premake.vstudio.vc200x.toolmap.VCLinkerTool = premake.vstudio.vc200x.VCLinkerTool -- this is important as well
+    premake.vstudio.vc200x.VCCLCompilerTool = wrap_remove_pdb_attribute(premake.vstudio.vc200x.VCCLCompilerTool)
+    premake.vstudio.vc200x.toolmap.VCCLCompilerTool = premake.vstudio.vc200x.VCCLCompilerTool -- this is important as well
+    -- Override the object directory paths ... don't make them "unique" inside premake4
+    local orig_gettarget = premake.gettarget
+    premake.gettarget = function(cfg, direction, pathstyle, namestyle, system)
+        local r = orig_gettarget(cfg, direction, pathstyle, namestyle, system)
+        if (cfg.objectsdir) and (cfg.objdir) then
+            cfg.objectsdir = cfg.objdir
+        end
+        return r
+    end
+    -- Silently suppress generation of the .user files ...
+    local orig_generate = premake.generate
+    premake.generate = function(obj, filename, callback)
+        if filename:find(".vcproj.user") or filename:find(".vcxproj.user") then
+            return
+        end
+        orig_generate(obj, filename, callback)
+    end
+    -- Fix up premake.getlinks() to not do stupid stuff with object files we pass
+    local orig_premake_getlinks = premake.getlinks
+    premake.getlinks = function(cfg, kind, part)
+        local origret = orig_premake_getlinks(cfg, kind, part)
+        local ret = {}
+        for k,v in ipairs(origret) do
+            local dep = v:gsub(".obj.lib", ".obj")
+            dep = dep:gsub(".lib.lib", ".lib")
+            table.insert(ret, dep)
+        end
+        return ret
+    end
+
+    -- Remove an option altogether or some otherwise accepted values for that option
+    local function remove_allowed_optionvalues(option, values_toremove)
+        if premake.option.list[option] ~= nil then
+            if values_toremove == nil then
+                premake.option.list[option] = nil
+                return
+            end
+            if premake.option.list.platform["allowed"] ~= nil then
+                local allowed = premake.option.list[option].allowed
+                for i = #allowed, 1, -1 do
+                    if values_toremove[allowed[i][1]] then
+                        table.remove(allowed, i)
+                    end
+                end
+            end
+        end
+    end
+
+    local function remove_action(action)
+        if premake.action.list[action] ~= nil then
+            premake.action.list[action] = nil
+        end
+    end
+
+    -- Remove some unwanted/outdated options
+    remove_allowed_optionvalues("dotnet")
+    remove_allowed_optionvalues("platform", { universal = 0, universal32 = 0, universal64 = 0, ps3 = 0, xbox360 = 0, })
+    remove_allowed_optionvalues("os", { haiku = 0, solaris = 0, })
+    -- ... and actions (mainly because they are untested)
+    for k,v in pairs({codeblocks = 0, codelite = 0, xcode3 = 0, xcode4 = 0, vs2002 = 0}) do
+        remove_action(k)
+    end
+end

--- a/s_mp_rand_platform.c
+++ b/s_mp_rand_platform.c
@@ -26,9 +26,22 @@ static mp_err s_read_arc4random(void *p, size_t n)
 #define WINVER 0x0501
 #endif
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4255)
+/* otherwise windef.h from the Windows SDK 7.1 will bomb out here when targeting XP, for example */
+#endif /* _MSC_VER */
+/* clang-format off */
 #include <windows.h>
 #include <wincrypt.h>
+/* clang-format on */
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif /* _MSC_VER */
 
 static mp_err s_read_wincsp(void *p, size_t n)
 {

--- a/tommath.h
+++ b/tommath.h
@@ -5,8 +5,12 @@
 #define TOMMATH_H_
 
 #include <stddef.h>
+#if !defined(_MSC_VER) || (_MSC_VER >= 1600)
 #include <stdint.h>
 #include <stdbool.h>
+#else
+#include "old_msvc_glue.h"
+#endif
 
 #ifndef MP_NO_FILE
 #  include <stdio.h>


### PR DESCRIPTION
- Glue code is based on the stdint.h from Android's libusb_aah, which I
  mentioned in libtomcrypt#577, I added the stdbool.h stuff, too.
- This required adjusting the main header: tommath.h
- The premake4.lua was tested thoroughly with VS2003 through VS2008 for now

Please do not merge as of yet. I am going to refine this further. The discussion surrounding this can be found in [libtomcrypt#577](https://github.com/libtom/libtomcrypt/issues/577), as this library is a prerequisite, I am starting with this one.