### PR TITLE
Deploy via gh actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+#############################################################################
+#                                                                           #
+#  Packagecloud deployment via GH actions for LibTomMath                    #
+#      (https://github.com/libtom/libtommath.git)                           #
+#                                                                           #
+#############################################################################
+
+name: Deploy
+
+on:
+  workflow_dispatch
+
+jobs:
+  deploy-to-packagecloud:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: set Ubuntu codename
+        run: |
+          echo "ubuntu_codename="$(lsb_release -sc) >> "$GITHUB_ENV"
+      - name: install dependencies
+        run: |
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+          echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ ${{ env.ubuntu_codename }} main" | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y cmake gcc
+      - name: build static
+        run: |
+          mkdir -p build
+          cd build
+          cmake -DBUILD_SHARED_LIBS=Off -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+          make -j$(nproc)
+          cpack -G DEB
+          cmake -DBUILD_SHARED_LIBS=On -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+          make -j$(nproc)
+          cpack -G DEB
+      - name: push package to packagecloud.io
+        uses: computology/packagecloud-github-action@v0.6
+        with:
+          PACKAGE-NAME: packages/ubuntu/${{ env.ubuntu_codename }}/*.deb
+          PACKAGECLOUD-USERNAME: libtom
+          PACKAGECLOUD-REPONAME: libtom
+          PACKAGECLOUD-DISTRO: ubuntu/${{ env.ubuntu_codename }}
+          PACKAGECLOUD-TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,14 @@ else()
     set(DISTRO_PACK_PATH ${CMAKE_SYSTEM_NAME}/)
 endif()
 
+# make sure untagged versions get a different package name
+execute_process(COMMAND git describe --exact-match --tags RESULT_VARIABLE REPO_HAS_TAG)
+if(REPO_HAS_TAG EQUAL 0)
+    set(PACKAGE_NAME_SUFFIX "")
+else()
+    set(PACKAGE_NAME_SUFFIX "-git")
+endif()
+
 # default CPack generators
 set(CPACK_GENERATOR TGZ STGZ)
 
@@ -245,6 +253,7 @@ if(BUILD_SHARED_LIBS)
 else()
     set(CPACK_PACKAGE_NAME "${PROJECT_NAME}-devel")
 endif()
+set(CPACK_PACKAGE_NAME "${CPACK_PACKAGE_NAME}${PACKAGE_NAME_SUFFIX}")
 set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "LibTomMath")
 set(CPACK_PACKAGE_VENDOR "libtom projects")


### PR DESCRIPTION
In order to be able to build ltc, we need an installable ltm.

I did this manually in the past, lets use GH actions now.