### PR TITLE
Make sure s_mp_rand_source is defined for all its uses

### DIFF
--- a/mp_rand_source.c
+++ b/mp_rand_source.c
@@ -1,5 +1,7 @@
 #include "tommath_private.h"
-#ifdef MP_RAND_C
+/* MP_RAND_C relates to mp_rand.c, MP_PRIME_RAND_C relates tp mp_prime_rand.c
+   Both use s_mp_rand_source */
+#if defined(MP_RAND_C) || defined(MP_PRIME_RAND_C)
 /* LibTomMath, multiple-precision integer library -- Tom St Denis */
 /* SPDX-License-Identifier: Unlicense */
 


### PR DESCRIPTION
mp_prime_rand.c uses s_mp_rand_source as well, so ensure that the
latter is defined on the conditions of the former as well.

Fixes #582
