### PR TITLE
Correct sanitation of mp_prime_rand

### DIFF
--- a/mp_prime_rand.c
+++ b/mp_prime_rand.c
@@ -26,7 +26,7 @@ mp_err mp_prime_rand(mp_int *a, int t, int size, int flags)
    mp_err err;
 
    /* sanity check the input */
-   if ((size <= 1) || (t <= 0)) {
+   if (size <= 1) {
       return MP_VAL;
    }
 


### PR DESCRIPTION
Since `mp_prime_is_prime` accepts negative values for the number of Miller-Rabin trials and `mp_prime_rabin_miller_trials` can emit a negative value, the check for a negative number of trials at the beginning of `mp_prime_rand` is wrong now.