### PR TITLE
Newer GCC requires `-flto=auto`

### DIFF
--- a/makefile_include.mk
+++ b/makefile_include.mk
@@ -86,8 +86,11 @@ LTM_CFLAGS  += -fomit-frame-pointer
 endif
 
 ifdef COMPILE_LTO
-LTM_CFLAGS += -flto
-LTM_LDFLAGS += -flto
+ifeq ($(findstring clang,$(CC)),)
+LTO_ARG = "=auto"
+endif
+LTM_CFLAGS += -flto$(LTO_ARG)
+LTM_LDFLAGS += -flto$(LTO_ARG)
 AR = $(subst clang,llvm-ar,$(subst gcc,gcc-ar,$(CC)))
 endif
 


### PR DESCRIPTION
GCC changed something internally [0] and emits now a warning in case there's no `=n` parameter given to force parallelization.

This patch tells the lto process to select the number of parallel jobs automatically.

[0] https://www.mail-archive.com/gcc-patches@gcc.gnu.org/msg258325.html