### PR TITLE
Support "Cryptography API: Next Generation" on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ set(PACKAGE_RELEASE_VERSION 1)
 include(GNUInstallDirs)
 include(CheckIPOSupported)
 include(CMakePackageConfigHelpers)
+include(CMakePushCheckState)
+include(CheckSymbolExists)
 # default is "No tests"
 option(BUILD_TESTING "" OFF)
 include(CTest)
@@ -104,6 +106,16 @@ target_compile_options(${PROJECT_NAME} BEFORE PRIVATE
 target_link_options(${PROJECT_NAME} BEFORE PRIVATE
     ${LTM_LD_FLAGS}
 )
+if(MSVC)
+    cmake_push_check_state()
+    set(CMAKE_REQUIRED_LIBRARIES bcrypt)
+    check_symbol_exists(BCryptGenRandom "Windows.h;bcrypt.h" BCRYPT_AVAILABLE)
+    cmake_pop_check_state()
+    if(BCRYPT_AVAILABLE)
+        target_compile_definitions(${PROJECT_NAME} PRIVATE LTM_WIN32_BCRYPT)
+        target_link_libraries(${PROJECT_NAME} PRIVATE bcrypt)
+    endif()
+endif()
 
 set(PUBLIC_HEADERS tommath.h)
 set(C89 False CACHE BOOL "(Usually maintained automatically) Enable when the library is in c89 mode to package the correct header files on install")

--- a/s_mp_rand_platform.c
+++ b/s_mp_rand_platform.c
@@ -28,6 +28,17 @@ static mp_err s_read_arc4random(void *p, size_t n)
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+
+#ifdef LTM_WIN32_BCRYPT
+#include <bcrypt.h>
+#pragma comment(lib, "bcrypt")
+
+static mp_err s_read_wincsp(void *p, size_t n)
+{
+   return BCRYPT_SUCCESS(BCryptGenRandom(NULL, (PUCHAR)p, (ULONG)n,
+                                         BCRYPT_USE_SYSTEM_PREFERRED_RNG)) ? MP_OKAY : MP_ERR;
+}
+#else
 #include <wincrypt.h>
 
 static mp_err s_read_wincsp(void *p, size_t n)
@@ -45,6 +56,7 @@ static mp_err s_read_wincsp(void *p, size_t n)
    }
    return CryptGenRandom(hProv, (DWORD)n, (BYTE *)p) == TRUE ? MP_OKAY : MP_ERR;
 }
+#endif
 #endif /* WIN32 */
 
 #if !defined(S_READ_WINCSP_C) && defined(__linux__) && defined(__GLIBC_PREREQ)


### PR DESCRIPTION
Use Cryptography API: Next Generation, because UWP doesn't support old api.
There is a simpler implementation if we don't care about RSA:
```c
BCryptGenRandom(NULL, (PUCHAR)p, (ULONG)n, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
```