### PR TITLE
cmake: Simplify ccache logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,20 +34,6 @@ include(sources.cmake)
 option(BUILD_SHARED_LIBS "Build shared library and only the shared library if \"ON\", default is static" OFF)
 
 #-----------------------------------------------------------------------------
-# Add support for ccache if desired
-#-----------------------------------------------------------------------------
-find_program(CCACHE ccache)
-
-if(CCACHE)
-    option(ENABLE_CCACHE "Enable ccache." ON)
-endif()
-
-# use ccache if installed
-if(CCACHE AND ENABLE_CCACHE)
-    set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE})
-endif()
-
-#-----------------------------------------------------------------------------
 # Compose CFLAGS
 #-----------------------------------------------------------------------------
 


### PR DESCRIPTION
* Use USE_CCACHE switch, this seems to be a more common option having a quick look using Google
* Make use of find_program() functionality introduced in CMake 3.18 to simplify code