### PR TITLE
Support 64bit MP_DIGIT on Windows under clang-cl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,19 @@ endif()
 
 # We only differentiate between MSVC and GCC-compatible compilers
 if(MSVC)
-    set(LTM_C_FLAGS -W3)
+  if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    # We are clang-cl
+    # Some flags for linux similarity and warnings
+    set(LTM_C_FLAGS -fstrict-aliasing /W3 /D_CRT_SECURE_NO_WARNINGS)
+    # Optimization flags
+    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /Zc:inline /Gw /Gy /clang:-funroll-loops")
+    # Pass optimization option to override the debug flags, and allow dead code elimination
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /clang:-O1" )
+    # We need to link the runtime for 128 bit int support, which clang-cl has
+    link_libraries(clang_rt.builtins-x86_64.lib)
+  else()
+    set(LTM_C_FLAGS /W3 /D_CRT_SECURE_NO_WARNINGS)
+  endif()
 elseif(WATCOM)
     set(LTM_C_FLAGS -fo=.obj -oaxt -3r -w3)
 else()
@@ -63,7 +75,7 @@ else()
 endif()
 
 # What compiler do we have and what are their...uhm... peculiarities
-if(CMAKE_C_COMPILER_ID MATCHES "(C|c?)lang")
+if(CMAKE_C_COMPILER_ID MATCHES "(C|c?)lang" AND NOT MSVC)
     list(APPEND LTM_C_FLAGS -Wno-typedef-redefinition -Wno-tautological-compare -Wno-builtin-requires-header)
     # Clang requires at least '-O1' for dead code elimination
     set(CMAKE_C_FLAGS_DEBUG "-O1 ${CMAKE_C_FLAGS_DEBUG}")
@@ -97,7 +109,7 @@ add_library(${PROJECT_NAME}
 
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 target_compile_options(${PROJECT_NAME} BEFORE PRIVATE

--- a/tommath.h
+++ b/tommath.h
@@ -17,7 +17,7 @@ extern "C" {
 #endif
 
 /* MS Visual C++ doesn't have a 128bit type for words, so fall back to 32bit MPI's (where words are 64bit) */
-#if (defined(_MSC_VER) || defined(__LLP64__) || defined(__e2k__) || defined(__LCC__)) && !defined(MP_64BIT)
+#if ((defined(_MSC_VER) && !defined(__clang__)) || defined(__LLP64__) || defined(__e2k__) || defined(__LCC__)) && !defined(MP_64BIT)
 #   define MP_32BIT
 #endif
 
@@ -29,7 +29,7 @@ extern "C" {
     defined(__ia64) || defined(__ia64__) || defined(__itanium__) || defined(_M_IA64) || \
     defined(__LP64__) || defined(_LP64) || defined(__64BIT__)
 #   if !(defined(MP_64BIT) || defined(MP_32BIT) || defined(MP_16BIT))
-#      if defined(__GNUC__) && defined(__SIZEOF_INT128__) && !defined(__hppa)
+#      if defined(__GNUC__) && defined(__SIZEOF_INT128__) && !defined(__hppa) || (defined(_MSC_VER) && defined(__SIZEOF_INT128__))
 /* we support 128bit integers only via: __attribute__((mode(TI))) */
 #         define MP_64BIT
 #      else


### PR DESCRIPTION
This commit make MP_DIGIT 64 bit when using clang-cl. It also explicitly sets compile flags for clang-cl.