### PR TITLE
Add input check to mp_pack and mp_pack_count

### DIFF
--- a/mp_pack.c
+++ b/mp_pack.c
@@ -15,6 +15,10 @@ mp_err mp_pack(void *rop, size_t maxcount, size_t *written, mp_order order, size
 
    mp_int t;
 
+   if ((size == 0u) || (nails >= (size * 8u))) {
+      return MP_VAL;
+   }
+
    count = mp_pack_count(op, nails, size);
 
    if (count > maxcount) {

--- a/mp_pack_count.c
+++ b/mp_pack_count.c
@@ -5,7 +5,11 @@
 
 size_t mp_pack_count(const mp_int *a, size_t nails, size_t size)
 {
-   size_t bits = (size_t)mp_count_bits(a);
+   size_t bits;
+   if ((size == 0u) || (nails >= (size * 8u))) {
+      return 0u;
+   }
+   bits = (size_t)mp_count_bits(a);
    return ((bits / ((size * 8u) - nails)) + (((bits % ((size * 8u) - nails)) != 0u) ? 1u : 0u));
 }
 


### PR DESCRIPTION
`mp_pack_count` computes `bits / ((size*8) - nails)`. When `nails == size*8` the divisor is zero — a division by zero (SIGFPE on x86). `mp_pack` calls `mp_pack_count` unconditionally, so the same crash is reachable through `mp_pack`.

Like `mp_unpack`, these parameters can originate from an external format, making the bad combination reachable from untrusted input.

Fix: reject `size == 0` and `nails >= size*8` early in both functions (`mp_pack_count` returns 0, `mp_pack` returns `MP_VAL`). The check is placed before `mp_count_bits` in `mp_pack_count`.

Confirmed with UndefinedBehaviorSanitizer:
```
mp_pack_count.c:9:18: runtime error: division by zero
```
Reproducer: `mp_pack_count(&a, 8, 1);`