### PR TITLE
Generate import library in CMake

### DIFF
--- a/helper.pl
+++ b/helper.pl
@@ -249,7 +249,11 @@ set(SOURCES\n";
   foreach my $hobj (sort @headers) {
     $output .= $hobj . "\n";
   }
-  $output .= ")\n";
+  $output .= ")
+
+if(MSVC AND BUILD_SHARED_LIBS)
+  list(APPEND SOURCES tommath.def)
+endif()\n";
   return $output;
 }
 

--- a/sources.cmake
+++ b/sources.cmake
@@ -173,3 +173,7 @@ tommath_cutoffs.h
 tommath_private.h
 tommath_superclass.h
 )
+
+if(MSVC AND BUILD_SHARED_LIBS)
+  list(APPEND SOURCES tommath.def)
+endif()


### PR DESCRIPTION
CMake supports `.def` as input to generate import library.
