### PR TITLE
Reject zero exponent in mp_root_n

### DIFF
--- a/mp_root_n.c
+++ b/mp_root_n.c
@@ -18,7 +18,7 @@ mp_err mp_root_n(const mp_int *a, int b, mp_int *c)
    int    ilog2;
    mp_err err;
 
-   if (b < 0 || (unsigned)b > (unsigned)MP_DIGIT_MAX) {
+   if (b < 1 || (unsigned)b > (unsigned)MP_DIGIT_MAX) {
       return MP_VAL;
    }
 


### PR DESCRIPTION
`mp_root_n(a, b, c)` validates `b < 0` but not `b == 0`. A zero exponent passes the input check and reaches `ilog2 = ilog2 / b`, a division by zero.

The early-exit branches (`b > INT_MAX/2` and `ilog2 < b`) are both false when `b == 0` and `a` has at least one bit, so control always reaches the divide.

Effect is platform dependent: SIGFPE (process abort / DoS) on x86/x86-64, silently returns a wrong result on architectures where integer divide-by-zero does not trap. It is undefined behavior on all platforms.

Fix: change the bound to `b < 1` so a zero exponent returns `MP_VAL`.

Confirmed with UndefinedBehaviorSanitizer:
```
mp_root_n.c:60:19: runtime error: division by zero
```
Reproducer: `mp_set_u32(&a, 123456789); mp_root_n(&a, 0, &c);`