### PR TITLE
Add input check to mp_unpack

### DIFF
--- a/mp_unpack.c
+++ b/mp_unpack.c
@@ -13,6 +13,10 @@ mp_err mp_unpack(mp_int *rop, size_t count, mp_order order, size_t size,
    size_t odd_nails, nail_bytes, i, j;
    uint8_t odd_nail_mask;
 
+   if ((size == 0u) || (nails >= (size * 8u))) {
+      return MP_VAL;
+   }
+
    mp_zero(rop);
 
    if (endian == MP_NATIVE_ENDIAN) {


### PR DESCRIPTION
`mp_unpack` does not validate `size` and `nails`. When `nails >= size*8` (i.e. `nail_bytes > size`), the loop bound `size - nail_bytes` underflows to a value near `SIZE_MAX`, so the inner loop runs essentially unbounded and reads progressively past the `op` buffer — an out-of-bounds read. `size == 0` is an alternate trigger via `size - 1u`.

These parameters often come from an external serialization format, so an unchecked combination is reachable from untrusted input.

Fix: reject `size == 0` and `nails >= size*8` with `MP_VAL` before the loop.

Confirmed with AddressSanitizer:
```
ERROR: AddressSanitizer: stack-buffer-overflow ... READ of size 1
    #0 mp_unpack mp_unpack.c:31
```
Reproducer: `mp_unpack(&r, 1, MP_MSB_FIRST, 2, MP_BIG_ENDIAN, 64, buf);`